### PR TITLE
Add identifiers and mappings for Canadian federal electoral districts

### DIFF
--- a/identifiers/country-ca/ca_federal_electoral_districts.csv
+++ b/identifiers/country-ca/ca_federal_electoral_districts.csv
@@ -1,0 +1,308 @@
+ocd-division/country:ca/fed:10001,Avalon
+ocd-division/country:ca/fed:10002,Bonavista–Gander–Grand Falls–Windsor
+ocd-division/country:ca/fed:10003,Humber–St. Barbe–Baie Verte
+ocd-division/country:ca/fed:10004,Labrador
+ocd-division/country:ca/fed:10005,Random–Burin–St. George's
+ocd-division/country:ca/fed:10006,St. John's East
+ocd-division/country:ca/fed:10007,St. John's South–Mount Pearl
+ocd-division/country:ca/fed:11001,Cardigan
+ocd-division/country:ca/fed:11002,Charlottetown
+ocd-division/country:ca/fed:11003,Egmont
+ocd-division/country:ca/fed:11004,Malpeque
+ocd-division/country:ca/fed:12001,Cape Breton–Canso
+ocd-division/country:ca/fed:12002,Central Nova
+ocd-division/country:ca/fed:12003,Dartmouth–Cole Harbour
+ocd-division/country:ca/fed:12004,Halifax
+ocd-division/country:ca/fed:12005,Halifax West
+ocd-division/country:ca/fed:12006,Kings–Hants
+ocd-division/country:ca/fed:12007,Cumberland–Colchester–Musquodoboit Valley
+ocd-division/country:ca/fed:12008,Sackville–Eastern Shore
+ocd-division/country:ca/fed:12009,South Shore–St. Margaret's
+ocd-division/country:ca/fed:12010,Sydney–Victoria
+ocd-division/country:ca/fed:12011,West Nova
+ocd-division/country:ca/fed:13001,Acadie–Bathurst
+ocd-division/country:ca/fed:13002,Beauséjour
+ocd-division/country:ca/fed:13003,Fredericton
+ocd-division/country:ca/fed:13004,Fundy Royal
+ocd-division/country:ca/fed:13005,Madawaska–Restigouche
+ocd-division/country:ca/fed:13006,Miramichi
+ocd-division/country:ca/fed:13007,Moncton–Riverview–Dieppe
+ocd-division/country:ca/fed:13008,New Brunswick Southwest
+ocd-division/country:ca/fed:13009,Saint John
+ocd-division/country:ca/fed:13010,Tobique–Mactaquac
+ocd-division/country:ca/fed:24001,Abitibi–Témiscamingue
+ocd-division/country:ca/fed:24002,Ahuntsic
+ocd-division/country:ca/fed:24003,Alfred-Pellan
+ocd-division/country:ca/fed:24004,Argenteuil–Papineau–Mirabel
+ocd-division/country:ca/fed:24005,Beauce
+ocd-division/country:ca/fed:24006,Beauharnois–Salaberry
+ocd-division/country:ca/fed:24007,Beauport–Limoilou
+ocd-division/country:ca/fed:24008,Berthier–Maskinongé
+ocd-division/country:ca/fed:24009,Bourassa
+ocd-division/country:ca/fed:24010,Brome–Missisquoi
+ocd-division/country:ca/fed:24011,Brossard–La Prairie
+ocd-division/country:ca/fed:24012,Chambly–Borduas
+ocd-division/country:ca/fed:24013,Charlesbourg–Haute-Saint-Charles
+ocd-division/country:ca/fed:24014,Montmorency–Charlevoix–Haute-Côte-Nord
+ocd-division/country:ca/fed:24015,Châteauguay–Saint-Constant
+ocd-division/country:ca/fed:24016,Chicoutimi–Le Fjord
+ocd-division/country:ca/fed:24017,Compton–Stanstead
+ocd-division/country:ca/fed:24018,Drummond
+ocd-division/country:ca/fed:24019,Gaspésie–Îles-de-la-Madeleine
+ocd-division/country:ca/fed:24020,Gatineau
+ocd-division/country:ca/fed:24021,Hochelaga
+ocd-division/country:ca/fed:24022,Honoré-Mercier
+ocd-division/country:ca/fed:24023,Hull–Aylmer
+ocd-division/country:ca/fed:24024,Jeanne-Le Ber
+ocd-division/country:ca/fed:24025,Joliette
+ocd-division/country:ca/fed:24026,Jonquière–Alma
+ocd-division/country:ca/fed:24027,Lac-Saint-Louis
+ocd-division/country:ca/fed:24028,La Pointe-de-l'Île
+ocd-division/country:ca/fed:24029,LaSalle–Émard
+ocd-division/country:ca/fed:24030,Laurentides–Labelle
+ocd-division/country:ca/fed:24031,Laurier–Sainte-Marie
+ocd-division/country:ca/fed:24032,Laval
+ocd-division/country:ca/fed:24033,Laval–Les Îles
+ocd-division/country:ca/fed:24034,Lévis–Bellechasse
+ocd-division/country:ca/fed:24035,Longueuil–Pierre-Boucher
+ocd-division/country:ca/fed:24036,Lotbinière–Chutes-de-la-Chaudière
+ocd-division/country:ca/fed:24037,Louis-Hébert
+ocd-division/country:ca/fed:24038,Louis-Saint-Laurent
+ocd-division/country:ca/fed:24039,Manicouagan
+ocd-division/country:ca/fed:24040,Marc-Aurèle-Fortin
+ocd-division/country:ca/fed:24041,Haute-Gaspésie–La Mitis–Matane–Matapédia
+ocd-division/country:ca/fed:24042,Mégantic–L'Érable
+ocd-division/country:ca/fed:24043,Montcalm
+ocd-division/country:ca/fed:24044,Mount Royal
+ocd-division/country:ca/fed:24045,Notre-Dame-de-Grâce–Lachine
+ocd-division/country:ca/fed:24046,Abitibi–Baie-James–Nunavik–Eeyou
+ocd-division/country:ca/fed:24047,Outremont
+ocd-division/country:ca/fed:24048,Papineau
+ocd-division/country:ca/fed:24049,Pierrefonds–Dollard
+ocd-division/country:ca/fed:24050,Pontiac
+ocd-division/country:ca/fed:24051,Portneuf–Jacques-Cartier
+ocd-division/country:ca/fed:24052,Québec
+ocd-division/country:ca/fed:24053,Repentigny
+ocd-division/country:ca/fed:24054,Bas-Richelieu–Nicolet–Bécancour
+ocd-division/country:ca/fed:24055,Richmond–Arthabaska
+ocd-division/country:ca/fed:24056,Rimouski-Neigette–Témiscouata–Les Basques
+ocd-division/country:ca/fed:24057,Rivière-des-Mille-Îles
+ocd-division/country:ca/fed:24058,Montmagny–L'Islet–Kamouraska–Rivière-du-Loup
+ocd-division/country:ca/fed:24059,Rivière-du-Nord
+ocd-division/country:ca/fed:24060,Roberval–Lac-Saint-Jean
+ocd-division/country:ca/fed:24061,Rosemont–La Petite-Patrie
+ocd-division/country:ca/fed:24062,Saint-Bruno–Saint-Hubert
+ocd-division/country:ca/fed:24063,Saint-Hyacinthe–Bagot
+ocd-division/country:ca/fed:24064,Saint-Jean
+ocd-division/country:ca/fed:24065,Saint-Lambert
+ocd-division/country:ca/fed:24066,Saint-Laurent–Cartierville
+ocd-division/country:ca/fed:24067,Saint-Léonard–Saint-Michel
+ocd-division/country:ca/fed:24068,Saint-Maurice–Champlain
+ocd-division/country:ca/fed:24069,Shefford
+ocd-division/country:ca/fed:24070,Sherbrooke
+ocd-division/country:ca/fed:24071,Terrebonne–Blainville
+ocd-division/country:ca/fed:24072,Trois-Rivières
+ocd-division/country:ca/fed:24073,Vaudreuil-Soulanges
+ocd-division/country:ca/fed:24074,Verchères–Les Patriotes
+ocd-division/country:ca/fed:24075,Westmount–Ville-Marie
+ocd-division/country:ca/fed:35001,Ajax–Pickering
+ocd-division/country:ca/fed:35002,Algoma–Manitoulin–Kapuskasing
+ocd-division/country:ca/fed:35003,Ancaster–Dundas–Flamborough–Westdale
+ocd-division/country:ca/fed:35004,Barrie
+ocd-division/country:ca/fed:35005,Beaches–East York
+ocd-division/country:ca/fed:35006,Bramalea–Gore–Malton
+ocd-division/country:ca/fed:35007,Brampton–Springdale
+ocd-division/country:ca/fed:35008,Brampton West
+ocd-division/country:ca/fed:35009,Brant
+ocd-division/country:ca/fed:35010,Burlington
+ocd-division/country:ca/fed:35011,Cambridge
+ocd-division/country:ca/fed:35012,Carleton–Mississippi Mills
+ocd-division/country:ca/fed:35013,Chatham-Kent–Essex
+ocd-division/country:ca/fed:35014,Durham
+ocd-division/country:ca/fed:35015,Davenport
+ocd-division/country:ca/fed:35016,Don Valley East
+ocd-division/country:ca/fed:35017,Don Valley West
+ocd-division/country:ca/fed:35018,Dufferin–Caledon
+ocd-division/country:ca/fed:35019,Eglinton–Lawrence
+ocd-division/country:ca/fed:35020,Elgin–Middlesex–London
+ocd-division/country:ca/fed:35021,Essex
+ocd-division/country:ca/fed:35022,Etobicoke Centre
+ocd-division/country:ca/fed:35023,Etobicoke–Lakeshore
+ocd-division/country:ca/fed:35024,Etobicoke North
+ocd-division/country:ca/fed:35025,Glengarry–Prescott–Russell
+ocd-division/country:ca/fed:35026,Bruce–Grey–Owen Sound
+ocd-division/country:ca/fed:35027,Guelph
+ocd-division/country:ca/fed:35028,Haldimand–Norfolk
+ocd-division/country:ca/fed:35029,Haliburton–Kawartha Lakes–Brock
+ocd-division/country:ca/fed:35030,Halton
+ocd-division/country:ca/fed:35031,Hamilton Centre
+ocd-division/country:ca/fed:35032,Hamilton East–Stoney Creek
+ocd-division/country:ca/fed:35033,Hamilton Mountain
+ocd-division/country:ca/fed:35034,Huron–Bruce
+ocd-division/country:ca/fed:35035,Kenora
+ocd-division/country:ca/fed:35036,Kingston and the Islands
+ocd-division/country:ca/fed:35037,Kitchener Centre
+ocd-division/country:ca/fed:35038,Kitchener–Conestoga
+ocd-division/country:ca/fed:35039,Kitchener–Waterloo
+ocd-division/country:ca/fed:35040,Lanark–Frontenac–Lennox and Addington
+ocd-division/country:ca/fed:35041,Leeds–Grenville
+ocd-division/country:ca/fed:35042,London–Fanshawe
+ocd-division/country:ca/fed:35043,London North Centre
+ocd-division/country:ca/fed:35044,London West
+ocd-division/country:ca/fed:35045,Markham–Unionville
+ocd-division/country:ca/fed:35046,Lambton–Kent–Middlesex
+ocd-division/country:ca/fed:35047,Mississauga–Brampton South
+ocd-division/country:ca/fed:35048,Mississauga East–Cooksville
+ocd-division/country:ca/fed:35049,Mississauga–Erindale
+ocd-division/country:ca/fed:35050,Mississauga South
+ocd-division/country:ca/fed:35051,Mississauga–Streetsville
+ocd-division/country:ca/fed:35052,Nepean–Carleton
+ocd-division/country:ca/fed:35053,Newmarket–Aurora
+ocd-division/country:ca/fed:35054,Niagara Falls
+ocd-division/country:ca/fed:35055,Niagara West–Glanbrook
+ocd-division/country:ca/fed:35056,Nickel Belt
+ocd-division/country:ca/fed:35057,Nipissing–Timiskaming
+ocd-division/country:ca/fed:35058,Northumberland–Quinte West
+ocd-division/country:ca/fed:35059,Oak Ridges–Markham
+ocd-division/country:ca/fed:35060,Oakville
+ocd-division/country:ca/fed:35061,Oshawa
+ocd-division/country:ca/fed:35062,Ottawa Centre
+ocd-division/country:ca/fed:35063,Ottawa–Orléans
+ocd-division/country:ca/fed:35064,Ottawa South
+ocd-division/country:ca/fed:35065,Ottawa–Vanier
+ocd-division/country:ca/fed:35066,Ottawa West–Nepean
+ocd-division/country:ca/fed:35067,Oxford
+ocd-division/country:ca/fed:35068,Parkdale–High Park
+ocd-division/country:ca/fed:35069,Parry Sound–Muskoka
+ocd-division/country:ca/fed:35070,Perth–Wellington
+ocd-division/country:ca/fed:35071,Peterborough
+ocd-division/country:ca/fed:35072,Pickering–Scarborough East
+ocd-division/country:ca/fed:35073,Prince Edward–Hastings
+ocd-division/country:ca/fed:35074,Renfrew–Nipissing–Pembroke
+ocd-division/country:ca/fed:35075,Richmond Hill
+ocd-division/country:ca/fed:35076,St. Catharines
+ocd-division/country:ca/fed:35077,St. Paul's
+ocd-division/country:ca/fed:35078,Sarnia–Lambton
+ocd-division/country:ca/fed:35079,Sault Ste. Marie
+ocd-division/country:ca/fed:35080,Scarborough–Agincourt
+ocd-division/country:ca/fed:35081,Scarborough Centre
+ocd-division/country:ca/fed:35082,Scarborough–Guildwood
+ocd-division/country:ca/fed:35083,Scarborough–Rouge River
+ocd-division/country:ca/fed:35084,Scarborough Southwest
+ocd-division/country:ca/fed:35085,Simcoe–Grey
+ocd-division/country:ca/fed:35086,Simcoe North
+ocd-division/country:ca/fed:35087,Stormont–Dundas–South Glengarry
+ocd-division/country:ca/fed:35088,Sudbury
+ocd-division/country:ca/fed:35089,Thornhill
+ocd-division/country:ca/fed:35090,Thunder Bay–Rainy River
+ocd-division/country:ca/fed:35091,Thunder Bay–Superior North
+ocd-division/country:ca/fed:35092,Timmins–James Bay
+ocd-division/country:ca/fed:35093,Toronto Centre
+ocd-division/country:ca/fed:35094,Toronto–Danforth
+ocd-division/country:ca/fed:35095,Trinity–Spadina
+ocd-division/country:ca/fed:35096,Vaughan
+ocd-division/country:ca/fed:35097,Welland
+ocd-division/country:ca/fed:35098,Wellington–Halton Hills
+ocd-division/country:ca/fed:35099,Whitby–Oshawa
+ocd-division/country:ca/fed:35100,Willowdale
+ocd-division/country:ca/fed:35101,Windsor–Tecumseh
+ocd-division/country:ca/fed:35102,Windsor West
+ocd-division/country:ca/fed:35103,York Centre
+ocd-division/country:ca/fed:35104,York–Simcoe
+ocd-division/country:ca/fed:35105,York South–Weston
+ocd-division/country:ca/fed:35106,York West
+ocd-division/country:ca/fed:46001,Brandon–Souris
+ocd-division/country:ca/fed:46002,Charleswood–St. James–Assiniboia
+ocd-division/country:ca/fed:46003,Churchill
+ocd-division/country:ca/fed:46004,Dauphin–Swan River–Marquette
+ocd-division/country:ca/fed:46005,Elmwood–Transcona
+ocd-division/country:ca/fed:46006,Kildonan–St. Paul
+ocd-division/country:ca/fed:46007,Portage–Lisgar
+ocd-division/country:ca/fed:46008,Provencher
+ocd-division/country:ca/fed:46009,Saint Boniface
+ocd-division/country:ca/fed:46010,Selkirk–Interlake
+ocd-division/country:ca/fed:46011,Winnipeg Centre
+ocd-division/country:ca/fed:46012,Winnipeg North
+ocd-division/country:ca/fed:46013,Winnipeg South
+ocd-division/country:ca/fed:46014,Winnipeg South Centre
+ocd-division/country:ca/fed:47001,Battlefords–Lloydminster
+ocd-division/country:ca/fed:47002,Blackstrap
+ocd-division/country:ca/fed:47003,Desnethé–Missinippi–Churchill River
+ocd-division/country:ca/fed:47004,Cypress Hills–Grasslands
+ocd-division/country:ca/fed:47005,Palliser
+ocd-division/country:ca/fed:47006,Prince Albert
+ocd-division/country:ca/fed:47007,Regina–Lumsden–Lake Centre
+ocd-division/country:ca/fed:47008,Regina–Qu'Appelle
+ocd-division/country:ca/fed:47009,Saskatoon–Humboldt
+ocd-division/country:ca/fed:47010,Saskatoon–Rosetown–Biggar
+ocd-division/country:ca/fed:47011,Saskatoon–Wanuskewin
+ocd-division/country:ca/fed:47012,Souris–Moose Mountain
+ocd-division/country:ca/fed:47013,Wascana
+ocd-division/country:ca/fed:47014,Yorkton–Melville
+ocd-division/country:ca/fed:48001,Fort McMurray–Athabasca
+ocd-division/country:ca/fed:48002,Calgary East
+ocd-division/country:ca/fed:48003,Calgary Centre-North
+ocd-division/country:ca/fed:48004,Calgary Northeast
+ocd-division/country:ca/fed:48005,Calgary–Nose Hill
+ocd-division/country:ca/fed:48006,Calgary Centre
+ocd-division/country:ca/fed:48007,Calgary Southeast
+ocd-division/country:ca/fed:48008,Calgary Southwest
+ocd-division/country:ca/fed:48009,Calgary West
+ocd-division/country:ca/fed:48010,Crowfoot
+ocd-division/country:ca/fed:48011,Edmonton–Mill Woods–Beaumont
+ocd-division/country:ca/fed:48012,Edmonton Centre
+ocd-division/country:ca/fed:48013,Edmonton East
+ocd-division/country:ca/fed:48014,Edmonton–Leduc
+ocd-division/country:ca/fed:48015,Edmonton–St. Albert
+ocd-division/country:ca/fed:48016,Edmonton–Sherwood Park
+ocd-division/country:ca/fed:48017,Edmonton–Spruce Grove
+ocd-division/country:ca/fed:48018,Edmonton–Strathcona
+ocd-division/country:ca/fed:48019,Lethbridge
+ocd-division/country:ca/fed:48020,Macleod
+ocd-division/country:ca/fed:48021,Medicine Hat
+ocd-division/country:ca/fed:48022,Peace River
+ocd-division/country:ca/fed:48023,Red Deer
+ocd-division/country:ca/fed:48024,Vegreville–Wainwright
+ocd-division/country:ca/fed:48025,Westlock–St. Paul
+ocd-division/country:ca/fed:48026,Wetaskiwin
+ocd-division/country:ca/fed:48027,Wild Rose
+ocd-division/country:ca/fed:48028,Yellowhead
+ocd-division/country:ca/fed:59001,Abbotsford
+ocd-division/country:ca/fed:59002,Burnaby–Douglas
+ocd-division/country:ca/fed:59003,Burnaby–New Westminster
+ocd-division/country:ca/fed:59004,Cariboo–Prince George
+ocd-division/country:ca/fed:59005,Chilliwack–Fraser Canyon
+ocd-division/country:ca/fed:59006,Delta–Richmond East
+ocd-division/country:ca/fed:59007,Pitt Meadows–Maple Ridge–Mission
+ocd-division/country:ca/fed:59008,Esquimalt–Juan de Fuca
+ocd-division/country:ca/fed:59009,Fleetwood–Port Kells
+ocd-division/country:ca/fed:59010,Kamloops–Thompson–Cariboo
+ocd-division/country:ca/fed:59011,Kelowna–Lake Country
+ocd-division/country:ca/fed:59012,Kootenay–Columbia
+ocd-division/country:ca/fed:59013,Langley
+ocd-division/country:ca/fed:59014,Nanaimo–Alberni
+ocd-division/country:ca/fed:59015,Nanaimo–Cowichan
+ocd-division/country:ca/fed:59016,Newton–North Delta
+ocd-division/country:ca/fed:59017,New Westminster–Coquitlam
+ocd-division/country:ca/fed:59018,Okanagan–Shuswap
+ocd-division/country:ca/fed:59019,North Vancouver
+ocd-division/country:ca/fed:59020,Okanagan–Coquihalla
+ocd-division/country:ca/fed:59021,Port Moody–Westwood–Port Coquitlam
+ocd-division/country:ca/fed:59022,Prince George–Peace River
+ocd-division/country:ca/fed:59023,Richmond
+ocd-division/country:ca/fed:59024,Saanich–Gulf Islands
+ocd-division/country:ca/fed:59025,Skeena–Bulkley Valley
+ocd-division/country:ca/fed:59026,British Columbia Southern Interior
+ocd-division/country:ca/fed:59027,South Surrey–White Rock–Cloverdale
+ocd-division/country:ca/fed:59028,Surrey North
+ocd-division/country:ca/fed:59029,Vancouver Centre
+ocd-division/country:ca/fed:59030,Vancouver East
+ocd-division/country:ca/fed:59031,Vancouver Island North
+ocd-division/country:ca/fed:59032,Vancouver Kingsway
+ocd-division/country:ca/fed:59033,Vancouver Quadra
+ocd-division/country:ca/fed:59034,Vancouver South
+ocd-division/country:ca/fed:59035,Victoria
+ocd-division/country:ca/fed:59036,West Vancouver–Sunshine Coast–Sea to Sky Country
+ocd-division/country:ca/fed:60001,Yukon
+ocd-division/country:ca/fed:61001,Western Arctic
+ocd-division/country:ca/fed:62001,Nunavut

