### PR TITLE
Add additional new NC OCD IDs for general election 2016

### DIFF
--- a/identifiers/country-us/state-nc-local_gov.csv
+++ b/identifiers/country-us/state-nc-local_gov.csv
@@ -440,3 +440,41 @@ ocd-division/country:us/state:nc/county:surry/place:mount_airy,Mount Airy Town
 ocd-division/country:us/state:nc/county:hertford/place:ahoskie,Ahoskie Town
 ocd-division/country:us/state:nc/county:johnston/place:benson,Benson Town
 ocd-division/country:us/state:nc/county:robeson/place:lumberton,Lumberton City
+ocd-division/country:us/state:nc/county:bertie/council_district:1,Bertie County District 1
+ocd-division/country:us/state:nc/county:bertie/council_district:4,Bertie County District 4
+ocd-division/country:us/state:nc/county:camden/council_district:south_mills,Camden County Board Of County Commissioners South Mills District
+ocd-division/country:us/state:nc/county:carteret/sanitation:harkers_island,Harkers Island Sanitary District
+ocd-division/country:us/state:nc/county:carteret/sanitation:ocracoke,Ocracoke Sanitary District
+ocd-division/country:us/state:nc/county:chatham/school_board_district:1,Chatham County School Board District 1
+ocd-division/country:us/state:nc/county:chatham/school_board_district:2,Chatham County School Board District 2
+ocd-division/country:us/state:nc/county:columbus/sanitation:riegelwood,Riegelwood Sanitary District
+ocd-division/country:us/state:nc/county:gates/council_district:4,Gates County District 4
+ocd-division/country:us/state:nc/county:gates/council_district:5,Gates County District 5
+ocd-division/country:us/state:nc/county:gates/school_district:central_middle_school,Central Middle School District
+ocd-division/country:us/state:nc/county:greene/council_district:2,Greene County Board Of Commissioners District 2
+ocd-division/country:us/state:nc/county:haywood/sanitation:junaluska,Junaluska Sanitary District
+ocd-division/country:us/state:nc/county:haywood/sanitation:maggie_valley,Maggie Valley Sanitary District
+ocd-division/country:us/state:nc/county:hertford/council_district:3,Hertford County Board Of Commissioners District 3
+ocd-division/country:us/state:nc/county:hyde/sanitation:swan_quarter,Swan Quarter Sanitary District
+ocd-division/country:us/state:nc/county:jackson/sanitation:whittier,Whittier Sanitary District
+ocd-division/country:us/state:nc/county:mcdowell/school_board_district:marion,Mcdowell County Marion School Board District
+ocd-division/country:us/state:nc/county:mcdowell/school_board_district:north_cove,Mcdowell County North Cove School Board District
+ocd-division/country:us/state:nc/county:mcdowell/school_board_district:old_fort,Mcdowell County Old Fort School Board District
+ocd-division/country:us/state:nc/county:montgomery/sanitation:handy,Handy Sanitary District
+ocd-division/country:us/state:nc/county:moore/school_board_district:1,Moore County School Board District 1
+ocd-division/country:us/state:nc/county:moore/school_board_district:2,Moore County School Board District 2
+ocd-division/country:us/state:nc/county:moore/school_board_district:4,Moore County School Board District 4
+ocd-division/country:us/state:nc/county:moore/school_board_district:5,Moore County School Board District 5
+ocd-division/country:us/state:nc/county:nash/school_board_district:10,Nash County School Board District 10
+ocd-division/country:us/state:nc/county:nash/school_board_district:11,Nash County School Board District 11
+ocd-division/country:us/state:nc/county:pasquotank/council_district:cdni,Pasquotank County Board Of Commissioners CDNI District
+ocd-division/country:us/state:nc/county:pasquotank/council_district:cdso,Pasquotank County Board Of Commissioners CDSO District
+ocd-division/country:us/state:nc/county:perquimans/sanitation:minzies_creek,Minzies Creek Sanitary District
+ocd-division/country:us/state:nc/county:rutherford/school_board_district:1,Rutherford County School Board District 1
+ocd-division/country:us/state:nc/county:rutherford/school_board_district:2,Rutherford County School Board District 2
+ocd-division/country:us/state:nc/county:rutherford/school_board_district:3,Rutherford County School Board District 3
+ocd-division/country:us/state:nc/county:scotland/council_district:laurel_hill,Scotland County Board Of Commissioners Laurel Hill District
+ocd-division/country:us/state:nc/county:scotland/council_district:stewartsville,Scotland County Board Of Commissioners Stewartsville District
+ocd-division/country:us/state:nc/county:scotland/council_district:williamson,Scotland County Board Of Commissioners Williamson District
+ocd-division/country:us/state:nc/county:stanly/school_board_district:2,Stanly County Board Of Education District 2
+ocd-division/country:us/state:nc/county:swain/sanitation:whittier,Whittier Sanitary District

--- a/identifiers/country-us/state-nc-local_gov.csv
+++ b/identifiers/country-us/state-nc-local_gov.csv
@@ -478,3 +478,5 @@ ocd-division/country:us/state:nc/county:scotland/council_district:stewartsville,
 ocd-division/country:us/state:nc/county:scotland/council_district:williamson,Scotland County Board Of Commissioners Williamson District
 ocd-division/country:us/state:nc/county:stanly/school_board_district:2,Stanly County Board Of Education District 2
 ocd-division/country:us/state:nc/county:swain/sanitation:whittier,Whittier Sanitary District
+ocd-division/country:us/state:nc/county:pasquotank/school_board_district:ocl,Pasquotank County Board Of Education OCL
+ocd-division/country:us/state:nc/county:pasquotank/school_board_district:icl,Pasquotank County Board Of Education ICL

--- a/identifiers/country-us/us_state_courts.csv
+++ b/identifiers/country-us/us_state_courts.csv
@@ -1628,3 +1628,6 @@ ocd-division/country:us/state:nc/superior_court:5b,NC Superior Court District 5b
 ocd-division/country:us/state:nc/superior_court:8a,NC Superior Court District 8a
 ocd-division/country:us/state:nc/superior_court:8b,NC Superior Court District 8b
 ocd-division/country:us/state:nc/court_of_appeals:judge,NC Court Of Appeals Judge
+ocd-division/country:us/state:nc/district_court:11a,NC State Court - District 11A
+ocd-division/country:us/state:nc/district_court:19d,NC State Court - District 19D
+ocd-division/country:us/state:nc/superior_court:17d,NC Superior Court District 17D


### PR DESCRIPTION
We have identified more North Carolina OCD IDs while working with NC BoE, updating the OCDID master list with these additions.