### PR TITLE
Update `type` in Identifier Scheme documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Identifiers respect the format `ocd-division/country:<country_code>[/<type>:<typ
 
 * **country_code** - An [ISO-3166-1 alpha-2 code](http://en.wikipedia.org/wiki/ISO_3166-1_alpha-2).
 * **type** - The type of boundary.  (e.g. `country`, `state`, `town`, `city`, `cd`, `sldl`, `sldu`)
-  * Valid characters are lowercase ASCII letters.
+  * Valid characters are lowercase UTF-8 letters, and underscore (\_).
   * Use existing types where possible.
 * **type_id** - An identifier that is locally unique to its scope.
   * Valid characters are lowercase UTF-8 letters, numerals (0-9), period (.), hyphen (-), underscore (\_), and tilde (~).  These characters match the unreserved characters in a URI [RFC 3986 section 2.3](http://www.rfc-editor.org/rfc/rfc3986.txt).


### PR DESCRIPTION
This better reflects what seems to be the currently accepted identifier format (and what the validator actually checks for), except we do not yet have examples of non-ascii letters in division types.

I realize setting policy based on current validator implementation seems backwards, but codifying common practice is acceptable, right?