--- a/mappings/country-ca-fr/ca_federal_electoral_districts.csv
+++ b/mappings/country-ca-fr/ca_federal_electoral_districts.csv
@@ -1,0 +1,308 @@
+ocd-division/country:ca/fed:10001,Avalon
+ocd-division/country:ca/fed:10002,Bonavista–Gander–Grand Falls–Windsor
+ocd-division/country:ca/fed:10003,Humber–St. Barbe–Baie Verte
+ocd-division/country:ca/fed:10004,Labrador
+ocd-division/country:ca/fed:10005,Random–Burin–St. George's
+ocd-division/country:ca/fed:10006,St. John's-Est
+ocd-division/country:ca/fed:10007,St. John's-Sud–Mount Pearl
+ocd-division/country:ca/fed:11001,Cardigan
+ocd-division/country:ca/fed:11002,Charlottetown
+ocd-division/country:ca/fed:11003,Egmont
+ocd-division/country:ca/fed:11004,Malpeque
+ocd-division/country:ca/fed:12001,Cape Breton–Canso
+ocd-division/country:ca/fed:12002,Nova-Centre
+ocd-division/country:ca/fed:12003,Dartmouth–Cole Harbour
+ocd-division/country:ca/fed:12004,Halifax
+ocd-division/country:ca/fed:12005,Halifax-Ouest
+ocd-division/country:ca/fed:12006,Kings–Hants
+ocd-division/country:ca/fed:12007,Cumberland–Colchester–Musquodoboit Valley
+ocd-division/country:ca/fed:12008,Sackville–Eastern Shore
+ocd-division/country:ca/fed:12009,South Shore–St. Margaret's
+ocd-division/country:ca/fed:12010,Sydney–Victoria
+ocd-division/country:ca/fed:12011,Nova-Ouest
+ocd-division/country:ca/fed:13001,Acadie–Bathurst
+ocd-division/country:ca/fed:13002,Beauséjour
+ocd-division/country:ca/fed:13003,Fredericton
+ocd-division/country:ca/fed:13004,Fundy Royal
+ocd-division/country:ca/fed:13005,Madawaska–Restigouche
+ocd-division/country:ca/fed:13006,Miramichi
+ocd-division/country:ca/fed:13007,Moncton–Riverview–Dieppe
+ocd-division/country:ca/fed:13008,Nouveau-Brunswick-Sud-Ouest
+ocd-division/country:ca/fed:13009,Saint John
+ocd-division/country:ca/fed:13010,Tobique–Mactaquac
+ocd-division/country:ca/fed:24001,Abitibi–Témiscamingue
+ocd-division/country:ca/fed:24002,Ahuntsic
+ocd-division/country:ca/fed:24003,Alfred-Pellan
+ocd-division/country:ca/fed:24004,Argenteuil–Papineau–Mirabel
+ocd-division/country:ca/fed:24005,Beauce
+ocd-division/country:ca/fed:24006,Beauharnois–Salaberry
+ocd-division/country:ca/fed:24007,Beauport–Limoilou
+ocd-division/country:ca/fed:24008,Berthier–Maskinongé
+ocd-division/country:ca/fed:24009,Bourassa
+ocd-division/country:ca/fed:24010,Brome–Missisquoi
+ocd-division/country:ca/fed:24011,Brossard–La Prairie
+ocd-division/country:ca/fed:24012,Chambly–Borduas
+ocd-division/country:ca/fed:24013,Charlesbourg–Haute-Saint-Charles
+ocd-division/country:ca/fed:24014,Montmorency–Charlevoix–Haute-Côte-Nord
+ocd-division/country:ca/fed:24015,Châteauguay–Saint-Constant
+ocd-division/country:ca/fed:24016,Chicoutimi–Le Fjord
+ocd-division/country:ca/fed:24017,Compton–Stanstead
+ocd-division/country:ca/fed:24018,Drummond
+ocd-division/country:ca/fed:24019,Gaspésie–Îles-de-la-Madeleine
+ocd-division/country:ca/fed:24020,Gatineau
+ocd-division/country:ca/fed:24021,Hochelaga
+ocd-division/country:ca/fed:24022,Honoré-Mercier
+ocd-division/country:ca/fed:24023,Hull–Aylmer
+ocd-division/country:ca/fed:24024,Jeanne-Le Ber
+ocd-division/country:ca/fed:24025,Joliette
+ocd-division/country:ca/fed:24026,Jonquière–Alma
+ocd-division/country:ca/fed:24027,Lac-Saint-Louis
+ocd-division/country:ca/fed:24028,La Pointe-de-l'Île
+ocd-division/country:ca/fed:24029,LaSalle–Émard
+ocd-division/country:ca/fed:24030,Laurentides–Labelle
+ocd-division/country:ca/fed:24031,Laurier–Sainte-Marie
+ocd-division/country:ca/fed:24032,Laval
+ocd-division/country:ca/fed:24033,Laval–Les Îles
+ocd-division/country:ca/fed:24034,Lévis–Bellechasse
+ocd-division/country:ca/fed:24035,Longueuil–Pierre-Boucher
+ocd-division/country:ca/fed:24036,Lotbinière–Chutes-de-la-Chaudière
+ocd-division/country:ca/fed:24037,Louis-Hébert
+ocd-division/country:ca/fed:24038,Louis-Saint-Laurent
+ocd-division/country:ca/fed:24039,Manicouagan
+ocd-division/country:ca/fed:24040,Marc-Aurèle-Fortin
+ocd-division/country:ca/fed:24041,Haute-Gaspésie–La Mitis–Matane–Matapédia
+ocd-division/country:ca/fed:24042,Mégantic–L'Érable
+ocd-division/country:ca/fed:24043,Montcalm
+ocd-division/country:ca/fed:24044,Mont-Royal
+ocd-division/country:ca/fed:24045,Notre-Dame-de-Grâce–Lachine
+ocd-division/country:ca/fed:24046,Abitibi–Baie-James–Nunavik–Eeyou
+ocd-division/country:ca/fed:24047,Outremont
+ocd-division/country:ca/fed:24048,Papineau
+ocd-division/country:ca/fed:24049,Pierrefonds–Dollard
+ocd-division/country:ca/fed:24050,Pontiac
+ocd-division/country:ca/fed:24051,Portneuf–Jacques-Cartier
+ocd-division/country:ca/fed:24052,Québec
+ocd-division/country:ca/fed:24053,Repentigny
+ocd-division/country:ca/fed:24054,Bas-Richelieu–Nicolet–Bécancour
+ocd-division/country:ca/fed:24055,Richmond–Arthabaska
+ocd-division/country:ca/fed:24056,Rimouski-Neigette–Témiscouata–Les Basques
+ocd-division/country:ca/fed:24057,Rivière-des-Mille-Îles
+ocd-division/country:ca/fed:24058,Montmagny–L'Islet–Kamouraska–Rivière-du-Loup
+ocd-division/country:ca/fed:24059,Rivière-du-Nord
+ocd-division/country:ca/fed:24060,Roberval–Lac-Saint-Jean
+ocd-division/country:ca/fed:24061,Rosemont–La Petite-Patrie
+ocd-division/country:ca/fed:24062,Saint-Bruno–Saint-Hubert
+ocd-division/country:ca/fed:24063,Saint-Hyacinthe–Bagot
+ocd-division/country:ca/fed:24064,Saint-Jean
+ocd-division/country:ca/fed:24065,Saint-Lambert
+ocd-division/country:ca/fed:24066,Saint-Laurent–Cartierville
+ocd-division/country:ca/fed:24067,Saint-Léonard–Saint-Michel
+ocd-division/country:ca/fed:24068,Saint-Maurice–Champlain
+ocd-division/country:ca/fed:24069,Shefford
+ocd-division/country:ca/fed:24070,Sherbrooke
+ocd-division/country:ca/fed:24071,Terrebonne–Blainville
+ocd-division/country:ca/fed:24072,Trois-Rivières
+ocd-division/country:ca/fed:24073,Vaudreuil-Soulanges
+ocd-division/country:ca/fed:24074,Verchères–Les Patriotes
+ocd-division/country:ca/fed:24075,Westmount–Ville-Marie
+ocd-division/country:ca/fed:35001,Ajax–Pickering
+ocd-division/country:ca/fed:35002,Algoma–Manitoulin–Kapuskasing
+ocd-division/country:ca/fed:35003,Ancaster–Dundas–Flamborough–Westdale
+ocd-division/country:ca/fed:35004,Barrie
+ocd-division/country:ca/fed:35005,Beaches–East York
+ocd-division/country:ca/fed:35006,Bramalea–Gore–Malton
+ocd-division/country:ca/fed:35007,Brampton–Springdale
+ocd-division/country:ca/fed:35008,Brampton-Ouest
+ocd-division/country:ca/fed:35009,Brant
+ocd-division/country:ca/fed:35010,Burlington
+ocd-division/country:ca/fed:35011,Cambridge
+ocd-division/country:ca/fed:35012,Carleton–Mississippi Mills
+ocd-division/country:ca/fed:35013,Chatham-Kent–Essex
+ocd-division/country:ca/fed:35014,Durham
+ocd-division/country:ca/fed:35015,Davenport
+ocd-division/country:ca/fed:35016,Don Valley-Est
+ocd-division/country:ca/fed:35017,Don Valley-Ouest
+ocd-division/country:ca/fed:35018,Dufferin–Caledon
+ocd-division/country:ca/fed:35019,Eglinton–Lawrence
+ocd-division/country:ca/fed:35020,Elgin–Middlesex–London
+ocd-division/country:ca/fed:35021,Essex
+ocd-division/country:ca/fed:35022,Etobicoke-Centre
+ocd-division/country:ca/fed:35023,Etobicoke–Lakeshore
+ocd-division/country:ca/fed:35024,Etobicoke-Nord
+ocd-division/country:ca/fed:35025,Glengarry–Prescott–Russell
+ocd-division/country:ca/fed:35026,Bruce–Grey–Owen Sound
+ocd-division/country:ca/fed:35027,Guelph
+ocd-division/country:ca/fed:35028,Haldimand–Norfolk
+ocd-division/country:ca/fed:35029,Haliburton–Kawartha Lakes–Brock
+ocd-division/country:ca/fed:35030,Halton
+ocd-division/country:ca/fed:35031,Hamilton-Centre
+ocd-division/country:ca/fed:35032,Hamilton-Est–Stoney Creek
+ocd-division/country:ca/fed:35033,Hamilton Mountain
+ocd-division/country:ca/fed:35034,Huron–Bruce
+ocd-division/country:ca/fed:35035,Kenora
+ocd-division/country:ca/fed:35036,Kingston et les Îles
+ocd-division/country:ca/fed:35037,Kitchener-Centre
+ocd-division/country:ca/fed:35038,Kitchener–Conestoga
+ocd-division/country:ca/fed:35039,Kitchener–Waterloo
+ocd-division/country:ca/fed:35040,Lanark–Frontenac–Lennox and Addington
+ocd-division/country:ca/fed:35041,Leeds–Grenville
+ocd-division/country:ca/fed:35042,London–Fanshawe
+ocd-division/country:ca/fed:35043,London-Centre-Nord
+ocd-division/country:ca/fed:35044,London-Ouest
+ocd-division/country:ca/fed:35045,Markham–Unionville
+ocd-division/country:ca/fed:35046,Lambton–Kent–Middlesex
+ocd-division/country:ca/fed:35047,Mississauga–Brampton-Sud
+ocd-division/country:ca/fed:35048,Mississauga-Est–Cooksville
+ocd-division/country:ca/fed:35049,Mississauga–Erindale
+ocd-division/country:ca/fed:35050,Mississauga-Sud
+ocd-division/country:ca/fed:35051,Mississauga–Streetsville
+ocd-division/country:ca/fed:35052,Nepean–Carleton
+ocd-division/country:ca/fed:35053,Newmarket–Aurora
+ocd-division/country:ca/fed:35054,Niagara Falls
+ocd-division/country:ca/fed:35055,Niagara-Ouest–Glanbrook
+ocd-division/country:ca/fed:35056,Nickel Belt
+ocd-division/country:ca/fed:35057,Nipissing–Timiskaming
+ocd-division/country:ca/fed:35058,Northumberland–Quinte West
+ocd-division/country:ca/fed:35059,Oak Ridges–Markham
+ocd-division/country:ca/fed:35060,Oakville
+ocd-division/country:ca/fed:35061,Oshawa
+ocd-division/country:ca/fed:35062,Ottawa-Centre
+ocd-division/country:ca/fed:35063,Ottawa–Orléans
+ocd-division/country:ca/fed:35064,Ottawa-Sud
+ocd-division/country:ca/fed:35065,Ottawa–Vanier
+ocd-division/country:ca/fed:35066,Ottawa-Ouest–Nepean
+ocd-division/country:ca/fed:35067,Oxford
+ocd-division/country:ca/fed:35068,Parkdale–High Park
+ocd-division/country:ca/fed:35069,Parry Sound–Muskoka
+ocd-division/country:ca/fed:35070,Perth–Wellington
+ocd-division/country:ca/fed:35071,Peterborough
+ocd-division/country:ca/fed:35072,Pickering–Scarborough-Est
+ocd-division/country:ca/fed:35073,Prince Edward–Hastings
+ocd-division/country:ca/fed:35074,Renfrew–Nipissing–Pembroke
+ocd-division/country:ca/fed:35075,Richmond Hill
+ocd-division/country:ca/fed:35076,St. Catharines
+ocd-division/country:ca/fed:35077,St. Paul's
+ocd-division/country:ca/fed:35078,Sarnia–Lambton
+ocd-division/country:ca/fed:35079,Sault Ste. Marie
+ocd-division/country:ca/fed:35080,Scarborough–Agincourt
+ocd-division/country:ca/fed:35081,Scarborough-Centre
+ocd-division/country:ca/fed:35082,Scarborough–Guildwood
+ocd-division/country:ca/fed:35083,Scarborough–Rouge River
+ocd-division/country:ca/fed:35084,Scarborough-Sud-Ouest
+ocd-division/country:ca/fed:35085,Simcoe–Grey
+ocd-division/country:ca/fed:35086,Simcoe-Nord
+ocd-division/country:ca/fed:35087,Stormont–Dundas–South Glengarry
+ocd-division/country:ca/fed:35088,Sudbury
+ocd-division/country:ca/fed:35089,Thornhill
+ocd-division/country:ca/fed:35090,Thunder Bay–Rainy River
+ocd-division/country:ca/fed:35091,Thunder Bay–Superior-Nord
+ocd-division/country:ca/fed:35092,Timmins–Baie James
+ocd-division/country:ca/fed:35093,Toronto-Centre
+ocd-division/country:ca/fed:35094,Toronto–Danforth
+ocd-division/country:ca/fed:35095,Trinity–Spadina
+ocd-division/country:ca/fed:35096,Vaughan
+ocd-division/country:ca/fed:35097,Welland
+ocd-division/country:ca/fed:35098,Wellington–Halton Hills
+ocd-division/country:ca/fed:35099,Whitby–Oshawa
+ocd-division/country:ca/fed:35100,Willowdale
+ocd-division/country:ca/fed:35101,Windsor–Tecumseh
+ocd-division/country:ca/fed:35102,Windsor-Ouest
+ocd-division/country:ca/fed:35103,York-Centre
+ocd-division/country:ca/fed:35104,York–Simcoe
+ocd-division/country:ca/fed:35105,York-Sud–Weston
+ocd-division/country:ca/fed:35106,York-Ouest
+ocd-division/country:ca/fed:46001,Brandon–Souris
+ocd-division/country:ca/fed:46002,Charleswood–St. James–Assiniboia
+ocd-division/country:ca/fed:46003,Churchill
+ocd-division/country:ca/fed:46004,Dauphin–Swan River–Marquette
+ocd-division/country:ca/fed:46005,Elmwood–Transcona
+ocd-division/country:ca/fed:46006,Kildonan–St. Paul
+ocd-division/country:ca/fed:46007,Portage–Lisgar
+ocd-division/country:ca/fed:46008,Provencher
+ocd-division/country:ca/fed:46009,Saint-Boniface
+ocd-division/country:ca/fed:46010,Selkirk–Interlake
+ocd-division/country:ca/fed:46011,Winnipeg-Centre
+ocd-division/country:ca/fed:46012,Winnipeg-Nord
+ocd-division/country:ca/fed:46013,Winnipeg-Sud
+ocd-division/country:ca/fed:46014,Winnipeg-Centre-Sud
+ocd-division/country:ca/fed:47001,Battlefords–Lloydminster
+ocd-division/country:ca/fed:47002,Blackstrap
+ocd-division/country:ca/fed:47003,Desnethé–Missinippi–Rivière Churchill
+ocd-division/country:ca/fed:47004,Cypress Hills–Grasslands
+ocd-division/country:ca/fed:47005,Palliser
+ocd-division/country:ca/fed:47006,Prince Albert
+ocd-division/country:ca/fed:47007,Regina–Lumsden–Lake Centre
+ocd-division/country:ca/fed:47008,Regina–Qu'Appelle
+ocd-division/country:ca/fed:47009,Saskatoon–Humboldt
+ocd-division/country:ca/fed:47010,Saskatoon–Rosetown–Biggar
+ocd-division/country:ca/fed:47011,Saskatoon–Wanuskewin
+ocd-division/country:ca/fed:47012,Souris–Moose Mountain
+ocd-division/country:ca/fed:47013,Wascana
+ocd-division/country:ca/fed:47014,Yorkton–Melville
+ocd-division/country:ca/fed:48001,Fort McMurray–Athabasca
+ocd-division/country:ca/fed:48002,Calgary-Est
+ocd-division/country:ca/fed:48003,Calgary-Centre-Nord
+ocd-division/country:ca/fed:48004,Calgary-Nord-Est
+ocd-division/country:ca/fed:48005,Calgary–Nose Hill
+ocd-division/country:ca/fed:48006,Calgary-Centre
+ocd-division/country:ca/fed:48007,Calgary-Sud-Est
+ocd-division/country:ca/fed:48008,Calgary-Sud-Ouest
+ocd-division/country:ca/fed:48009,Calgary-Ouest
+ocd-division/country:ca/fed:48010,Crowfoot
+ocd-division/country:ca/fed:48011,Edmonton–Mill Woods–Beaumont
+ocd-division/country:ca/fed:48012,Edmonton-Centre
+ocd-division/country:ca/fed:48013,Edmonton-Est
+ocd-division/country:ca/fed:48014,Edmonton–Leduc
+ocd-division/country:ca/fed:48015,Edmonton–St. Albert
+ocd-division/country:ca/fed:48016,Edmonton–Sherwood Park
+ocd-division/country:ca/fed:48017,Edmonton–Spruce Grove
+ocd-division/country:ca/fed:48018,Edmonton–Strathcona
+ocd-division/country:ca/fed:48019,Lethbridge
+ocd-division/country:ca/fed:48020,Macleod
+ocd-division/country:ca/fed:48021,Medicine Hat
+ocd-division/country:ca/fed:48022,Peace River
+ocd-division/country:ca/fed:48023,Red Deer
+ocd-division/country:ca/fed:48024,Vegreville–Wainwright
+ocd-division/country:ca/fed:48025,Westlock–St. Paul
+ocd-division/country:ca/fed:48026,Wetaskiwin
+ocd-division/country:ca/fed:48027,Wild Rose
+ocd-division/country:ca/fed:48028,Yellowhead
+ocd-division/country:ca/fed:59001,Abbotsford
+ocd-division/country:ca/fed:59002,Burnaby–Douglas
+ocd-division/country:ca/fed:59003,Burnaby–New Westminster
+ocd-division/country:ca/fed:59004,Cariboo–Prince George
+ocd-division/country:ca/fed:59005,Chilliwack–Fraser Canyon
+ocd-division/country:ca/fed:59006,Delta–Richmond-Est
+ocd-division/country:ca/fed:59007,Pitt Meadows–Maple Ridge–Mission
+ocd-division/country:ca/fed:59008,Esquimalt–Juan de Fuca
+ocd-division/country:ca/fed:59009,Fleetwood–Port Kells
+ocd-division/country:ca/fed:59010,Kamloops–Thompson–Cariboo
+ocd-division/country:ca/fed:59011,Kelowna–Lake Country
+ocd-division/country:ca/fed:59012,Kootenay–Columbia
+ocd-division/country:ca/fed:59013,Langley
+ocd-division/country:ca/fed:59014,Nanaimo–Alberni
+ocd-division/country:ca/fed:59015,Nanaimo–Cowichan
+ocd-division/country:ca/fed:59016,Newton–Delta-Nord
+ocd-division/country:ca/fed:59017,New Westminster–Coquitlam
+ocd-division/country:ca/fed:59018,Okanagan–Shuswap
+ocd-division/country:ca/fed:59019,North Vancouver
+ocd-division/country:ca/fed:59020,Okanagan–Coquihalla
+ocd-division/country:ca/fed:59021,Port Moody–Westwood–Port Coquitlam
+ocd-division/country:ca/fed:59022,Prince George–Peace River
+ocd-division/country:ca/fed:59023,Richmond
+ocd-division/country:ca/fed:59024,Saanich–Gulf Islands
+ocd-division/country:ca/fed:59025,Skeena–Bulkley Valley
+ocd-division/country:ca/fed:59026,Colombie-Britannique-Southern Interior
+ocd-division/country:ca/fed:59027,Surrey-Sud–White Rock–Cloverdale
+ocd-division/country:ca/fed:59028,Surrey-Nord
+ocd-division/country:ca/fed:59029,Vancouver-Centre
+ocd-division/country:ca/fed:59030,Vancouver-Est
+ocd-division/country:ca/fed:59031,Île de Vancouver-Nord
+ocd-division/country:ca/fed:59032,Vancouver Kingsway
+ocd-division/country:ca/fed:59033,Vancouver Quadra
+ocd-division/country:ca/fed:59034,Vancouver-Sud
+ocd-division/country:ca/fed:59035,Victoria
+ocd-division/country:ca/fed:59036,West Vancouver–Sunshine Coast–Sea to Sky Country
+ocd-division/country:ca/fed:60001,Yukon
+ocd-division/country:ca/fed:61001,Western Arctic
+ocd-division/country:ca/fed:62001,Nunavut

--- a/scripts/country-ca/Gemfile
+++ b/scripts/country-ca/Gemfile
@@ -1,0 +1,2 @@
+source 'https://rubygems.org'
+gem 'nokogiri'

--- a/scripts/country-ca/Gemfile.lock
+++ b/scripts/country-ca/Gemfile.lock
@@ -1,0 +1,10 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    nokogiri (1.5.9)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  nokogiri

--- a/scripts/country-ca/ca_federal_electoral_districts.rb
+++ b/scripts/country-ca/ca_federal_electoral_districts.rb
@@ -1,0 +1,68 @@
+#!/usr/bin/env ruby
+# coding: utf-8
+
+# Scrapes federal electoral district codes and names from elections.ca
+
+require "rubygems"
+require "bundler/setup"
+
+require "csv"
+require "open-uri"
+require "optparse"
+
+require "nokogiri"
+
+opts = OptionParser.new do |opts|
+  opts.program_name = "ca_federal_electoral_districts.rb"
+  opts.banner = <<-EOS
+Usage: #{opts.program_name} COMMAND
+
+Commands:
+  identifiers  Prints a CSV of identifiers and English names, e.g.:
+               #{opts.program_name} identifiers > identifiers/country-ca/ca_federal_electoral_districts.csv
+  mappings     Prints a CSV of identifiers and French names, e.g.:
+               #{opts.program_name} mappings > mappings/country-ca-fr/ca_federal_electoral_districts.csv
+  EOS
+
+  opts.separator ""
+  opts.separator "Options:"
+  opts.on_tail("-h", "--help", "Display this screen") do
+    puts opts
+    exit
+  end
+end
+
+opts.parse!
+
+command = ARGV.shift
+
+case command
+when "identifiers"
+  lang = "e"
+when "mappings"
+  lang = "f"
+when nil
+  puts opts
+  exit
+else
+  puts %(`#{command}` is not a #{opts.program_name} command. See `#{opts.program_name} --help` for a list of available commands.)
+  exit
+end
+
+puts CSV.generate{|csv|
+  # The most authoritative data is only available as HTML.
+  Nokogiri::HTML(open("http://elections.ca/content.aspx?section=res&dir=cir/list&document=index&lang=#{lang}")).css("tr").each do |tr|
+    tds = tr.css("td")
+    next if tds.empty?
+
+    code = tds[0].text.gsub(/\D/, "")
+    next unless code[/\A\d{5}\z/]
+
+    # Statistics Canada uses the "FED" abbreviation.
+    # @see http://www12.statcan.gc.ca/census-recensement/2011/ref/dict/geo025-eng.cfm
+    csv << [
+      "ocd-division/country:ca/fed:#{code}",
+      tds[1].children[0].text.gsub(/[[:space:]]+/, " ").strip,
+    ]
+  end
+}


### PR DESCRIPTION
I added some scripts for generating the CSVs, not sure what the protocol is on that. Also, not sure if the mappings directory name matters.

Btw, running `verify` gives me lots of warnings like `unexpected geoid for ocd-division/country:us/state:wy/place:yoder` and doesn't create any files.
