### PR TITLE
Add UK Electoral Divisions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *swp
 cache/*
+__pycache__

--- a/identifiers/country-uk.csv
+++ b/identifiers/country-uk.csv
@@ -1,0 +1,827 @@
+id,name,gss_code
+ocd-division/country:uk,United Kingdom,K02000001
+ocd-division/country:uk/cauth:cambridgeshire_and_peterborough,Cambridgeshire and Peterborough,E47000008
+ocd-division/country:uk/cauth:greater_manchester,Greater Manchester,E47000001
+ocd-division/country:uk/cauth:liverpool_city_region,Liverpool City Region,E47000004
+ocd-division/country:uk/cauth:north_east,North East,E47000005
+ocd-division/country:uk/cauth:sheffield_city_region,Sheffield City Region,E47000002
+ocd-division/country:uk/cauth:tees_valley,Tees Valley,E47000006
+ocd-division/country:uk/cauth:west_midlands,West Midlands,E47000007
+ocd-division/country:uk/cauth:west_of_england,West of England,E47000009
+ocd-division/country:uk/cauth:west_yorkshire,West Yorkshire,E47000003
+ocd-division/country:uk/nawc:aberavon,Aberavon,W09000022
+ocd-division/country:uk/nawc:aberconwy,Aberconwy,W09000003
+ocd-division/country:uk/nawc:alyn_and_deeside,Alyn and Deeside,W09000007
+ocd-division/country:uk/nawc:arfon,Arfon,W09000002
+ocd-division/country:uk/nawc:blaenau_gwent,Blaenau Gwent,W09000038
+ocd-division/country:uk/nawc:brecon_and_radnorshire,Brecon and Radnorshire,W09000041
+ocd-division/country:uk/nawc:bridgend,Bridgend,W09000023
+ocd-division/country:uk/nawc:caerphilly,Caerphilly,W09000035
+ocd-division/country:uk/nawc:cardiff_central,Cardiff Central,W09000031
+ocd-division/country:uk/nawc:cardiff_north,Cardiff North,W09000042
+ocd-division/country:uk/nawc:cardiff_south_and_penarth,Cardiff South and Penarth,W09000043
+ocd-division/country:uk/nawc:cardiff_west,Cardiff West,W09000029
+ocd-division/country:uk/nawc:carmarthen_east_and_dinefwr,Carmarthen East and Dinefwr,W09000015
+ocd-division/country:uk/nawc:carmarthen_west_and_south_pembrokeshire,Carmarthen West and South Pembrokeshire,W09000016
+ocd-division/country:uk/nawc:ceredigion,Ceredigion,W09000012
+ocd-division/country:uk/nawc:clwyd_south,Clwyd South,W09000009
+ocd-division/country:uk/nawc:clwyd_west,Clwyd West,W09000004
+ocd-division/country:uk/nawc:cynon_valley,Cynon Valley,W09000026
+ocd-division/country:uk/nawc:delyn,Delyn,W09000006
+ocd-division/country:uk/nawc:dwyfor_meirionnydd,Dwyfor Meirionnydd,W09000010
+ocd-division/country:uk/nawc:gower,Gower,W09000018
+ocd-division/country:uk/nawc:islwyn,Islwyn,W09000036
+ocd-division/country:uk/nawc:llanelli,Llanelli,W09000017
+ocd-division/country:uk/nawc:merthyr_tydfil_and_rhymney,Merthyr Tydfil and Rhymney,W09000044
+ocd-division/country:uk/nawc:monmouth,Monmouth,W09000034
+ocd-division/country:uk/nawc:montgomeryshire,Montgomeryshire,W09000011
+ocd-division/country:uk/nawc:neath,Neath,W09000021
+ocd-division/country:uk/nawc:newport_east,Newport East,W09000040
+ocd-division/country:uk/nawc:newport_west,Newport West,W09000039
+ocd-division/country:uk/nawc:ogmore,Ogmore,W09000045
+ocd-division/country:uk/nawc:pontypridd,Pontypridd,W09000046
+ocd-division/country:uk/nawc:preseli_pembrokeshire,Preseli Pembrokeshire,W09000014
+ocd-division/country:uk/nawc:rhondda,Rhondda,W09000025
+ocd-division/country:uk/nawc:swansea_east,Swansea East,W09000020
+ocd-division/country:uk/nawc:swansea_west,Swansea West,W09000019
+ocd-division/country:uk/nawc:torfaen,Torfaen,W09000037
+ocd-division/country:uk/nawc:vale_of_clwyd,Vale of Clwyd,W09000005
+ocd-division/country:uk/nawc:vale_of_glamorgan,Vale of Glamorgan,W09000047
+ocd-division/country:uk/nawc:wrexham,Wrexham,W09000008
+ocd-division/country:uk/nawc:ynys_mon,Ynys Mon,W09000001
+ocd-division/country:uk/nawr:mid_and_west_wales,Mid and West Wales,W10000006
+ocd-division/country:uk/nawr:north_wales,North Wales,W10000001
+ocd-division/country:uk/nawr:south_wales_central,South Wales Central,W10000007
+ocd-division/country:uk/nawr:south_wales_east,South Wales East,W10000008
+ocd-division/country:uk/nawr:south_wales_west,South Wales West,W10000009
+ocd-division/country:uk/pcon:aberavon,Aberavon,W07000049
+ocd-division/country:uk/pcon:aberconwy,Aberconwy,W07000058
+ocd-division/country:uk/pcon:aberdeen_north,Aberdeen North,S14000001
+ocd-division/country:uk/pcon:aberdeen_south,Aberdeen South,S14000002
+ocd-division/country:uk/pcon:airdrie_and_shotts,Airdrie and Shotts,S14000003
+ocd-division/country:uk/pcon:aldershot,Aldershot,E14000530
+ocd-division/country:uk/pcon:aldridge-brownhills,Aldridge-Brownhills,E14000531
+ocd-division/country:uk/pcon:altrincham_and_sale_west,Altrincham and Sale West,E14000532
+ocd-division/country:uk/pcon:alyn_and_deeside,Alyn and Deeside,W07000043
+ocd-division/country:uk/pcon:amber_valley,Amber Valley,E14000533
+ocd-division/country:uk/pcon:angus,Angus,S14000004
+ocd-division/country:uk/pcon:arfon,Arfon,W07000057
+ocd-division/country:uk/pcon:argyll_and_bute,Argyll and Bute,S14000005
+ocd-division/country:uk/pcon:arundel_and_south_downs,Arundel and South Downs,E14000534
+ocd-division/country:uk/pcon:ashfield,Ashfield,E14000535
+ocd-division/country:uk/pcon:ashford,Ashford,E14000536
+ocd-division/country:uk/pcon:ashton-under-lyne,Ashton-under-Lyne,E14000537
+ocd-division/country:uk/pcon:aylesbury,Aylesbury,E14000538
+ocd-division/country:uk/pcon:ayr_carrick_and_cumnock,"Ayr, Carrick and Cumnock",S14000006
+ocd-division/country:uk/pcon:banbury,Banbury,E14000539
+ocd-division/country:uk/pcon:banff_and_buchan,Banff and Buchan,S14000007
+ocd-division/country:uk/pcon:barking,Barking,E14000540
+ocd-division/country:uk/pcon:barnsley_central,Barnsley Central,E14000541
+ocd-division/country:uk/pcon:barnsley_east,Barnsley East,E14000542
+ocd-division/country:uk/pcon:barrow_and_furness,Barrow and Furness,E14000543
+ocd-division/country:uk/pcon:basildon_and_billericay,Basildon and Billericay,E14000544
+ocd-division/country:uk/pcon:basingstoke,Basingstoke,E14000545
+ocd-division/country:uk/pcon:bassetlaw,Bassetlaw,E14000546
+ocd-division/country:uk/pcon:bath,Bath,E14000547
+ocd-division/country:uk/pcon:batley_and_spen,Batley and Spen,E14000548
+ocd-division/country:uk/pcon:battersea,Battersea,E14000549
+ocd-division/country:uk/pcon:beaconsfield,Beaconsfield,E14000550
+ocd-division/country:uk/pcon:beckenham,Beckenham,E14000551
+ocd-division/country:uk/pcon:bedford,Bedford,E14000552
+ocd-division/country:uk/pcon:belfast_east,Belfast East,N06000001
+ocd-division/country:uk/pcon:belfast_north,Belfast North,N06000002
+ocd-division/country:uk/pcon:belfast_south,Belfast South,N06000003
+ocd-division/country:uk/pcon:belfast_west,Belfast West,N06000004
+ocd-division/country:uk/pcon:bermondsey_and_old_southwark,Bermondsey and Old Southwark,E14000553
+ocd-division/country:uk/pcon:berwick-upon-tweed,Berwick-upon-Tweed,E14000554
+ocd-division/country:uk/pcon:berwickshire_roxburgh_and_selkirk,"Berwickshire, Roxburgh and Selkirk",S14000008
+ocd-division/country:uk/pcon:bethnal_green_and_bow,Bethnal Green and Bow,E14000555
+ocd-division/country:uk/pcon:beverley_and_holderness,Beverley and Holderness,E14000556
+ocd-division/country:uk/pcon:bexhill_and_battle,Bexhill and Battle,E14000557
+ocd-division/country:uk/pcon:bexleyheath_and_crayford,Bexleyheath and Crayford,E14000558
+ocd-division/country:uk/pcon:birkenhead,Birkenhead,E14000559
+ocd-division/country:uk/pcon:birmingham_edgbaston,"Birmingham, Edgbaston",E14000560
+ocd-division/country:uk/pcon:birmingham_erdington,"Birmingham, Erdington",E14000561
+ocd-division/country:uk/pcon:birmingham_hall_green,"Birmingham, Hall Green",E14000562
+ocd-division/country:uk/pcon:birmingham_hodge_hill,"Birmingham, Hodge Hill",E14000563
+ocd-division/country:uk/pcon:birmingham_ladywood,"Birmingham, Ladywood",E14000564
+ocd-division/country:uk/pcon:birmingham_northfield,"Birmingham, Northfield",E14000565
+ocd-division/country:uk/pcon:birmingham_perry_barr,"Birmingham, Perry Barr",E14000566
+ocd-division/country:uk/pcon:birmingham_selly_oak,"Birmingham, Selly Oak",E14000567
+ocd-division/country:uk/pcon:birmingham_yardley,"Birmingham, Yardley",E14000568
+ocd-division/country:uk/pcon:bishop_auckland,Bishop Auckland,E14000569
+ocd-division/country:uk/pcon:blackburn,Blackburn,E14000570
+ocd-division/country:uk/pcon:blackley_and_broughton,Blackley and Broughton,E14000571
+ocd-division/country:uk/pcon:blackpool_north_and_cleveleys,Blackpool North and Cleveleys,E14000572
+ocd-division/country:uk/pcon:blackpool_south,Blackpool South,E14000573
+ocd-division/country:uk/pcon:blaenau_gwent,Blaenau Gwent,W07000072
+ocd-division/country:uk/pcon:blaydon,Blaydon,E14000574
+ocd-division/country:uk/pcon:blyth_valley,Blyth Valley,E14000575
+ocd-division/country:uk/pcon:bognor_regis_and_littlehampton,Bognor Regis and Littlehampton,E14000576
+ocd-division/country:uk/pcon:bolsover,Bolsover,E14000577
+ocd-division/country:uk/pcon:bolton_north_east,Bolton North East,E14000578
+ocd-division/country:uk/pcon:bolton_south_east,Bolton South East,E14000579
+ocd-division/country:uk/pcon:bolton_west,Bolton West,E14000580
+ocd-division/country:uk/pcon:bootle,Bootle,E14000581
+ocd-division/country:uk/pcon:boston_and_skegness,Boston and Skegness,E14000582
+ocd-division/country:uk/pcon:bosworth,Bosworth,E14000583
+ocd-division/country:uk/pcon:bournemouth_east,Bournemouth East,E14000584
+ocd-division/country:uk/pcon:bournemouth_west,Bournemouth West,E14000585
+ocd-division/country:uk/pcon:bracknell,Bracknell,E14000586
+ocd-division/country:uk/pcon:bradford_east,Bradford East,E14000587
+ocd-division/country:uk/pcon:bradford_south,Bradford South,E14000588
+ocd-division/country:uk/pcon:bradford_west,Bradford West,E14000589
+ocd-division/country:uk/pcon:braintree,Braintree,E14000590
+ocd-division/country:uk/pcon:brecon_and_radnorshire,Brecon and Radnorshire,W07000068
+ocd-division/country:uk/pcon:brent_central,Brent Central,E14000591
+ocd-division/country:uk/pcon:brent_north,Brent North,E14000592
+ocd-division/country:uk/pcon:brentford_and_isleworth,Brentford and Isleworth,E14000593
+ocd-division/country:uk/pcon:brentwood_and_ongar,Brentwood and Ongar,E14000594
+ocd-division/country:uk/pcon:bridgend,Bridgend,W07000073
+ocd-division/country:uk/pcon:bridgwater_and_west_somerset,Bridgwater and West Somerset,E14000595
+ocd-division/country:uk/pcon:brigg_and_goole,Brigg and Goole,E14000596
+ocd-division/country:uk/pcon:brighton_kemptown,"Brighton, Kemptown",E14000597
+ocd-division/country:uk/pcon:brighton_pavilion,"Brighton, Pavilion",E14000598
+ocd-division/country:uk/pcon:bristol_east,Bristol East,E14000599
+ocd-division/country:uk/pcon:bristol_north_west,Bristol North West,E14000600
+ocd-division/country:uk/pcon:bristol_south,Bristol South,E14000601
+ocd-division/country:uk/pcon:bristol_west,Bristol West,E14000602
+ocd-division/country:uk/pcon:broadland,Broadland,E14000603
+ocd-division/country:uk/pcon:bromley_and_chislehurst,Bromley and Chislehurst,E14000604
+ocd-division/country:uk/pcon:bromsgrove,Bromsgrove,E14000605
+ocd-division/country:uk/pcon:broxbourne,Broxbourne,E14000606
+ocd-division/country:uk/pcon:broxtowe,Broxtowe,E14000607
+ocd-division/country:uk/pcon:buckingham,Buckingham,E14000608
+ocd-division/country:uk/pcon:burnley,Burnley,E14000609
+ocd-division/country:uk/pcon:burton,Burton,E14000610
+ocd-division/country:uk/pcon:bury_north,Bury North,E14000611
+ocd-division/country:uk/pcon:bury_south,Bury South,E14000612
+ocd-division/country:uk/pcon:bury_st_edmunds,Bury St Edmunds,E14000613
+ocd-division/country:uk/pcon:caerphilly,Caerphilly,W07000076
+ocd-division/country:uk/pcon:caithness_sutherland_and_easter_ross,"Caithness, Sutherland and Easter Ross",S14000009
+ocd-division/country:uk/pcon:calder_valley,Calder Valley,E14000614
+ocd-division/country:uk/pcon:camberwell_and_peckham,Camberwell and Peckham,E14000615
+ocd-division/country:uk/pcon:camborne_and_redruth,Camborne and Redruth,E14000616
+ocd-division/country:uk/pcon:cambridge,Cambridge,E14000617
+ocd-division/country:uk/pcon:cannock_chase,Cannock Chase,E14000618
+ocd-division/country:uk/pcon:canterbury,Canterbury,E14000619
+ocd-division/country:uk/pcon:cardiff_central,Cardiff Central,W07000050
+ocd-division/country:uk/pcon:cardiff_north,Cardiff North,W07000051
+ocd-division/country:uk/pcon:cardiff_south_and_penarth,Cardiff South and Penarth,W07000080
+ocd-division/country:uk/pcon:cardiff_west,Cardiff West,W07000079
+ocd-division/country:uk/pcon:carlisle,Carlisle,E14000620
+ocd-division/country:uk/pcon:carmarthen_east_and_dinefwr,Carmarthen East and Dinefwr,W07000067
+ocd-division/country:uk/pcon:carmarthen_west_and_south_pembrokeshire,Carmarthen West and South Pembrokeshire,W07000066
+ocd-division/country:uk/pcon:carshalton_and_wallington,Carshalton and Wallington,E14000621
+ocd-division/country:uk/pcon:castle_point,Castle Point,E14000622
+ocd-division/country:uk/pcon:central_ayrshire,Central Ayrshire,S14000010
+ocd-division/country:uk/pcon:central_devon,Central Devon,E14000623
+ocd-division/country:uk/pcon:central_suffolk_and_north_ipswich,Central Suffolk and North Ipswich,E14000624
+ocd-division/country:uk/pcon:ceredigion,Ceredigion,W07000064
+ocd-division/country:uk/pcon:charnwood,Charnwood,E14000625
+ocd-division/country:uk/pcon:chatham_and_aylesford,Chatham and Aylesford,E14000626
+ocd-division/country:uk/pcon:cheadle,Cheadle,E14000627
+ocd-division/country:uk/pcon:chelmsford,Chelmsford,E14000628
+ocd-division/country:uk/pcon:chelsea_and_fulham,Chelsea and Fulham,E14000629
+ocd-division/country:uk/pcon:cheltenham,Cheltenham,E14000630
+ocd-division/country:uk/pcon:chesham_and_amersham,Chesham and Amersham,E14000631
+ocd-division/country:uk/pcon:chesterfield,Chesterfield,E14000632
+ocd-division/country:uk/pcon:chichester,Chichester,E14000633
+ocd-division/country:uk/pcon:chingford_and_woodford_green,Chingford and Woodford Green,E14000634
+ocd-division/country:uk/pcon:chippenham,Chippenham,E14000635
+ocd-division/country:uk/pcon:chipping_barnet,Chipping Barnet,E14000636
+ocd-division/country:uk/pcon:chorley,Chorley,E14000637
+ocd-division/country:uk/pcon:christchurch,Christchurch,E14000638
+ocd-division/country:uk/pcon:cities_of_london_and_westminster,Cities of London and Westminster,E14000639
+ocd-division/country:uk/pcon:city_of_chester,City of Chester,E14000640
+ocd-division/country:uk/pcon:city_of_durham,City of Durham,E14000641
+ocd-division/country:uk/pcon:clacton,Clacton,E14000642
+ocd-division/country:uk/pcon:cleethorpes,Cleethorpes,E14000643
+ocd-division/country:uk/pcon:clwyd_south,Clwyd South,W07000062
+ocd-division/country:uk/pcon:clwyd_west,Clwyd West,W07000059
+ocd-division/country:uk/pcon:coatbridge_chryston_and_bellshill,"Coatbridge, Chryston and Bellshill",S14000011
+ocd-division/country:uk/pcon:colchester,Colchester,E14000644
+ocd-division/country:uk/pcon:colne_valley,Colne Valley,E14000645
+ocd-division/country:uk/pcon:congleton,Congleton,E14000646
+ocd-division/country:uk/pcon:copeland,Copeland,E14000647
+ocd-division/country:uk/pcon:corby,Corby,E14000648
+ocd-division/country:uk/pcon:coventry_north_east,Coventry North East,E14000649
+ocd-division/country:uk/pcon:coventry_north_west,Coventry North West,E14000650
+ocd-division/country:uk/pcon:coventry_south,Coventry South,E14000651
+ocd-division/country:uk/pcon:crawley,Crawley,E14000652
+ocd-division/country:uk/pcon:crewe_and_nantwich,Crewe and Nantwich,E14000653
+ocd-division/country:uk/pcon:croydon_central,Croydon Central,E14000654
+ocd-division/country:uk/pcon:croydon_north,Croydon North,E14000655
+ocd-division/country:uk/pcon:croydon_south,Croydon South,E14000656
+ocd-division/country:uk/pcon:cumbernauld_kilsyth_and_kirkintilloch_east,"Cumbernauld, Kilsyth and Kirkintilloch East",S14000012
+ocd-division/country:uk/pcon:cynon_valley,Cynon Valley,W07000070
+ocd-division/country:uk/pcon:dagenham_and_rainham,Dagenham and Rainham,E14000657
+ocd-division/country:uk/pcon:darlington,Darlington,E14000658
+ocd-division/country:uk/pcon:dartford,Dartford,E14000659
+ocd-division/country:uk/pcon:daventry,Daventry,E14000660
+ocd-division/country:uk/pcon:delyn,Delyn,W07000042
+ocd-division/country:uk/pcon:denton_and_reddish,Denton and Reddish,E14000661
+ocd-division/country:uk/pcon:derby_north,Derby North,E14000662
+ocd-division/country:uk/pcon:derby_south,Derby South,E14000663
+ocd-division/country:uk/pcon:derbyshire_dales,Derbyshire Dales,E14000664
+ocd-division/country:uk/pcon:devizes,Devizes,E14000665
+ocd-division/country:uk/pcon:dewsbury,Dewsbury,E14000666
+ocd-division/country:uk/pcon:don_valley,Don Valley,E14000667
+ocd-division/country:uk/pcon:doncaster_central,Doncaster Central,E14000668
+ocd-division/country:uk/pcon:doncaster_north,Doncaster North,E14000669
+ocd-division/country:uk/pcon:dover,Dover,E14000670
+ocd-division/country:uk/pcon:dudley_north,Dudley North,E14000671
+ocd-division/country:uk/pcon:dudley_south,Dudley South,E14000672
+ocd-division/country:uk/pcon:dulwich_and_west_norwood,Dulwich and West Norwood,E14000673
+ocd-division/country:uk/pcon:dumfries_and_galloway,Dumfries and Galloway,S14000013
+ocd-division/country:uk/pcon:dumfriesshire_clydesdale_and_tweeddale,"Dumfriesshire, Clydesdale and Tweeddale",S14000014
+ocd-division/country:uk/pcon:dundee_east,Dundee East,S14000015
+ocd-division/country:uk/pcon:dundee_west,Dundee West,S14000016
+ocd-division/country:uk/pcon:dunfermline_and_west_fife,Dunfermline and West Fife,S14000017
+ocd-division/country:uk/pcon:dwyfor_meirionnydd,Dwyfor Meirionnydd,W07000061
+ocd-division/country:uk/pcon:ealing_central_and_acton,Ealing Central and Acton,E14000674
+ocd-division/country:uk/pcon:ealing_north,Ealing North,E14000675
+ocd-division/country:uk/pcon:ealing_southall,"Ealing, Southall",E14000676
+ocd-division/country:uk/pcon:easington,Easington,E14000677
+ocd-division/country:uk/pcon:east_antrim,East Antrim,N06000005
+ocd-division/country:uk/pcon:east_devon,East Devon,E14000678
+ocd-division/country:uk/pcon:east_dunbartonshire,East Dunbartonshire,S14000018
+ocd-division/country:uk/pcon:east_ham,East Ham,E14000679
+ocd-division/country:uk/pcon:east_hampshire,East Hampshire,E14000680
+ocd-division/country:uk/pcon:east_kilbride_strathaven_and_lesmahagow,"East Kilbride, Strathaven and Lesmahagow",S14000019
+ocd-division/country:uk/pcon:east_londonderry,East Londonderry,N06000006
+ocd-division/country:uk/pcon:east_lothian,East Lothian,S14000020
+ocd-division/country:uk/pcon:east_renfrewshire,East Renfrewshire,S14000021
+ocd-division/country:uk/pcon:east_surrey,East Surrey,E14000681
+ocd-division/country:uk/pcon:east_worthing_and_shoreham,East Worthing and Shoreham,E14000682
+ocd-division/country:uk/pcon:east_yorkshire,East Yorkshire,E14000683
+ocd-division/country:uk/pcon:eastbourne,Eastbourne,E14000684
+ocd-division/country:uk/pcon:eastleigh,Eastleigh,E14000685
+ocd-division/country:uk/pcon:eddisbury,Eddisbury,E14000686
+ocd-division/country:uk/pcon:edinburgh_east,Edinburgh East,S14000022
+ocd-division/country:uk/pcon:edinburgh_north_and_leith,Edinburgh North and Leith,S14000023
+ocd-division/country:uk/pcon:edinburgh_south,Edinburgh South,S14000024
+ocd-division/country:uk/pcon:edinburgh_south_west,Edinburgh South West,S14000025
+ocd-division/country:uk/pcon:edinburgh_west,Edinburgh West,S14000026
+ocd-division/country:uk/pcon:edmonton,Edmonton,E14000687
+ocd-division/country:uk/pcon:ellesmere_port_and_neston,Ellesmere Port and Neston,E14000688
+ocd-division/country:uk/pcon:elmet_and_rothwell,Elmet and Rothwell,E14000689
+ocd-division/country:uk/pcon:eltham,Eltham,E14000690
+ocd-division/country:uk/pcon:enfield_north,Enfield North,E14000691
+ocd-division/country:uk/pcon:enfield_southgate,"Enfield, Southgate",E14000692
+ocd-division/country:uk/pcon:epping_forest,Epping Forest,E14000693
+ocd-division/country:uk/pcon:epsom_and_ewell,Epsom and Ewell,E14000694
+ocd-division/country:uk/pcon:erewash,Erewash,E14000695
+ocd-division/country:uk/pcon:erith_and_thamesmead,Erith and Thamesmead,E14000696
+ocd-division/country:uk/pcon:esher_and_walton,Esher and Walton,E14000697
+ocd-division/country:uk/pcon:exeter,Exeter,E14000698
+ocd-division/country:uk/pcon:falkirk,Falkirk,S14000028
+ocd-division/country:uk/pcon:fareham,Fareham,E14000699
+ocd-division/country:uk/pcon:faversham_and_mid_kent,Faversham and Mid Kent,E14000700
+ocd-division/country:uk/pcon:feltham_and_heston,Feltham and Heston,E14000701
+ocd-division/country:uk/pcon:fermanagh_and_south_tyrone,Fermanagh and South Tyrone,N06000007
+ocd-division/country:uk/pcon:filton_and_bradley_stoke,Filton and Bradley Stoke,E14000702
+ocd-division/country:uk/pcon:finchley_and_golders_green,Finchley and Golders Green,E14000703
+ocd-division/country:uk/pcon:folkestone_and_hythe,Folkestone and Hythe,E14000704
+ocd-division/country:uk/pcon:forest_of_dean,Forest of Dean,E14000705
+ocd-division/country:uk/pcon:foyle,Foyle,N06000008
+ocd-division/country:uk/pcon:fylde,Fylde,E14000706
+ocd-division/country:uk/pcon:gainsborough,Gainsborough,E14000707
+ocd-division/country:uk/pcon:garston_and_halewood,Garston and Halewood,E14000708
+ocd-division/country:uk/pcon:gateshead,Gateshead,E14000709
+ocd-division/country:uk/pcon:gedling,Gedling,E14000710
+ocd-division/country:uk/pcon:gillingham_and_rainham,Gillingham and Rainham,E14000711
+ocd-division/country:uk/pcon:glasgow_central,Glasgow Central,S14000029
+ocd-division/country:uk/pcon:glasgow_east,Glasgow East,S14000030
+ocd-division/country:uk/pcon:glasgow_north,Glasgow North,S14000031
+ocd-division/country:uk/pcon:glasgow_north_east,Glasgow North East,S14000032
+ocd-division/country:uk/pcon:glasgow_north_west,Glasgow North West,S14000033
+ocd-division/country:uk/pcon:glasgow_south,Glasgow South,S14000034
+ocd-division/country:uk/pcon:glasgow_south_west,Glasgow South West,S14000035
+ocd-division/country:uk/pcon:glenrothes,Glenrothes,S14000036
+ocd-division/country:uk/pcon:gloucester,Gloucester,E14000712
+ocd-division/country:uk/pcon:gordon,Gordon,S14000037
+ocd-division/country:uk/pcon:gosport,Gosport,E14000713
+ocd-division/country:uk/pcon:gower,Gower,W07000046
+ocd-division/country:uk/pcon:grantham_and_stamford,Grantham and Stamford,E14000714
+ocd-division/country:uk/pcon:gravesham,Gravesham,E14000715
+ocd-division/country:uk/pcon:great_grimsby,Great Grimsby,E14000716
+ocd-division/country:uk/pcon:great_yarmouth,Great Yarmouth,E14000717
+ocd-division/country:uk/pcon:greenwich_and_woolwich,Greenwich and Woolwich,E14000718
+ocd-division/country:uk/pcon:guildford,Guildford,E14000719
+ocd-division/country:uk/pcon:hackney_north_and_stoke_newington,Hackney North and Stoke Newington,E14000720
+ocd-division/country:uk/pcon:hackney_south_and_shoreditch,Hackney South and Shoreditch,E14000721
+ocd-division/country:uk/pcon:halesowen_and_rowley_regis,Halesowen and Rowley Regis,E14000722
+ocd-division/country:uk/pcon:halifax,Halifax,E14000723
+ocd-division/country:uk/pcon:haltemprice_and_howden,Haltemprice and Howden,E14000724
+ocd-division/country:uk/pcon:halton,Halton,E14000725
+ocd-division/country:uk/pcon:hammersmith,Hammersmith,E14000726
+ocd-division/country:uk/pcon:hampstead_and_kilburn,Hampstead and Kilburn,E14000727
+ocd-division/country:uk/pcon:harborough,Harborough,E14000728
+ocd-division/country:uk/pcon:harlow,Harlow,E14000729
+ocd-division/country:uk/pcon:harrogate_and_knaresborough,Harrogate and Knaresborough,E14000730
+ocd-division/country:uk/pcon:harrow_east,Harrow East,E14000731
+ocd-division/country:uk/pcon:harrow_west,Harrow West,E14000732
+ocd-division/country:uk/pcon:hartlepool,Hartlepool,E14000733
+ocd-division/country:uk/pcon:harwich_and_north_essex,Harwich and North Essex,E14000734
+ocd-division/country:uk/pcon:hastings_and_rye,Hastings and Rye,E14000735
+ocd-division/country:uk/pcon:havant,Havant,E14000736
+ocd-division/country:uk/pcon:hayes_and_harlington,Hayes and Harlington,E14000737
+ocd-division/country:uk/pcon:hazel_grove,Hazel Grove,E14000738
+ocd-division/country:uk/pcon:hemel_hempstead,Hemel Hempstead,E14000739
+ocd-division/country:uk/pcon:hemsworth,Hemsworth,E14000740
+ocd-division/country:uk/pcon:hendon,Hendon,E14000741
+ocd-division/country:uk/pcon:henley,Henley,E14000742
+ocd-division/country:uk/pcon:hereford_and_south_herefordshire,Hereford and South Herefordshire,E14000743
+ocd-division/country:uk/pcon:hertford_and_stortford,Hertford and Stortford,E14000744
+ocd-division/country:uk/pcon:hertsmere,Hertsmere,E14000745
+ocd-division/country:uk/pcon:hexham,Hexham,E14000746
+ocd-division/country:uk/pcon:heywood_and_middleton,Heywood and Middleton,E14000747
+ocd-division/country:uk/pcon:high_peak,High Peak,E14000748
+ocd-division/country:uk/pcon:hitchin_and_harpenden,Hitchin and Harpenden,E14000749
+ocd-division/country:uk/pcon:holborn_and_st_pancras,Holborn and St Pancras,E14000750
+ocd-division/country:uk/pcon:hornchurch_and_upminster,Hornchurch and Upminster,E14000751
+ocd-division/country:uk/pcon:hornsey_and_wood_green,Hornsey and Wood Green,E14000752
+ocd-division/country:uk/pcon:horsham,Horsham,E14000753
+ocd-division/country:uk/pcon:houghton_and_sunderland_south,Houghton and Sunderland South,E14000754
+ocd-division/country:uk/pcon:hove,Hove,E14000755
+ocd-division/country:uk/pcon:huddersfield,Huddersfield,E14000756
+ocd-division/country:uk/pcon:huntingdon,Huntingdon,E14000757
+ocd-division/country:uk/pcon:hyndburn,Hyndburn,E14000758
+ocd-division/country:uk/pcon:ilford_north,Ilford North,E14000759
+ocd-division/country:uk/pcon:ilford_south,Ilford South,E14000760
+ocd-division/country:uk/pcon:inverclyde,Inverclyde,S14000038
+ocd-division/country:uk/pcon:inverness_nairn_badenoch_and_strathspey,"Inverness, Nairn, Badenoch and Strathspey",S14000039
+ocd-division/country:uk/pcon:ipswich,Ipswich,E14000761
+ocd-division/country:uk/pcon:isle_of_wight,Isle of Wight,E14000762
+ocd-division/country:uk/pcon:islington_north,Islington North,E14000763
+ocd-division/country:uk/pcon:islington_south_and_finsbury,Islington South and Finsbury,E14000764
+ocd-division/country:uk/pcon:islwyn,Islwyn,W07000077
+ocd-division/country:uk/pcon:jarrow,Jarrow,E14000765
+ocd-division/country:uk/pcon:keighley,Keighley,E14000766
+ocd-division/country:uk/pcon:kenilworth_and_southam,Kenilworth and Southam,E14000767
+ocd-division/country:uk/pcon:kensington,Kensington,E14000768
+ocd-division/country:uk/pcon:kettering,Kettering,E14000769
+ocd-division/country:uk/pcon:kilmarnock_and_loudoun,Kilmarnock and Loudoun,S14000040
+ocd-division/country:uk/pcon:kingston_and_surbiton,Kingston and Surbiton,E14000770
+ocd-division/country:uk/pcon:kingston_upon_hull_east,Kingston upon Hull East,E14000771
+ocd-division/country:uk/pcon:kingston_upon_hull_north,Kingston upon Hull North,E14000772
+ocd-division/country:uk/pcon:kingston_upon_hull_west_and_hessle,Kingston upon Hull West and Hessle,E14000773
+ocd-division/country:uk/pcon:kingswood,Kingswood,E14000774
+ocd-division/country:uk/pcon:kirkcaldy_and_cowdenbeath,Kirkcaldy and Cowdenbeath,S14000041
+ocd-division/country:uk/pcon:knowsley,Knowsley,E14000775
+ocd-division/country:uk/pcon:lagan_valley,Lagan Valley,N06000009
+ocd-division/country:uk/pcon:lanark_and_hamilton_east,Lanark and Hamilton East,S14000042
+ocd-division/country:uk/pcon:lancaster_and_fleetwood,Lancaster and Fleetwood,E14000776
+ocd-division/country:uk/pcon:leeds_central,Leeds Central,E14000777
+ocd-division/country:uk/pcon:leeds_east,Leeds East,E14000778
+ocd-division/country:uk/pcon:leeds_north_east,Leeds North East,E14000779
+ocd-division/country:uk/pcon:leeds_north_west,Leeds North West,E14000780
+ocd-division/country:uk/pcon:leeds_west,Leeds West,E14000781
+ocd-division/country:uk/pcon:leicester_east,Leicester East,E14000782
+ocd-division/country:uk/pcon:leicester_south,Leicester South,E14000783
+ocd-division/country:uk/pcon:leicester_west,Leicester West,E14000784
+ocd-division/country:uk/pcon:leigh,Leigh,E14000785
+ocd-division/country:uk/pcon:lewes,Lewes,E14000786
+ocd-division/country:uk/pcon:lewisham_deptford,"Lewisham, Deptford",E14000789
+ocd-division/country:uk/pcon:lewisham_east,Lewisham East,E14000787
+ocd-division/country:uk/pcon:lewisham_west_and_penge,Lewisham West and Penge,E14000788
+ocd-division/country:uk/pcon:leyton_and_wanstead,Leyton and Wanstead,E14000790
+ocd-division/country:uk/pcon:lichfield,Lichfield,E14000791
+ocd-division/country:uk/pcon:lincoln,Lincoln,E14000792
+ocd-division/country:uk/pcon:linlithgow_and_east_falkirk,Linlithgow and East Falkirk,S14000043
+ocd-division/country:uk/pcon:liverpool_riverside,"Liverpool, Riverside",E14000793
+ocd-division/country:uk/pcon:liverpool_walton,"Liverpool, Walton",E14000794
+ocd-division/country:uk/pcon:liverpool_wavertree,"Liverpool, Wavertree",E14000795
+ocd-division/country:uk/pcon:liverpool_west_derby,"Liverpool, West Derby",E14000796
+ocd-division/country:uk/pcon:livingston,Livingston,S14000044
+ocd-division/country:uk/pcon:llanelli,Llanelli,W07000045
+ocd-division/country:uk/pcon:loughborough,Loughborough,E14000797
+ocd-division/country:uk/pcon:louth_and_horncastle,Louth and Horncastle,E14000798
+ocd-division/country:uk/pcon:ludlow,Ludlow,E14000799
+ocd-division/country:uk/pcon:luton_north,Luton North,E14000800
+ocd-division/country:uk/pcon:luton_south,Luton South,E14000801
+ocd-division/country:uk/pcon:macclesfield,Macclesfield,E14000802
+ocd-division/country:uk/pcon:maidenhead,Maidenhead,E14000803
+ocd-division/country:uk/pcon:maidstone_and_the_weald,Maidstone and The Weald,E14000804
+ocd-division/country:uk/pcon:makerfield,Makerfield,E14000805
+ocd-division/country:uk/pcon:maldon,Maldon,E14000806
+ocd-division/country:uk/pcon:manchester_central,Manchester Central,E14000807
+ocd-division/country:uk/pcon:manchester_gorton,"Manchester, Gorton",E14000808
+ocd-division/country:uk/pcon:manchester_withington,"Manchester, Withington",E14000809
+ocd-division/country:uk/pcon:mansfield,Mansfield,E14000810
+ocd-division/country:uk/pcon:meon_valley,Meon Valley,E14000811
+ocd-division/country:uk/pcon:meriden,Meriden,E14000812
+ocd-division/country:uk/pcon:merthyr_tydfil_and_rhymney,Merthyr Tydfil and Rhymney,W07000071
+ocd-division/country:uk/pcon:mid_bedfordshire,Mid Bedfordshire,E14000813
+ocd-division/country:uk/pcon:mid_derbyshire,Mid Derbyshire,E14000814
+ocd-division/country:uk/pcon:mid_dorset_and_north_poole,Mid Dorset and North Poole,E14000815
+ocd-division/country:uk/pcon:mid_norfolk,Mid Norfolk,E14000816
+ocd-division/country:uk/pcon:mid_sussex,Mid Sussex,E14000817
+ocd-division/country:uk/pcon:mid_ulster,Mid Ulster,N06000010
+ocd-division/country:uk/pcon:mid_worcestershire,Mid Worcestershire,E14000818
+ocd-division/country:uk/pcon:middlesbrough,Middlesbrough,E14000819
+ocd-division/country:uk/pcon:middlesbrough_south_and_east_cleveland,Middlesbrough South and East Cleveland,E14000820
+ocd-division/country:uk/pcon:midlothian,Midlothian,S14000045
+ocd-division/country:uk/pcon:milton_keynes_north,Milton Keynes North,E14000821
+ocd-division/country:uk/pcon:milton_keynes_south,Milton Keynes South,E14000822
+ocd-division/country:uk/pcon:mitcham_and_morden,Mitcham and Morden,E14000823
+ocd-division/country:uk/pcon:mole_valley,Mole Valley,E14000824
+ocd-division/country:uk/pcon:monmouth,Monmouth,W07000054
+ocd-division/country:uk/pcon:montgomeryshire,Montgomeryshire,W07000063
+ocd-division/country:uk/pcon:moray,Moray,S14000046
+ocd-division/country:uk/pcon:morecambe_and_lunesdale,Morecambe and Lunesdale,E14000825
+ocd-division/country:uk/pcon:morley_and_outwood,Morley and Outwood,E14000826
+ocd-division/country:uk/pcon:motherwell_and_wishaw,Motherwell and Wishaw,S14000047
+ocd-division/country:uk/pcon:na_h-eileanan_an_iar,Na h-Eileanan an Iar,S14000027
+ocd-division/country:uk/pcon:neath,Neath,W07000069
+ocd-division/country:uk/pcon:new_forest_east,New Forest East,E14000827
+ocd-division/country:uk/pcon:new_forest_west,New Forest West,E14000828
+ocd-division/country:uk/pcon:newark,Newark,E14000829
+ocd-division/country:uk/pcon:newbury,Newbury,E14000830
+ocd-division/country:uk/pcon:newcastle-under-lyme,Newcastle-under-Lyme,E14000834
+ocd-division/country:uk/pcon:newcastle_upon_tyne_central,Newcastle upon Tyne Central,E14000831
+ocd-division/country:uk/pcon:newcastle_upon_tyne_east,Newcastle upon Tyne East,E14000832
+ocd-division/country:uk/pcon:newcastle_upon_tyne_north,Newcastle upon Tyne North,E14000833
+ocd-division/country:uk/pcon:newport_east,Newport East,W07000055
+ocd-division/country:uk/pcon:newport_west,Newport West,W07000056
+ocd-division/country:uk/pcon:newry_and_armagh,Newry and Armagh,N06000011
+ocd-division/country:uk/pcon:newton_abbot,Newton Abbot,E14000835
+ocd-division/country:uk/pcon:normanton_pontefract_and_castleford,"Normanton, Pontefract and Castleford",E14000836
+ocd-division/country:uk/pcon:north_antrim,North Antrim,N06000012
+ocd-division/country:uk/pcon:north_ayrshire_and_arran,North Ayrshire and Arran,S14000048
+ocd-division/country:uk/pcon:north_cornwall,North Cornwall,E14000837
+ocd-division/country:uk/pcon:north_devon,North Devon,E14000838
+ocd-division/country:uk/pcon:north_dorset,North Dorset,E14000839
+ocd-division/country:uk/pcon:north_down,North Down,N06000013
+ocd-division/country:uk/pcon:north_durham,North Durham,E14000840
+ocd-division/country:uk/pcon:north_east_bedfordshire,North East Bedfordshire,E14000841
+ocd-division/country:uk/pcon:north_east_cambridgeshire,North East Cambridgeshire,E14000842
+ocd-division/country:uk/pcon:north_east_derbyshire,North East Derbyshire,E14000843
+ocd-division/country:uk/pcon:north_east_fife,North East Fife,S14000049
+ocd-division/country:uk/pcon:north_east_hampshire,North East Hampshire,E14000844
+ocd-division/country:uk/pcon:north_east_hertfordshire,North East Hertfordshire,E14000845
+ocd-division/country:uk/pcon:north_east_somerset,North East Somerset,E14000846
+ocd-division/country:uk/pcon:north_herefordshire,North Herefordshire,E14000847
+ocd-division/country:uk/pcon:north_norfolk,North Norfolk,E14000848
+ocd-division/country:uk/pcon:north_shropshire,North Shropshire,E14000849
+ocd-division/country:uk/pcon:north_somerset,North Somerset,E14000850
+ocd-division/country:uk/pcon:north_swindon,North Swindon,E14000851
+ocd-division/country:uk/pcon:north_thanet,North Thanet,E14000852
+ocd-division/country:uk/pcon:north_tyneside,North Tyneside,E14000853
+ocd-division/country:uk/pcon:north_warwickshire,North Warwickshire,E14000854
+ocd-division/country:uk/pcon:north_west_cambridgeshire,North West Cambridgeshire,E14000855
+ocd-division/country:uk/pcon:north_west_durham,North West Durham,E14000856
+ocd-division/country:uk/pcon:north_west_hampshire,North West Hampshire,E14000857
+ocd-division/country:uk/pcon:north_west_leicestershire,North West Leicestershire,E14000858
+ocd-division/country:uk/pcon:north_west_norfolk,North West Norfolk,E14000859
+ocd-division/country:uk/pcon:north_wiltshire,North Wiltshire,E14000860
+ocd-division/country:uk/pcon:northampton_north,Northampton North,E14000861
+ocd-division/country:uk/pcon:northampton_south,Northampton South,E14000862
+ocd-division/country:uk/pcon:norwich_north,Norwich North,E14000863
+ocd-division/country:uk/pcon:norwich_south,Norwich South,E14000864
+ocd-division/country:uk/pcon:nottingham_east,Nottingham East,E14000865
+ocd-division/country:uk/pcon:nottingham_north,Nottingham North,E14000866
+ocd-division/country:uk/pcon:nottingham_south,Nottingham South,E14000867
+ocd-division/country:uk/pcon:nuneaton,Nuneaton,E14000868
+ocd-division/country:uk/pcon:ochil_and_south_perthshire,Ochil and South Perthshire,S14000050
+ocd-division/country:uk/pcon:ogmore,Ogmore,W07000074
+ocd-division/country:uk/pcon:old_bexley_and_sidcup,Old Bexley and Sidcup,E14000869
+ocd-division/country:uk/pcon:oldham_east_and_saddleworth,Oldham East and Saddleworth,E14000870
+ocd-division/country:uk/pcon:oldham_west_and_royton,Oldham West and Royton,E14000871
+ocd-division/country:uk/pcon:orkney_and_shetland,Orkney and Shetland,S14000051
+ocd-division/country:uk/pcon:orpington,Orpington,E14000872
+ocd-division/country:uk/pcon:oxford_east,Oxford East,E14000873
+ocd-division/country:uk/pcon:oxford_west_and_abingdon,Oxford West and Abingdon,E14000874
+ocd-division/country:uk/pcon:paisley_and_renfrewshire_north,Paisley and Renfrewshire North,S14000052
+ocd-division/country:uk/pcon:paisley_and_renfrewshire_south,Paisley and Renfrewshire South,S14000053
+ocd-division/country:uk/pcon:pendle,Pendle,E14000875
+ocd-division/country:uk/pcon:penistone_and_stocksbridge,Penistone and Stocksbridge,E14000876
+ocd-division/country:uk/pcon:penrith_and_the_border,Penrith and The Border,E14000877
+ocd-division/country:uk/pcon:perth_and_north_perthshire,Perth and North Perthshire,S14000054
+ocd-division/country:uk/pcon:peterborough,Peterborough,E14000878
+ocd-division/country:uk/pcon:plymouth_moor_view,"Plymouth, Moor View",E14000879
+ocd-division/country:uk/pcon:plymouth_sutton_and_devonport,"Plymouth, Sutton and Devonport",E14000880
+ocd-division/country:uk/pcon:pontypridd,Pontypridd,W07000075
+ocd-division/country:uk/pcon:poole,Poole,E14000881
+ocd-division/country:uk/pcon:poplar_and_limehouse,Poplar and Limehouse,E14000882
+ocd-division/country:uk/pcon:portsmouth_north,Portsmouth North,E14000883
+ocd-division/country:uk/pcon:portsmouth_south,Portsmouth South,E14000884
+ocd-division/country:uk/pcon:preseli_pembrokeshire,Preseli Pembrokeshire,W07000065
+ocd-division/country:uk/pcon:preston,Preston,E14000885
+ocd-division/country:uk/pcon:pudsey,Pudsey,E14000886
+ocd-division/country:uk/pcon:putney,Putney,E14000887
+ocd-division/country:uk/pcon:rayleigh_and_wickford,Rayleigh and Wickford,E14000888
+ocd-division/country:uk/pcon:reading_east,Reading East,E14000889
+ocd-division/country:uk/pcon:reading_west,Reading West,E14000890
+ocd-division/country:uk/pcon:redcar,Redcar,E14000891
+ocd-division/country:uk/pcon:redditch,Redditch,E14000892
+ocd-division/country:uk/pcon:reigate,Reigate,E14000893
+ocd-division/country:uk/pcon:rhondda,Rhondda,W07000052
+ocd-division/country:uk/pcon:ribble_valley,Ribble Valley,E14000894
+ocd-division/country:uk/pcon:richmond_park,Richmond Park,E14000896
+ocd-division/country:uk/pcon:richmond_~yorks~,Richmond (Yorks),E14000895
+ocd-division/country:uk/pcon:rochdale,Rochdale,E14000897
+ocd-division/country:uk/pcon:rochester_and_strood,Rochester and Strood,E14000898
+ocd-division/country:uk/pcon:rochford_and_southend_east,Rochford and Southend East,E14000899
+ocd-division/country:uk/pcon:romford,Romford,E14000900
+ocd-division/country:uk/pcon:romsey_and_southampton_north,Romsey and Southampton North,E14000901
+ocd-division/country:uk/pcon:ross_skye_and_lochaber,"Ross, Skye and Lochaber",S14000055
+ocd-division/country:uk/pcon:rossendale_and_darwen,Rossendale and Darwen,E14000902
+ocd-division/country:uk/pcon:rother_valley,Rother Valley,E14000903
+ocd-division/country:uk/pcon:rotherham,Rotherham,E14000904
+ocd-division/country:uk/pcon:rugby,Rugby,E14000905
+ocd-division/country:uk/pcon:ruislip_northwood_and_pinner,"Ruislip, Northwood and Pinner",E14000906
+ocd-division/country:uk/pcon:runnymede_and_weybridge,Runnymede and Weybridge,E14000907
+ocd-division/country:uk/pcon:rushcliffe,Rushcliffe,E14000908
+ocd-division/country:uk/pcon:rutherglen_and_hamilton_west,Rutherglen and Hamilton West,S14000056
+ocd-division/country:uk/pcon:rutland_and_melton,Rutland and Melton,E14000909
+ocd-division/country:uk/pcon:saffron_walden,Saffron Walden,E14000910
+ocd-division/country:uk/pcon:salford_and_eccles,Salford and Eccles,E14000911
+ocd-division/country:uk/pcon:salisbury,Salisbury,E14000912
+ocd-division/country:uk/pcon:scarborough_and_whitby,Scarborough and Whitby,E14000913
+ocd-division/country:uk/pcon:scunthorpe,Scunthorpe,E14000914
+ocd-division/country:uk/pcon:sedgefield,Sedgefield,E14000915
+ocd-division/country:uk/pcon:sefton_central,Sefton Central,E14000916
+ocd-division/country:uk/pcon:selby_and_ainsty,Selby and Ainsty,E14000917
+ocd-division/country:uk/pcon:sevenoaks,Sevenoaks,E14000918
+ocd-division/country:uk/pcon:sheffield_brightside_and_hillsborough,"Sheffield, Brightside and Hillsborough",E14000921
+ocd-division/country:uk/pcon:sheffield_central,Sheffield Central,E14000919
+ocd-division/country:uk/pcon:sheffield_hallam,"Sheffield, Hallam",E14000922
+ocd-division/country:uk/pcon:sheffield_heeley,"Sheffield, Heeley",E14000923
+ocd-division/country:uk/pcon:sheffield_south_east,Sheffield South East,E14000920
+ocd-division/country:uk/pcon:sherwood,Sherwood,E14000924
+ocd-division/country:uk/pcon:shipley,Shipley,E14000925
+ocd-division/country:uk/pcon:shrewsbury_and_atcham,Shrewsbury and Atcham,E14000926
+ocd-division/country:uk/pcon:sittingbourne_and_sheppey,Sittingbourne and Sheppey,E14000927
+ocd-division/country:uk/pcon:skipton_and_ripon,Skipton and Ripon,E14000928
+ocd-division/country:uk/pcon:sleaford_and_north_hykeham,Sleaford and North Hykeham,E14000929
+ocd-division/country:uk/pcon:slough,Slough,E14000930
+ocd-division/country:uk/pcon:solihull,Solihull,E14000931
+ocd-division/country:uk/pcon:somerton_and_frome,Somerton and Frome,E14000932
+ocd-division/country:uk/pcon:south_antrim,South Antrim,N06000014
+ocd-division/country:uk/pcon:south_basildon_and_east_thurrock,South Basildon and East Thurrock,E14000933
+ocd-division/country:uk/pcon:south_cambridgeshire,South Cambridgeshire,E14000934
+ocd-division/country:uk/pcon:south_derbyshire,South Derbyshire,E14000935
+ocd-division/country:uk/pcon:south_dorset,South Dorset,E14000936
+ocd-division/country:uk/pcon:south_down,South Down,N06000015
+ocd-division/country:uk/pcon:south_east_cambridgeshire,South East Cambridgeshire,E14000937
+ocd-division/country:uk/pcon:south_east_cornwall,South East Cornwall,E14000938
+ocd-division/country:uk/pcon:south_holland_and_the_deepings,South Holland and The Deepings,E14000939
+ocd-division/country:uk/pcon:south_leicestershire,South Leicestershire,E14000940
+ocd-division/country:uk/pcon:south_norfolk,South Norfolk,E14000941
+ocd-division/country:uk/pcon:south_northamptonshire,South Northamptonshire,E14000942
+ocd-division/country:uk/pcon:south_ribble,South Ribble,E14000943
+ocd-division/country:uk/pcon:south_shields,South Shields,E14000944
+ocd-division/country:uk/pcon:south_staffordshire,South Staffordshire,E14000945
+ocd-division/country:uk/pcon:south_suffolk,South Suffolk,E14000946
+ocd-division/country:uk/pcon:south_swindon,South Swindon,E14000947
+ocd-division/country:uk/pcon:south_thanet,South Thanet,E14000948
+ocd-division/country:uk/pcon:south_west_bedfordshire,South West Bedfordshire,E14000949
+ocd-division/country:uk/pcon:south_west_devon,South West Devon,E14000950
+ocd-division/country:uk/pcon:south_west_hertfordshire,South West Hertfordshire,E14000951
+ocd-division/country:uk/pcon:south_west_norfolk,South West Norfolk,E14000952
+ocd-division/country:uk/pcon:south_west_surrey,South West Surrey,E14000953
+ocd-division/country:uk/pcon:south_west_wiltshire,South West Wiltshire,E14000954
+ocd-division/country:uk/pcon:southampton_itchen,"Southampton, Itchen",E14000955
+ocd-division/country:uk/pcon:southampton_test,"Southampton, Test",E14000956
+ocd-division/country:uk/pcon:southend_west,Southend West,E14000957
+ocd-division/country:uk/pcon:southport,Southport,E14000958
+ocd-division/country:uk/pcon:spelthorne,Spelthorne,E14000959
+ocd-division/country:uk/pcon:st_albans,St Albans,E14000960
+ocd-division/country:uk/pcon:st_austell_and_newquay,St Austell and Newquay,E14000961
+ocd-division/country:uk/pcon:st_helens_north,St Helens North,E14000962
+ocd-division/country:uk/pcon:st_helens_south_and_whiston,St Helens South and Whiston,E14000963
+ocd-division/country:uk/pcon:st_ives,St Ives,E14000964
+ocd-division/country:uk/pcon:stafford,Stafford,E14000965
+ocd-division/country:uk/pcon:staffordshire_moorlands,Staffordshire Moorlands,E14000966
+ocd-division/country:uk/pcon:stalybridge_and_hyde,Stalybridge and Hyde,E14000967
+ocd-division/country:uk/pcon:stevenage,Stevenage,E14000968
+ocd-division/country:uk/pcon:stirling,Stirling,S14000057
+ocd-division/country:uk/pcon:stockport,Stockport,E14000969
+ocd-division/country:uk/pcon:stockton_north,Stockton North,E14000970
+ocd-division/country:uk/pcon:stockton_south,Stockton South,E14000971
+ocd-division/country:uk/pcon:stoke-on-trent_central,Stoke-on-Trent Central,E14000972
+ocd-division/country:uk/pcon:stoke-on-trent_north,Stoke-on-Trent North,E14000973
+ocd-division/country:uk/pcon:stoke-on-trent_south,Stoke-on-Trent South,E14000974
+ocd-division/country:uk/pcon:stone,Stone,E14000975
+ocd-division/country:uk/pcon:stourbridge,Stourbridge,E14000976
+ocd-division/country:uk/pcon:strangford,Strangford,N06000016
+ocd-division/country:uk/pcon:stratford-on-avon,Stratford-on-Avon,E14000977
+ocd-division/country:uk/pcon:streatham,Streatham,E14000978
+ocd-division/country:uk/pcon:stretford_and_urmston,Stretford and Urmston,E14000979
+ocd-division/country:uk/pcon:stroud,Stroud,E14000980
+ocd-division/country:uk/pcon:suffolk_coastal,Suffolk Coastal,E14000981
+ocd-division/country:uk/pcon:sunderland_central,Sunderland Central,E14000982
+ocd-division/country:uk/pcon:surrey_heath,Surrey Heath,E14000983
+ocd-division/country:uk/pcon:sutton_and_cheam,Sutton and Cheam,E14000984
+ocd-division/country:uk/pcon:sutton_coldfield,Sutton Coldfield,E14000985
+ocd-division/country:uk/pcon:swansea_east,Swansea East,W07000048
+ocd-division/country:uk/pcon:swansea_west,Swansea West,W07000047
+ocd-division/country:uk/pcon:tamworth,Tamworth,E14000986
+ocd-division/country:uk/pcon:tatton,Tatton,E14000987
+ocd-division/country:uk/pcon:taunton_deane,Taunton Deane,E14000988
+ocd-division/country:uk/pcon:telford,Telford,E14000989
+ocd-division/country:uk/pcon:tewkesbury,Tewkesbury,E14000990
+ocd-division/country:uk/pcon:the_cotswolds,The Cotswolds,E14000991
+ocd-division/country:uk/pcon:the_wrekin,The Wrekin,E14000992
+ocd-division/country:uk/pcon:thirsk_and_malton,Thirsk and Malton,E14000993
+ocd-division/country:uk/pcon:thornbury_and_yate,Thornbury and Yate,E14000994
+ocd-division/country:uk/pcon:thurrock,Thurrock,E14000995
+ocd-division/country:uk/pcon:tiverton_and_honiton,Tiverton and Honiton,E14000996
+ocd-division/country:uk/pcon:tonbridge_and_malling,Tonbridge and Malling,E14000997
+ocd-division/country:uk/pcon:tooting,Tooting,E14000998
+ocd-division/country:uk/pcon:torbay,Torbay,E14000999
+ocd-division/country:uk/pcon:torfaen,Torfaen,W07000053
+ocd-division/country:uk/pcon:torridge_and_west_devon,Torridge and West Devon,E14001000
+ocd-division/country:uk/pcon:totnes,Totnes,E14001001
+ocd-division/country:uk/pcon:tottenham,Tottenham,E14001002
+ocd-division/country:uk/pcon:truro_and_falmouth,Truro and Falmouth,E14001003
+ocd-division/country:uk/pcon:tunbridge_wells,Tunbridge Wells,E14001004
+ocd-division/country:uk/pcon:twickenham,Twickenham,E14001005
+ocd-division/country:uk/pcon:tynemouth,Tynemouth,E14001006
+ocd-division/country:uk/pcon:upper_bann,Upper Bann,N06000017
+ocd-division/country:uk/pcon:uxbridge_and_south_ruislip,Uxbridge and South Ruislip,E14001007
+ocd-division/country:uk/pcon:vale_of_clwyd,Vale of Clwyd,W07000060
+ocd-division/country:uk/pcon:vale_of_glamorgan,Vale of Glamorgan,W07000078
+ocd-division/country:uk/pcon:vauxhall,Vauxhall,E14001008
+ocd-division/country:uk/pcon:wakefield,Wakefield,E14001009
+ocd-division/country:uk/pcon:wallasey,Wallasey,E14001010
+ocd-division/country:uk/pcon:walsall_north,Walsall North,E14001011
+ocd-division/country:uk/pcon:walsall_south,Walsall South,E14001012
+ocd-division/country:uk/pcon:walthamstow,Walthamstow,E14001013
+ocd-division/country:uk/pcon:wansbeck,Wansbeck,E14001014
+ocd-division/country:uk/pcon:wantage,Wantage,E14001015
+ocd-division/country:uk/pcon:warley,Warley,E14001016
+ocd-division/country:uk/pcon:warrington_north,Warrington North,E14001017
+ocd-division/country:uk/pcon:warrington_south,Warrington South,E14001018
+ocd-division/country:uk/pcon:warwick_and_leamington,Warwick and Leamington,E14001019
+ocd-division/country:uk/pcon:washington_and_sunderland_west,Washington and Sunderland West,E14001020
+ocd-division/country:uk/pcon:watford,Watford,E14001021
+ocd-division/country:uk/pcon:waveney,Waveney,E14001022
+ocd-division/country:uk/pcon:wealden,Wealden,E14001023
+ocd-division/country:uk/pcon:weaver_vale,Weaver Vale,E14001024
+ocd-division/country:uk/pcon:wellingborough,Wellingborough,E14001025
+ocd-division/country:uk/pcon:wells,Wells,E14001026
+ocd-division/country:uk/pcon:welwyn_hatfield,Welwyn Hatfield,E14001027
+ocd-division/country:uk/pcon:wentworth_and_dearne,Wentworth and Dearne,E14001028
+ocd-division/country:uk/pcon:west_aberdeenshire_and_kincardine,West Aberdeenshire and Kincardine,S14000058
+ocd-division/country:uk/pcon:west_bromwich_east,West Bromwich East,E14001029
+ocd-division/country:uk/pcon:west_bromwich_west,West Bromwich West,E14001030
+ocd-division/country:uk/pcon:west_dorset,West Dorset,E14001031
+ocd-division/country:uk/pcon:west_dunbartonshire,West Dunbartonshire,S14000059
+ocd-division/country:uk/pcon:west_ham,West Ham,E14001032
+ocd-division/country:uk/pcon:west_lancashire,West Lancashire,E14001033
+ocd-division/country:uk/pcon:west_suffolk,West Suffolk,E14001034
+ocd-division/country:uk/pcon:west_tyrone,West Tyrone,N06000018
+ocd-division/country:uk/pcon:west_worcestershire,West Worcestershire,E14001035
+ocd-division/country:uk/pcon:westminster_north,Westminster North,E14001036
+ocd-division/country:uk/pcon:westmorland_and_lonsdale,Westmorland and Lonsdale,E14001037
+ocd-division/country:uk/pcon:weston-super-mare,Weston-Super-Mare,E14001038
+ocd-division/country:uk/pcon:wigan,Wigan,E14001039
+ocd-division/country:uk/pcon:wimbledon,Wimbledon,E14001040
+ocd-division/country:uk/pcon:winchester,Winchester,E14001041
+ocd-division/country:uk/pcon:windsor,Windsor,E14001042
+ocd-division/country:uk/pcon:wirral_south,Wirral South,E14001043
+ocd-division/country:uk/pcon:wirral_west,Wirral West,E14001044
+ocd-division/country:uk/pcon:witham,Witham,E14001045
+ocd-division/country:uk/pcon:witney,Witney,E14001046
+ocd-division/country:uk/pcon:woking,Woking,E14001047
+ocd-division/country:uk/pcon:wokingham,Wokingham,E14001048
+ocd-division/country:uk/pcon:wolverhampton_north_east,Wolverhampton North East,E14001049
+ocd-division/country:uk/pcon:wolverhampton_south_east,Wolverhampton South East,E14001050
+ocd-division/country:uk/pcon:wolverhampton_south_west,Wolverhampton South West,E14001051
+ocd-division/country:uk/pcon:worcester,Worcester,E14001052
+ocd-division/country:uk/pcon:workington,Workington,E14001053
+ocd-division/country:uk/pcon:worsley_and_eccles_south,Worsley and Eccles South,E14001054
+ocd-division/country:uk/pcon:worthing_west,Worthing West,E14001055
+ocd-division/country:uk/pcon:wrexham,Wrexham,W07000044
+ocd-division/country:uk/pcon:wycombe,Wycombe,E14001056
+ocd-division/country:uk/pcon:wyre_and_preston_north,Wyre and Preston North,E14001057
+ocd-division/country:uk/pcon:wyre_forest,Wyre Forest,E14001058
+ocd-division/country:uk/pcon:wythenshawe_and_sale_east,Wythenshawe and Sale East,E14001059
+ocd-division/country:uk/pcon:yeovil,Yeovil,E14001060
+ocd-division/country:uk/pcon:ynys_mon,Ynys Mon,W07000041
+ocd-division/country:uk/pcon:york_central,York Central,E14001061
+ocd-division/country:uk/pcon:york_outer,York Outer,E14001062
+ocd-division/country:uk/pfa:avon_and_somerset,Avon and Somerset,E23000036
+ocd-division/country:uk/pfa:bedfordshire,Bedfordshire,E23000026
+ocd-division/country:uk/pfa:cambridgeshire,Cambridgeshire,E23000023
+ocd-division/country:uk/pfa:cheshire,Cheshire,E23000006
+ocd-division/country:uk/pfa:cleveland,Cleveland,E23000013
+ocd-division/country:uk/pfa:cumbria,Cumbria,E23000002
+ocd-division/country:uk/pfa:derbyshire,Derbyshire,E23000018
+ocd-division/country:uk/pfa:devon_and_cornwall,Devon and Cornwall,E23000035
+ocd-division/country:uk/pfa:dorset,Dorset,E23000039
+ocd-division/country:uk/pfa:durham,Durham,E23000008
+ocd-division/country:uk/pfa:dyfed-powys,Dyfed-Powys,W15000004
+ocd-division/country:uk/pfa:essex,Essex,E23000028
+ocd-division/country:uk/pfa:gloucestershire,Gloucestershire,E23000037
+ocd-division/country:uk/pfa:gwent,Gwent,W15000002
+ocd-division/country:uk/pfa:hampshire,Hampshire,E23000030
+ocd-division/country:uk/pfa:hertfordshire,Hertfordshire,E23000027
+ocd-division/country:uk/pfa:humberside,Humberside,E23000012
+ocd-division/country:uk/pfa:kent,Kent,E23000032
+ocd-division/country:uk/pfa:lancashire,Lancashire,E23000003
+ocd-division/country:uk/pfa:leicestershire,Leicestershire,E23000021
+ocd-division/country:uk/pfa:lincolnshire,Lincolnshire,E23000020
+ocd-division/country:uk/pfa:merseyside,Merseyside,E23000004
+ocd-division/country:uk/pfa:norfolk,Norfolk,E23000024
+ocd-division/country:uk/pfa:north_wales,North Wales,W15000001
+ocd-division/country:uk/pfa:north_yorkshire,North Yorkshire,E23000009
+ocd-division/country:uk/pfa:northamptonshire,Northamptonshire,E23000022
+ocd-division/country:uk/pfa:northumbria,Northumbria,E23000007
+ocd-division/country:uk/pfa:nottinghamshire,Nottinghamshire,E23000019
+ocd-division/country:uk/pfa:south_wales,South Wales,W15000003
+ocd-division/country:uk/pfa:south_yorkshire,South Yorkshire,E23000011
+ocd-division/country:uk/pfa:staffordshire,Staffordshire,E23000015
+ocd-division/country:uk/pfa:suffolk,Suffolk,E23000025
+ocd-division/country:uk/pfa:surrey,Surrey,E23000031
+ocd-division/country:uk/pfa:sussex,Sussex,E23000033
+ocd-division/country:uk/pfa:thames_valley,Thames Valley,E23000029
+ocd-division/country:uk/pfa:warwickshire,Warwickshire,E23000017
+ocd-division/country:uk/pfa:west_mercia,West Mercia,E23000016
+ocd-division/country:uk/pfa:west_midlands,West Midlands,E23000014
+ocd-division/country:uk/pfa:west_yorkshire,West Yorkshire,E23000010
+ocd-division/country:uk/pfa:wiltshire,Wiltshire,E23000038
+ocd-division/country:uk/spc:aberdeen_central,Aberdeen Central,S16000074
+ocd-division/country:uk/spc:aberdeen_donside,Aberdeen Donside,S16000075
+ocd-division/country:uk/spc:aberdeen_south_and_north_kincardine,Aberdeen South and North Kincardine,S16000076
+ocd-division/country:uk/spc:aberdeenshire_east,Aberdeenshire East,S16000077
+ocd-division/country:uk/spc:aberdeenshire_west,Aberdeenshire West,S16000078
+ocd-division/country:uk/spc:airdrie_and_shotts,Airdrie and Shotts,S16000079
+ocd-division/country:uk/spc:almond_valley,Almond Valley,S16000080
+ocd-division/country:uk/spc:angus_north_and_mearns,Angus North and Mearns,S16000081
+ocd-division/country:uk/spc:angus_south,Angus South,S16000082
+ocd-division/country:uk/spc:argyll_and_bute,Argyll and Bute,S16000083
+ocd-division/country:uk/spc:ayr,Ayr,S16000084
+ocd-division/country:uk/spc:banffshire_and_buchan_coast,Banffshire and Buchan Coast,S16000085
+ocd-division/country:uk/spc:caithness_sutherland_and_ross,"Caithness, Sutherland and Ross",S16000086
+ocd-division/country:uk/spc:carrick_cumnock_and_doon_valley,"Carrick, Cumnock and Doon Valley",S16000087
+ocd-division/country:uk/spc:clackmannanshire_and_dunblane,Clackmannanshire and Dunblane,S16000088
+ocd-division/country:uk/spc:clydebank_and_milngavie,Clydebank and Milngavie,S16000089
+ocd-division/country:uk/spc:clydesdale,Clydesdale,S16000090
+ocd-division/country:uk/spc:coatbridge_and_chryston,Coatbridge and Chryston,S16000091
+ocd-division/country:uk/spc:cowdenbeath,Cowdenbeath,S16000092
+ocd-division/country:uk/spc:cumbernauld_and_kilsyth,Cumbernauld and Kilsyth,S16000093
+ocd-division/country:uk/spc:cunninghame_north,Cunninghame North,S16000094
+ocd-division/country:uk/spc:cunninghame_south,Cunninghame South,S16000095
+ocd-division/country:uk/spc:dumbarton,Dumbarton,S16000096
+ocd-division/country:uk/spc:dumfriesshire,Dumfriesshire,S16000097
+ocd-division/country:uk/spc:dundee_city_east,Dundee City East,S16000098
+ocd-division/country:uk/spc:dundee_city_west,Dundee City West,S16000099
+ocd-division/country:uk/spc:dunfermline,Dunfermline,S16000100
+ocd-division/country:uk/spc:east_kilbride,East Kilbride,S16000101
+ocd-division/country:uk/spc:east_lothian,East Lothian,S16000102
+ocd-division/country:uk/spc:eastwood,Eastwood,S16000103
+ocd-division/country:uk/spc:edinburgh_central,Edinburgh Central,S16000104
+ocd-division/country:uk/spc:edinburgh_eastern,Edinburgh Eastern,S16000105
+ocd-division/country:uk/spc:edinburgh_northern_and_leith,Edinburgh Northern and Leith,S16000106
+ocd-division/country:uk/spc:edinburgh_pentlands,Edinburgh Pentlands,S16000107
+ocd-division/country:uk/spc:edinburgh_southern,Edinburgh Southern,S16000108
+ocd-division/country:uk/spc:edinburgh_western,Edinburgh Western,S16000109
+ocd-division/country:uk/spc:ettrick_roxburgh_and_berwickshire,"Ettrick, Roxburgh and Berwickshire",S16000111
+ocd-division/country:uk/spc:falkirk_east,Falkirk East,S16000112
+ocd-division/country:uk/spc:falkirk_west,Falkirk West,S16000113
+ocd-division/country:uk/spc:galloway_and_west_dumfries,Galloway and West Dumfries,S16000114
+ocd-division/country:uk/spc:glasgow_anniesland,Glasgow Anniesland,S16000115
+ocd-division/country:uk/spc:glasgow_cathcart,Glasgow Cathcart,S16000116
+ocd-division/country:uk/spc:glasgow_kelvin,Glasgow Kelvin,S16000117
+ocd-division/country:uk/spc:glasgow_maryhill_and_springburn,Glasgow Maryhill and Springburn,S16000118
+ocd-division/country:uk/spc:glasgow_pollok,Glasgow Pollok,S16000119
+ocd-division/country:uk/spc:glasgow_provan,Glasgow Provan,S16000147
+ocd-division/country:uk/spc:glasgow_shettleston,Glasgow Shettleston,S16000121
+ocd-division/country:uk/spc:glasgow_southside,Glasgow Southside,S16000122
+ocd-division/country:uk/spc:greenock_and_inverclyde,Greenock and Inverclyde,S16000123
+ocd-division/country:uk/spc:hamilton_larkhall_and_stonehouse,"Hamilton, Larkhall and Stonehouse",S16000124
+ocd-division/country:uk/spc:inverness_and_nairn,Inverness and Nairn,S16000125
+ocd-division/country:uk/spc:kilmarnock_and_irvine_valley,Kilmarnock and Irvine Valley,S16000126
+ocd-division/country:uk/spc:kirkcaldy,Kirkcaldy,S16000127
+ocd-division/country:uk/spc:linlithgow,Linlithgow,S16000128
+ocd-division/country:uk/spc:mid_fife_and_glenrothes,Mid Fife and Glenrothes,S16000129
+ocd-division/country:uk/spc:midlothian_north_and_musselburgh,Midlothian North and Musselburgh,S16000130
+ocd-division/country:uk/spc:midlothian_south_tweeddale_and_lauderdale,"Midlothian South, Tweeddale and Lauderdale",S16000131
+ocd-division/country:uk/spc:moray,Moray,S16000132
+ocd-division/country:uk/spc:motherwell_and_wishaw,Motherwell and Wishaw,S16000133
+ocd-division/country:uk/spc:na_h-eileanan_an_iar,Na h-Eileanan an Iar,S16000110
+ocd-division/country:uk/spc:north_east_fife,North East Fife,S16000134
+ocd-division/country:uk/spc:orkney_islands,Orkney Islands,S16000135
+ocd-division/country:uk/spc:paisley,Paisley,S16000136
+ocd-division/country:uk/spc:perthshire_north,Perthshire North,S16000137
+ocd-division/country:uk/spc:perthshire_south_and_kinross-shire,Perthshire South and Kinross-shire,S16000138
+ocd-division/country:uk/spc:renfrewshire_north_and_west,Renfrewshire North and West,S16000139
+ocd-division/country:uk/spc:renfrewshire_south,Renfrewshire South,S16000140
+ocd-division/country:uk/spc:rutherglen,Rutherglen,S16000141
+ocd-division/country:uk/spc:shetland_islands,Shetland Islands,S16000142
+ocd-division/country:uk/spc:skye_lochaber_and_badenoch,"Skye, Lochaber and Badenoch",S16000143
+ocd-division/country:uk/spc:stirling,Stirling,S16000144
+ocd-division/country:uk/spc:strathkelvin_and_bearsden,Strathkelvin and Bearsden,S16000148
+ocd-division/country:uk/spc:uddingston_and_bellshill,Uddingston and Bellshill,S16000146
+ocd-division/country:uk/spr:central_scotland,Central Scotland,S17000009
+ocd-division/country:uk/spr:glasgow,Glasgow,S17000017
+ocd-division/country:uk/spr:highlands_and_islands,Highlands and Islands,S17000011
+ocd-division/country:uk/spr:lothian,Lothian,S17000012
+ocd-division/country:uk/spr:mid_scotland_and_fife,Mid Scotland and Fife,S17000013
+ocd-division/country:uk/spr:north_east_scotland,North East Scotland,S17000014
+ocd-division/country:uk/spr:south_scotland,South Scotland,S17000015
+ocd-division/country:uk/spr:west_scotland,West Scotland,S17000018

--- a/identifiers/country-uk/combined_authorities.csv
+++ b/identifiers/country-uk/combined_authorities.csv
@@ -1,0 +1,10 @@
+id,name,gss_code
+ocd-division/country:uk/cauth:greater_manchester,Greater Manchester,E47000001
+ocd-division/country:uk/cauth:sheffield_city_region,Sheffield City Region,E47000002
+ocd-division/country:uk/cauth:west_yorkshire,West Yorkshire,E47000003
+ocd-division/country:uk/cauth:liverpool_city_region,Liverpool City Region,E47000004
+ocd-division/country:uk/cauth:north_east,North East,E47000005
+ocd-division/country:uk/cauth:tees_valley,Tees Valley,E47000006
+ocd-division/country:uk/cauth:west_midlands,West Midlands,E47000007
+ocd-division/country:uk/cauth:cambridgeshire_and_peterborough,Cambridgeshire and Peterborough,E47000008
+ocd-division/country:uk/cauth:west_of_england,West of England,E47000009

--- a/identifiers/country-uk/country-uk.csv
+++ b/identifiers/country-uk/country-uk.csv
@@ -1,0 +1,2 @@
+id,name,gss_code
+ocd-division/country:uk,United Kingdom,K02000001

--- a/identifiers/country-uk/naw_consitituencies.csv
+++ b/identifiers/country-uk/naw_consitituencies.csv
@@ -1,0 +1,41 @@
+id,name,gss_code
+ocd-division/country:uk/nawc:ynys_mon,Ynys Mon,W09000001
+ocd-division/country:uk/nawc:arfon,Arfon,W09000002
+ocd-division/country:uk/nawc:aberconwy,Aberconwy,W09000003
+ocd-division/country:uk/nawc:clwyd_west,Clwyd West,W09000004
+ocd-division/country:uk/nawc:vale_of_clwyd,Vale of Clwyd,W09000005
+ocd-division/country:uk/nawc:delyn,Delyn,W09000006
+ocd-division/country:uk/nawc:alyn_and_deeside,Alyn and Deeside,W09000007
+ocd-division/country:uk/nawc:wrexham,Wrexham,W09000008
+ocd-division/country:uk/nawc:clwyd_south,Clwyd South,W09000009
+ocd-division/country:uk/nawc:dwyfor_meirionnydd,Dwyfor Meirionnydd,W09000010
+ocd-division/country:uk/nawc:montgomeryshire,Montgomeryshire,W09000011
+ocd-division/country:uk/nawc:ceredigion,Ceredigion,W09000012
+ocd-division/country:uk/nawc:preseli_pembrokeshire,Preseli Pembrokeshire,W09000014
+ocd-division/country:uk/nawc:carmarthen_east_and_dinefwr,Carmarthen East and Dinefwr,W09000015
+ocd-division/country:uk/nawc:carmarthen_west_and_south_pembrokeshire,Carmarthen West and South Pembrokeshire,W09000016
+ocd-division/country:uk/nawc:llanelli,Llanelli,W09000017
+ocd-division/country:uk/nawc:gower,Gower,W09000018
+ocd-division/country:uk/nawc:rhondda,Rhondda,W09000025
+ocd-division/country:uk/nawc:cynon_valley,Cynon Valley,W09000026
+ocd-division/country:uk/nawc:cardiff_west,Cardiff West,W09000029
+ocd-division/country:uk/nawc:cardiff_central,Cardiff Central,W09000031
+ocd-division/country:uk/nawc:monmouth,Monmouth,W09000034
+ocd-division/country:uk/nawc:caerphilly,Caerphilly,W09000035
+ocd-division/country:uk/nawc:islwyn,Islwyn,W09000036
+ocd-division/country:uk/nawc:torfaen,Torfaen,W09000037
+ocd-division/country:uk/nawc:blaenau_gwent,Blaenau Gwent,W09000038
+ocd-division/country:uk/nawc:newport_west,Newport West,W09000039
+ocd-division/country:uk/nawc:newport_east,Newport East,W09000040
+ocd-division/country:uk/nawc:brecon_and_radnorshire,Brecon and Radnorshire,W09000041
+ocd-division/country:uk/nawc:cardiff_north,Cardiff North,W09000042
+ocd-division/country:uk/nawc:cardiff_south_and_penarth,Cardiff South and Penarth,W09000043
+ocd-division/country:uk/nawc:merthyr_tydfil_and_rhymney,Merthyr Tydfil and Rhymney,W09000044
+ocd-division/country:uk/nawc:ogmore,Ogmore,W09000045
+ocd-division/country:uk/nawc:pontypridd,Pontypridd,W09000046
+ocd-division/country:uk/nawc:vale_of_glamorgan,Vale of Glamorgan,W09000047
+ocd-division/country:uk/nawc:swansea_west,Swansea West,W09000019
+ocd-division/country:uk/nawc:swansea_east,Swansea East,W09000020
+ocd-division/country:uk/nawc:neath,Neath,W09000021
+ocd-division/country:uk/nawc:aberavon,Aberavon,W09000022
+ocd-division/country:uk/nawc:bridgend,Bridgend,W09000023

--- a/identifiers/country-uk/naw_regions.csv
+++ b/identifiers/country-uk/naw_regions.csv
@@ -1,0 +1,6 @@
+id,name,gss_code
+ocd-division/country:uk/nawr:north_wales,North Wales,W10000001
+ocd-division/country:uk/nawr:mid_and_west_wales,Mid and West Wales,W10000006
+ocd-division/country:uk/nawr:south_wales_central,South Wales Central,W10000007
+ocd-division/country:uk/nawr:south_wales_east,South Wales East,W10000008
+ocd-division/country:uk/nawr:south_wales_west,South Wales West,W10000009

--- a/identifiers/country-uk/police_force_areas.csv
+++ b/identifiers/country-uk/police_force_areas.csv
@@ -1,0 +1,41 @@
+id,name,gss_code
+ocd-division/country:uk/pfa:cumbria,Cumbria,E23000002
+ocd-division/country:uk/pfa:lancashire,Lancashire,E23000003
+ocd-division/country:uk/pfa:merseyside,Merseyside,E23000004
+ocd-division/country:uk/pfa:cheshire,Cheshire,E23000006
+ocd-division/country:uk/pfa:northumbria,Northumbria,E23000007
+ocd-division/country:uk/pfa:durham,Durham,E23000008
+ocd-division/country:uk/pfa:north_yorkshire,North Yorkshire,E23000009
+ocd-division/country:uk/pfa:west_yorkshire,West Yorkshire,E23000010
+ocd-division/country:uk/pfa:south_yorkshire,South Yorkshire,E23000011
+ocd-division/country:uk/pfa:humberside,Humberside,E23000012
+ocd-division/country:uk/pfa:cleveland,Cleveland,E23000013
+ocd-division/country:uk/pfa:west_midlands,West Midlands,E23000014
+ocd-division/country:uk/pfa:staffordshire,Staffordshire,E23000015
+ocd-division/country:uk/pfa:west_mercia,West Mercia,E23000016
+ocd-division/country:uk/pfa:warwickshire,Warwickshire,E23000017
+ocd-division/country:uk/pfa:derbyshire,Derbyshire,E23000018
+ocd-division/country:uk/pfa:nottinghamshire,Nottinghamshire,E23000019
+ocd-division/country:uk/pfa:lincolnshire,Lincolnshire,E23000020
+ocd-division/country:uk/pfa:leicestershire,Leicestershire,E23000021
+ocd-division/country:uk/pfa:northamptonshire,Northamptonshire,E23000022
+ocd-division/country:uk/pfa:cambridgeshire,Cambridgeshire,E23000023
+ocd-division/country:uk/pfa:norfolk,Norfolk,E23000024
+ocd-division/country:uk/pfa:suffolk,Suffolk,E23000025
+ocd-division/country:uk/pfa:bedfordshire,Bedfordshire,E23000026
+ocd-division/country:uk/pfa:hertfordshire,Hertfordshire,E23000027
+ocd-division/country:uk/pfa:essex,Essex,E23000028
+ocd-division/country:uk/pfa:thames_valley,Thames Valley,E23000029
+ocd-division/country:uk/pfa:hampshire,Hampshire,E23000030
+ocd-division/country:uk/pfa:surrey,Surrey,E23000031
+ocd-division/country:uk/pfa:kent,Kent,E23000032
+ocd-division/country:uk/pfa:sussex,Sussex,E23000033
+ocd-division/country:uk/pfa:devon_and_cornwall,Devon and Cornwall,E23000035
+ocd-division/country:uk/pfa:avon_and_somerset,Avon and Somerset,E23000036
+ocd-division/country:uk/pfa:gloucestershire,Gloucestershire,E23000037
+ocd-division/country:uk/pfa:wiltshire,Wiltshire,E23000038
+ocd-division/country:uk/pfa:dorset,Dorset,E23000039
+ocd-division/country:uk/pfa:north_wales,North Wales,W15000001
+ocd-division/country:uk/pfa:gwent,Gwent,W15000002
+ocd-division/country:uk/pfa:south_wales,South Wales,W15000003
+ocd-division/country:uk/pfa:dyfed-powys,Dyfed-Powys,W15000004

--- a/identifiers/country-uk/scottish_parliament_consitituencies.csv
+++ b/identifiers/country-uk/scottish_parliament_consitituencies.csv
@@ -1,0 +1,74 @@
+id,name,gss_code
+ocd-division/country:uk/spc:aberdeen_central,Aberdeen Central,S16000074
+ocd-division/country:uk/spc:aberdeen_donside,Aberdeen Donside,S16000075
+ocd-division/country:uk/spc:aberdeen_south_and_north_kincardine,Aberdeen South and North Kincardine,S16000076
+ocd-division/country:uk/spc:aberdeenshire_east,Aberdeenshire East,S16000077
+ocd-division/country:uk/spc:aberdeenshire_west,Aberdeenshire West,S16000078
+ocd-division/country:uk/spc:airdrie_and_shotts,Airdrie and Shotts,S16000079
+ocd-division/country:uk/spc:almond_valley,Almond Valley,S16000080
+ocd-division/country:uk/spc:angus_north_and_mearns,Angus North and Mearns,S16000081
+ocd-division/country:uk/spc:angus_south,Angus South,S16000082
+ocd-division/country:uk/spc:argyll_and_bute,Argyll and Bute,S16000083
+ocd-division/country:uk/spc:ayr,Ayr,S16000084
+ocd-division/country:uk/spc:banffshire_and_buchan_coast,Banffshire and Buchan Coast,S16000085
+ocd-division/country:uk/spc:caithness_sutherland_and_ross,"Caithness, Sutherland and Ross",S16000086
+ocd-division/country:uk/spc:carrick_cumnock_and_doon_valley,"Carrick, Cumnock and Doon Valley",S16000087
+ocd-division/country:uk/spc:clackmannanshire_and_dunblane,Clackmannanshire and Dunblane,S16000088
+ocd-division/country:uk/spc:clydebank_and_milngavie,Clydebank and Milngavie,S16000089
+ocd-division/country:uk/spc:clydesdale,Clydesdale,S16000090
+ocd-division/country:uk/spc:coatbridge_and_chryston,Coatbridge and Chryston,S16000091
+ocd-division/country:uk/spc:cowdenbeath,Cowdenbeath,S16000092
+ocd-division/country:uk/spc:cumbernauld_and_kilsyth,Cumbernauld and Kilsyth,S16000093
+ocd-division/country:uk/spc:cunninghame_north,Cunninghame North,S16000094
+ocd-division/country:uk/spc:cunninghame_south,Cunninghame South,S16000095
+ocd-division/country:uk/spc:dumbarton,Dumbarton,S16000096
+ocd-division/country:uk/spc:dumfriesshire,Dumfriesshire,S16000097
+ocd-division/country:uk/spc:glasgow_kelvin,Glasgow Kelvin,S16000117
+ocd-division/country:uk/spc:glasgow_maryhill_and_springburn,Glasgow Maryhill and Springburn,S16000118
+ocd-division/country:uk/spc:glasgow_pollok,Glasgow Pollok,S16000119
+ocd-division/country:uk/spc:glasgow_provan,Glasgow Provan,S16000147
+ocd-division/country:uk/spc:glasgow_shettleston,Glasgow Shettleston,S16000121
+ocd-division/country:uk/spc:glasgow_southside,Glasgow Southside,S16000122
+ocd-division/country:uk/spc:greenock_and_inverclyde,Greenock and Inverclyde,S16000123
+ocd-division/country:uk/spc:hamilton_larkhall_and_stonehouse,"Hamilton, Larkhall and Stonehouse",S16000124
+ocd-division/country:uk/spc:inverness_and_nairn,Inverness and Nairn,S16000125
+ocd-division/country:uk/spc:kilmarnock_and_irvine_valley,Kilmarnock and Irvine Valley,S16000126
+ocd-division/country:uk/spc:kirkcaldy,Kirkcaldy,S16000127
+ocd-division/country:uk/spc:linlithgow,Linlithgow,S16000128
+ocd-division/country:uk/spc:mid_fife_and_glenrothes,Mid Fife and Glenrothes,S16000129
+ocd-division/country:uk/spc:midlothian_north_and_musselburgh,Midlothian North and Musselburgh,S16000130
+ocd-division/country:uk/spc:midlothian_south_tweeddale_and_lauderdale,"Midlothian South, Tweeddale and Lauderdale",S16000131
+ocd-division/country:uk/spc:moray,Moray,S16000132
+ocd-division/country:uk/spc:motherwell_and_wishaw,Motherwell and Wishaw,S16000133
+ocd-division/country:uk/spc:north_east_fife,North East Fife,S16000134
+ocd-division/country:uk/spc:orkney_islands,Orkney Islands,S16000135
+ocd-division/country:uk/spc:paisley,Paisley,S16000136
+ocd-division/country:uk/spc:perthshire_north,Perthshire North,S16000137
+ocd-division/country:uk/spc:perthshire_south_and_kinross-shire,Perthshire South and Kinross-shire,S16000138
+ocd-division/country:uk/spc:renfrewshire_north_and_west,Renfrewshire North and West,S16000139
+ocd-division/country:uk/spc:renfrewshire_south,Renfrewshire South,S16000140
+ocd-division/country:uk/spc:rutherglen,Rutherglen,S16000141
+ocd-division/country:uk/spc:shetland_islands,Shetland Islands,S16000142
+ocd-division/country:uk/spc:skye_lochaber_and_badenoch,"Skye, Lochaber and Badenoch",S16000143
+ocd-division/country:uk/spc:stirling,Stirling,S16000144
+ocd-division/country:uk/spc:strathkelvin_and_bearsden,Strathkelvin and Bearsden,S16000148
+ocd-division/country:uk/spc:uddingston_and_bellshill,Uddingston and Bellshill,S16000146
+ocd-division/country:uk/spc:dundee_city_east,Dundee City East,S16000098
+ocd-division/country:uk/spc:dundee_city_west,Dundee City West,S16000099
+ocd-division/country:uk/spc:dunfermline,Dunfermline,S16000100
+ocd-division/country:uk/spc:east_kilbride,East Kilbride,S16000101
+ocd-division/country:uk/spc:east_lothian,East Lothian,S16000102
+ocd-division/country:uk/spc:eastwood,Eastwood,S16000103
+ocd-division/country:uk/spc:edinburgh_central,Edinburgh Central,S16000104
+ocd-division/country:uk/spc:edinburgh_eastern,Edinburgh Eastern,S16000105
+ocd-division/country:uk/spc:edinburgh_northern_and_leith,Edinburgh Northern and Leith,S16000106
+ocd-division/country:uk/spc:edinburgh_pentlands,Edinburgh Pentlands,S16000107
+ocd-division/country:uk/spc:edinburgh_southern,Edinburgh Southern,S16000108
+ocd-division/country:uk/spc:edinburgh_western,Edinburgh Western,S16000109
+ocd-division/country:uk/spc:na_h-eileanan_an_iar,Na h-Eileanan an Iar,S16000110
+ocd-division/country:uk/spc:ettrick_roxburgh_and_berwickshire,"Ettrick, Roxburgh and Berwickshire",S16000111
+ocd-division/country:uk/spc:falkirk_east,Falkirk East,S16000112
+ocd-division/country:uk/spc:falkirk_west,Falkirk West,S16000113
+ocd-division/country:uk/spc:galloway_and_west_dumfries,Galloway and West Dumfries,S16000114
+ocd-division/country:uk/spc:glasgow_anniesland,Glasgow Anniesland,S16000115
+ocd-division/country:uk/spc:glasgow_cathcart,Glasgow Cathcart,S16000116

--- a/identifiers/country-uk/scottish_parliament_regions.csv
+++ b/identifiers/country-uk/scottish_parliament_regions.csv
@@ -1,0 +1,9 @@
+id,name,gss_code
+ocd-division/country:uk/spr:central_scotland,Central Scotland,S17000009
+ocd-division/country:uk/spr:highlands_and_islands,Highlands and Islands,S17000011
+ocd-division/country:uk/spr:lothian,Lothian,S17000012
+ocd-division/country:uk/spr:mid_scotland_and_fife,Mid Scotland and Fife,S17000013
+ocd-division/country:uk/spr:north_east_scotland,North East Scotland,S17000014
+ocd-division/country:uk/spr:south_scotland,South Scotland,S17000015
+ocd-division/country:uk/spr:glasgow,Glasgow,S17000017
+ocd-division/country:uk/spr:west_scotland,West Scotland,S17000018

--- a/identifiers/country-uk/uk_parliament_consitituencies.csv
+++ b/identifiers/country-uk/uk_parliament_consitituencies.csv
@@ -1,0 +1,651 @@
+id,name,gss_code
+ocd-division/country:uk/pcon:aldershot,Aldershot,E14000530
+ocd-division/country:uk/pcon:aldridge-brownhills,Aldridge-Brownhills,E14000531
+ocd-division/country:uk/pcon:altrincham_and_sale_west,Altrincham and Sale West,E14000532
+ocd-division/country:uk/pcon:amber_valley,Amber Valley,E14000533
+ocd-division/country:uk/pcon:arundel_and_south_downs,Arundel and South Downs,E14000534
+ocd-division/country:uk/pcon:ashfield,Ashfield,E14000535
+ocd-division/country:uk/pcon:ashford,Ashford,E14000536
+ocd-division/country:uk/pcon:ashton-under-lyne,Ashton-under-Lyne,E14000537
+ocd-division/country:uk/pcon:aylesbury,Aylesbury,E14000538
+ocd-division/country:uk/pcon:banbury,Banbury,E14000539
+ocd-division/country:uk/pcon:bath,Bath,E14000547
+ocd-division/country:uk/pcon:batley_and_spen,Batley and Spen,E14000548
+ocd-division/country:uk/pcon:bridgend,Bridgend,W07000073
+ocd-division/country:uk/pcon:ogmore,Ogmore,W07000074
+ocd-division/country:uk/pcon:pontypridd,Pontypridd,W07000075
+ocd-division/country:uk/pcon:caerphilly,Caerphilly,W07000076
+ocd-division/country:uk/pcon:islwyn,Islwyn,W07000077
+ocd-division/country:uk/pcon:vale_of_glamorgan,Vale of Glamorgan,W07000078
+ocd-division/country:uk/pcon:cardiff_west,Cardiff West,W07000079
+ocd-division/country:uk/pcon:cardiff_south_and_penarth,Cardiff South and Penarth,W07000080
+ocd-division/country:uk/pcon:barking,Barking,E14000540
+ocd-division/country:uk/pcon:barnsley_central,Barnsley Central,E14000541
+ocd-division/country:uk/pcon:barnsley_east,Barnsley East,E14000542
+ocd-division/country:uk/pcon:barrow_and_furness,Barrow and Furness,E14000543
+ocd-division/country:uk/pcon:basildon_and_billericay,Basildon and Billericay,E14000544
+ocd-division/country:uk/pcon:basingstoke,Basingstoke,E14000545
+ocd-division/country:uk/pcon:bassetlaw,Bassetlaw,E14000546
+ocd-division/country:uk/pcon:battersea,Battersea,E14000549
+ocd-division/country:uk/pcon:beaconsfield,Beaconsfield,E14000550
+ocd-division/country:uk/pcon:beckenham,Beckenham,E14000551
+ocd-division/country:uk/pcon:bootle,Bootle,E14000581
+ocd-division/country:uk/pcon:bedford,Bedford,E14000552
+ocd-division/country:uk/pcon:bermondsey_and_old_southwark,Bermondsey and Old Southwark,E14000553
+ocd-division/country:uk/pcon:berwick-upon-tweed,Berwick-upon-Tweed,E14000554
+ocd-division/country:uk/pcon:bethnal_green_and_bow,Bethnal Green and Bow,E14000555
+ocd-division/country:uk/pcon:beverley_and_holderness,Beverley and Holderness,E14000556
+ocd-division/country:uk/pcon:bexhill_and_battle,Bexhill and Battle,E14000557
+ocd-division/country:uk/pcon:boston_and_skegness,Boston and Skegness,E14000582
+ocd-division/country:uk/pcon:bosworth,Bosworth,E14000583
+ocd-division/country:uk/pcon:bournemouth_east,Bournemouth East,E14000584
+ocd-division/country:uk/pcon:bexleyheath_and_crayford,Bexleyheath and Crayford,E14000558
+ocd-division/country:uk/pcon:bradford_east,Bradford East,E14000587
+ocd-division/country:uk/pcon:bradford_south,Bradford South,E14000588
+ocd-division/country:uk/pcon:bradford_west,Bradford West,E14000589
+ocd-division/country:uk/pcon:braintree,Braintree,E14000590
+ocd-division/country:uk/pcon:birkenhead,Birkenhead,E14000559
+ocd-division/country:uk/pcon:birmingham_edgbaston,"Birmingham, Edgbaston",E14000560
+ocd-division/country:uk/pcon:bury_south,Bury South,E14000612
+ocd-division/country:uk/pcon:bury_st_edmunds,Bury St Edmunds,E14000613
+ocd-division/country:uk/pcon:calder_valley,Calder Valley,E14000614
+ocd-division/country:uk/pcon:birmingham_erdington,"Birmingham, Erdington",E14000561
+ocd-division/country:uk/pcon:chelsea_and_fulham,Chelsea and Fulham,E14000629
+ocd-division/country:uk/pcon:cheltenham,Cheltenham,E14000630
+ocd-division/country:uk/pcon:chesham_and_amersham,Chesham and Amersham,E14000631
+ocd-division/country:uk/pcon:chesterfield,Chesterfield,E14000632
+ocd-division/country:uk/pcon:chichester,Chichester,E14000633
+ocd-division/country:uk/pcon:birmingham_hall_green,"Birmingham, Hall Green",E14000562
+ocd-division/country:uk/pcon:crewe_and_nantwich,Crewe and Nantwich,E14000653
+ocd-division/country:uk/pcon:birmingham_hodge_hill,"Birmingham, Hodge Hill",E14000563
+ocd-division/country:uk/pcon:devizes,Devizes,E14000665
+ocd-division/country:uk/pcon:dewsbury,Dewsbury,E14000666
+ocd-division/country:uk/pcon:don_valley,Don Valley,E14000667
+ocd-division/country:uk/pcon:doncaster_central,Doncaster Central,E14000668
+ocd-division/country:uk/pcon:doncaster_north,Doncaster North,E14000669
+ocd-division/country:uk/pcon:dover,Dover,E14000670
+ocd-division/country:uk/pcon:dudley_north,Dudley North,E14000671
+ocd-division/country:uk/pcon:dudley_south,Dudley South,E14000672
+ocd-division/country:uk/pcon:birmingham_ladywood,"Birmingham, Ladywood",E14000564
+ocd-division/country:uk/pcon:birmingham_northfield,"Birmingham, Northfield",E14000565
+ocd-division/country:uk/pcon:eastleigh,Eastleigh,E14000685
+ocd-division/country:uk/pcon:eddisbury,Eddisbury,E14000686
+ocd-division/country:uk/pcon:birmingham_perry_barr,"Birmingham, Perry Barr",E14000566
+ocd-division/country:uk/pcon:birmingham_selly_oak,"Birmingham, Selly Oak",E14000567
+ocd-division/country:uk/pcon:birmingham_yardley,"Birmingham, Yardley",E14000568
+ocd-division/country:uk/pcon:bishop_auckland,Bishop Auckland,E14000569
+ocd-division/country:uk/pcon:blackburn,Blackburn,E14000570
+ocd-division/country:uk/pcon:vauxhall,Vauxhall,E14001008
+ocd-division/country:uk/pcon:blackley_and_broughton,Blackley and Broughton,E14000571
+ocd-division/country:uk/pcon:blackpool_north_and_cleveleys,Blackpool North and Cleveleys,E14000572
+ocd-division/country:uk/pcon:wakefield,Wakefield,E14001009
+ocd-division/country:uk/pcon:wallasey,Wallasey,E14001010
+ocd-division/country:uk/pcon:blackpool_south,Blackpool South,E14000573
+ocd-division/country:uk/pcon:blaydon,Blaydon,E14000574
+ocd-division/country:uk/pcon:blyth_valley,Blyth Valley,E14000575
+ocd-division/country:uk/pcon:bognor_regis_and_littlehampton,Bognor Regis and Littlehampton,E14000576
+ocd-division/country:uk/pcon:bolsover,Bolsover,E14000577
+ocd-division/country:uk/pcon:bolton_north_east,Bolton North East,E14000578
+ocd-division/country:uk/pcon:bolton_south_east,Bolton South East,E14000579
+ocd-division/country:uk/pcon:bolton_west,Bolton West,E14000580
+ocd-division/country:uk/pcon:yeovil,Yeovil,E14001060
+ocd-division/country:uk/pcon:york_central,York Central,E14001061
+ocd-division/country:uk/pcon:york_outer,York Outer,E14001062
+ocd-division/country:uk/pcon:belfast_east,Belfast East,N06000001
+ocd-division/country:uk/pcon:belfast_north,Belfast North,N06000002
+ocd-division/country:uk/pcon:belfast_south,Belfast South,N06000003
+ocd-division/country:uk/pcon:belfast_west,Belfast West,N06000004
+ocd-division/country:uk/pcon:east_antrim,East Antrim,N06000005
+ocd-division/country:uk/pcon:east_londonderry,East Londonderry,N06000006
+ocd-division/country:uk/pcon:fermanagh_and_south_tyrone,Fermanagh and South Tyrone,N06000007
+ocd-division/country:uk/pcon:foyle,Foyle,N06000008
+ocd-division/country:uk/pcon:lagan_valley,Lagan Valley,N06000009
+ocd-division/country:uk/pcon:mid_ulster,Mid Ulster,N06000010
+ocd-division/country:uk/pcon:newry_and_armagh,Newry and Armagh,N06000011
+ocd-division/country:uk/pcon:north_antrim,North Antrim,N06000012
+ocd-division/country:uk/pcon:north_down,North Down,N06000013
+ocd-division/country:uk/pcon:south_antrim,South Antrim,N06000014
+ocd-division/country:uk/pcon:south_down,South Down,N06000015
+ocd-division/country:uk/pcon:strangford,Strangford,N06000016
+ocd-division/country:uk/pcon:upper_bann,Upper Bann,N06000017
+ocd-division/country:uk/pcon:west_tyrone,West Tyrone,N06000018
+ocd-division/country:uk/pcon:bournemouth_west,Bournemouth West,E14000585
+ocd-division/country:uk/pcon:bracknell,Bracknell,E14000586
+ocd-division/country:uk/pcon:brent_central,Brent Central,E14000591
+ocd-division/country:uk/pcon:dumfriesshire_clydesdale_and_tweeddale,"Dumfriesshire, Clydesdale and Tweeddale",S14000014
+ocd-division/country:uk/pcon:dundee_east,Dundee East,S14000015
+ocd-division/country:uk/pcon:dundee_west,Dundee West,S14000016
+ocd-division/country:uk/pcon:dunfermline_and_west_fife,Dunfermline and West Fife,S14000017
+ocd-division/country:uk/pcon:east_dunbartonshire,East Dunbartonshire,S14000018
+ocd-division/country:uk/pcon:east_kilbride_strathaven_and_lesmahagow,"East Kilbride, Strathaven and Lesmahagow",S14000019
+ocd-division/country:uk/pcon:east_lothian,East Lothian,S14000020
+ocd-division/country:uk/pcon:east_renfrewshire,East Renfrewshire,S14000021
+ocd-division/country:uk/pcon:brent_north,Brent North,E14000592
+ocd-division/country:uk/pcon:brentford_and_isleworth,Brentford and Isleworth,E14000593
+ocd-division/country:uk/pcon:brentwood_and_ongar,Brentwood and Ongar,E14000594
+ocd-division/country:uk/pcon:bridgwater_and_west_somerset,Bridgwater and West Somerset,E14000595
+ocd-division/country:uk/pcon:brigg_and_goole,Brigg and Goole,E14000596
+ocd-division/country:uk/pcon:brighton_kemptown,"Brighton, Kemptown",E14000597
+ocd-division/country:uk/pcon:brighton_pavilion,"Brighton, Pavilion",E14000598
+ocd-division/country:uk/pcon:bristol_east,Bristol East,E14000599
+ocd-division/country:uk/pcon:bristol_north_west,Bristol North West,E14000600
+ocd-division/country:uk/pcon:bristol_south,Bristol South,E14000601
+ocd-division/country:uk/pcon:bristol_west,Bristol West,E14000602
+ocd-division/country:uk/pcon:broadland,Broadland,E14000603
+ocd-division/country:uk/pcon:bromley_and_chislehurst,Bromley and Chislehurst,E14000604
+ocd-division/country:uk/pcon:bromsgrove,Bromsgrove,E14000605
+ocd-division/country:uk/pcon:broxbourne,Broxbourne,E14000606
+ocd-division/country:uk/pcon:broxtowe,Broxtowe,E14000607
+ocd-division/country:uk/pcon:buckingham,Buckingham,E14000608
+ocd-division/country:uk/pcon:burnley,Burnley,E14000609
+ocd-division/country:uk/pcon:burton,Burton,E14000610
+ocd-division/country:uk/pcon:bury_north,Bury North,E14000611
+ocd-division/country:uk/pcon:camberwell_and_peckham,Camberwell and Peckham,E14000615
+ocd-division/country:uk/pcon:camborne_and_redruth,Camborne and Redruth,E14000616
+ocd-division/country:uk/pcon:harrow_east,Harrow East,E14000731
+ocd-division/country:uk/pcon:cambridge,Cambridge,E14000617
+ocd-division/country:uk/pcon:cannock_chase,Cannock Chase,E14000618
+ocd-division/country:uk/pcon:canterbury,Canterbury,E14000619
+ocd-division/country:uk/pcon:carlisle,Carlisle,E14000620
+ocd-division/country:uk/pcon:heywood_and_middleton,Heywood and Middleton,E14000747
+ocd-division/country:uk/pcon:high_peak,High Peak,E14000748
+ocd-division/country:uk/pcon:hitchin_and_harpenden,Hitchin and Harpenden,E14000749
+ocd-division/country:uk/pcon:carshalton_and_wallington,Carshalton and Wallington,E14000621
+ocd-division/country:uk/pcon:castle_point,Castle Point,E14000622
+ocd-division/country:uk/pcon:central_devon,Central Devon,E14000623
+ocd-division/country:uk/pcon:central_suffolk_and_north_ipswich,Central Suffolk and North Ipswich,E14000624
+ocd-division/country:uk/pcon:charnwood,Charnwood,E14000625
+ocd-division/country:uk/pcon:chatham_and_aylesford,Chatham and Aylesford,E14000626
+ocd-division/country:uk/pcon:cheadle,Cheadle,E14000627
+ocd-division/country:uk/pcon:chelmsford,Chelmsford,E14000628
+ocd-division/country:uk/pcon:chingford_and_woodford_green,Chingford and Woodford Green,E14000634
+ocd-division/country:uk/pcon:chippenham,Chippenham,E14000635
+ocd-division/country:uk/pcon:chipping_barnet,Chipping Barnet,E14000636
+ocd-division/country:uk/pcon:chorley,Chorley,E14000637
+ocd-division/country:uk/pcon:christchurch,Christchurch,E14000638
+ocd-division/country:uk/pcon:islington_north,Islington North,E14000763
+ocd-division/country:uk/pcon:cities_of_london_and_westminster,Cities of London and Westminster,E14000639
+ocd-division/country:uk/pcon:city_of_chester,City of Chester,E14000640
+ocd-division/country:uk/pcon:city_of_durham,City of Durham,E14000641
+ocd-division/country:uk/pcon:clacton,Clacton,E14000642
+ocd-division/country:uk/pcon:cleethorpes,Cleethorpes,E14000643
+ocd-division/country:uk/pcon:islington_south_and_finsbury,Islington South and Finsbury,E14000764
+ocd-division/country:uk/pcon:jarrow,Jarrow,E14000765
+ocd-division/country:uk/pcon:keighley,Keighley,E14000766
+ocd-division/country:uk/pcon:kenilworth_and_southam,Kenilworth and Southam,E14000767
+ocd-division/country:uk/pcon:colchester,Colchester,E14000644
+ocd-division/country:uk/pcon:colne_valley,Colne Valley,E14000645
+ocd-division/country:uk/pcon:congleton,Congleton,E14000646
+ocd-division/country:uk/pcon:copeland,Copeland,E14000647
+ocd-division/country:uk/pcon:corby,Corby,E14000648
+ocd-division/country:uk/pcon:coventry_north_east,Coventry North East,E14000649
+ocd-division/country:uk/pcon:coventry_north_west,Coventry North West,E14000650
+ocd-division/country:uk/pcon:coventry_south,Coventry South,E14000651
+ocd-division/country:uk/pcon:crawley,Crawley,E14000652
+ocd-division/country:uk/pcon:croydon_central,Croydon Central,E14000654
+ocd-division/country:uk/pcon:croydon_north,Croydon North,E14000655
+ocd-division/country:uk/pcon:kensington,Kensington,E14000768
+ocd-division/country:uk/pcon:kettering,Kettering,E14000769
+ocd-division/country:uk/pcon:croydon_south,Croydon South,E14000656
+ocd-division/country:uk/pcon:dagenham_and_rainham,Dagenham and Rainham,E14000657
+ocd-division/country:uk/pcon:darlington,Darlington,E14000658
+ocd-division/country:uk/pcon:dartford,Dartford,E14000659
+ocd-division/country:uk/pcon:daventry,Daventry,E14000660
+ocd-division/country:uk/pcon:denton_and_reddish,Denton and Reddish,E14000661
+ocd-division/country:uk/pcon:derby_north,Derby North,E14000662
+ocd-division/country:uk/pcon:derby_south,Derby South,E14000663
+ocd-division/country:uk/pcon:derbyshire_dales,Derbyshire Dales,E14000664
+ocd-division/country:uk/pcon:dulwich_and_west_norwood,Dulwich and West Norwood,E14000673
+ocd-division/country:uk/pcon:luton_north,Luton North,E14000800
+ocd-division/country:uk/pcon:ealing_central_and_acton,Ealing Central and Acton,E14000674
+ocd-division/country:uk/pcon:north_west_cambridgeshire,North West Cambridgeshire,E14000855
+ocd-division/country:uk/pcon:north_west_durham,North West Durham,E14000856
+ocd-division/country:uk/pcon:north_west_hampshire,North West Hampshire,E14000857
+ocd-division/country:uk/pcon:north_west_leicestershire,North West Leicestershire,E14000858
+ocd-division/country:uk/pcon:north_west_norfolk,North West Norfolk,E14000859
+ocd-division/country:uk/pcon:north_wiltshire,North Wiltshire,E14000860
+ocd-division/country:uk/pcon:ealing_north,Ealing North,E14000675
+ocd-division/country:uk/pcon:ealing_southall,"Ealing, Southall",E14000676
+ocd-division/country:uk/pcon:easington,Easington,E14000677
+ocd-division/country:uk/pcon:east_devon,East Devon,E14000678
+ocd-division/country:uk/pcon:east_ham,East Ham,E14000679
+ocd-division/country:uk/pcon:east_hampshire,East Hampshire,E14000680
+ocd-division/country:uk/pcon:east_surrey,East Surrey,E14000681
+ocd-division/country:uk/pcon:east_worthing_and_shoreham,East Worthing and Shoreham,E14000682
+ocd-division/country:uk/pcon:east_yorkshire,East Yorkshire,E14000683
+ocd-division/country:uk/pcon:eastbourne,Eastbourne,E14000684
+ocd-division/country:uk/pcon:edmonton,Edmonton,E14000687
+ocd-division/country:uk/pcon:ellesmere_port_and_neston,Ellesmere Port and Neston,E14000688
+ocd-division/country:uk/pcon:elmet_and_rothwell,Elmet and Rothwell,E14000689
+ocd-division/country:uk/pcon:eltham,Eltham,E14000690
+ocd-division/country:uk/pcon:enfield_north,Enfield North,E14000691
+ocd-division/country:uk/pcon:enfield_southgate,"Enfield, Southgate",E14000692
+ocd-division/country:uk/pcon:epping_forest,Epping Forest,E14000693
+ocd-division/country:uk/pcon:epsom_and_ewell,Epsom and Ewell,E14000694
+ocd-division/country:uk/pcon:erewash,Erewash,E14000695
+ocd-division/country:uk/pcon:erith_and_thamesmead,Erith and Thamesmead,E14000696
+ocd-division/country:uk/pcon:esher_and_walton,Esher and Walton,E14000697
+ocd-division/country:uk/pcon:exeter,Exeter,E14000698
+ocd-division/country:uk/pcon:fareham,Fareham,E14000699
+ocd-division/country:uk/pcon:faversham_and_mid_kent,Faversham and Mid Kent,E14000700
+ocd-division/country:uk/pcon:feltham_and_heston,Feltham and Heston,E14000701
+ocd-division/country:uk/pcon:filton_and_bradley_stoke,Filton and Bradley Stoke,E14000702
+ocd-division/country:uk/pcon:finchley_and_golders_green,Finchley and Golders Green,E14000703
+ocd-division/country:uk/pcon:folkestone_and_hythe,Folkestone and Hythe,E14000704
+ocd-division/country:uk/pcon:forest_of_dean,Forest of Dean,E14000705
+ocd-division/country:uk/pcon:fylde,Fylde,E14000706
+ocd-division/country:uk/pcon:gainsborough,Gainsborough,E14000707
+ocd-division/country:uk/pcon:garston_and_halewood,Garston and Halewood,E14000708
+ocd-division/country:uk/pcon:gateshead,Gateshead,E14000709
+ocd-division/country:uk/pcon:gedling,Gedling,E14000710
+ocd-division/country:uk/pcon:gillingham_and_rainham,Gillingham and Rainham,E14000711
+ocd-division/country:uk/pcon:gloucester,Gloucester,E14000712
+ocd-division/country:uk/pcon:gosport,Gosport,E14000713
+ocd-division/country:uk/pcon:grantham_and_stamford,Grantham and Stamford,E14000714
+ocd-division/country:uk/pcon:gravesham,Gravesham,E14000715
+ocd-division/country:uk/pcon:great_grimsby,Great Grimsby,E14000716
+ocd-division/country:uk/pcon:great_yarmouth,Great Yarmouth,E14000717
+ocd-division/country:uk/pcon:greenwich_and_woolwich,Greenwich and Woolwich,E14000718
+ocd-division/country:uk/pcon:guildford,Guildford,E14000719
+ocd-division/country:uk/pcon:hackney_north_and_stoke_newington,Hackney North and Stoke Newington,E14000720
+ocd-division/country:uk/pcon:portsmouth_south,Portsmouth South,E14000884
+ocd-division/country:uk/pcon:preston,Preston,E14000885
+ocd-division/country:uk/pcon:hackney_south_and_shoreditch,Hackney South and Shoreditch,E14000721
+ocd-division/country:uk/pcon:halesowen_and_rowley_regis,Halesowen and Rowley Regis,E14000722
+ocd-division/country:uk/pcon:halifax,Halifax,E14000723
+ocd-division/country:uk/pcon:haltemprice_and_howden,Haltemprice and Howden,E14000724
+ocd-division/country:uk/pcon:halton,Halton,E14000725
+ocd-division/country:uk/pcon:pudsey,Pudsey,E14000886
+ocd-division/country:uk/pcon:hammersmith,Hammersmith,E14000726
+ocd-division/country:uk/pcon:putney,Putney,E14000887
+ocd-division/country:uk/pcon:rayleigh_and_wickford,Rayleigh and Wickford,E14000888
+ocd-division/country:uk/pcon:reading_east,Reading East,E14000889
+ocd-division/country:uk/pcon:reading_west,Reading West,E14000890
+ocd-division/country:uk/pcon:redcar,Redcar,E14000891
+ocd-division/country:uk/pcon:redditch,Redditch,E14000892
+ocd-division/country:uk/pcon:reigate,Reigate,E14000893
+ocd-division/country:uk/pcon:ribble_valley,Ribble Valley,E14000894
+ocd-division/country:uk/pcon:hampstead_and_kilburn,Hampstead and Kilburn,E14000727
+ocd-division/country:uk/pcon:harborough,Harborough,E14000728
+ocd-division/country:uk/pcon:harlow,Harlow,E14000729
+ocd-division/country:uk/pcon:harrogate_and_knaresborough,Harrogate and Knaresborough,E14000730
+ocd-division/country:uk/pcon:richmond_~yorks~,Richmond (Yorks),E14000895
+ocd-division/country:uk/pcon:harrow_west,Harrow West,E14000732
+ocd-division/country:uk/pcon:hartlepool,Hartlepool,E14000733
+ocd-division/country:uk/pcon:harwich_and_north_essex,Harwich and North Essex,E14000734
+ocd-division/country:uk/pcon:hastings_and_rye,Hastings and Rye,E14000735
+ocd-division/country:uk/pcon:havant,Havant,E14000736
+ocd-division/country:uk/pcon:hayes_and_harlington,Hayes and Harlington,E14000737
+ocd-division/country:uk/pcon:hazel_grove,Hazel Grove,E14000738
+ocd-division/country:uk/pcon:hemel_hempstead,Hemel Hempstead,E14000739
+ocd-division/country:uk/pcon:hemsworth,Hemsworth,E14000740
+ocd-division/country:uk/pcon:hendon,Hendon,E14000741
+ocd-division/country:uk/pcon:henley,Henley,E14000742
+ocd-division/country:uk/pcon:hereford_and_south_herefordshire,Hereford and South Herefordshire,E14000743
+ocd-division/country:uk/pcon:hertford_and_stortford,Hertford and Stortford,E14000744
+ocd-division/country:uk/pcon:hertsmere,Hertsmere,E14000745
+ocd-division/country:uk/pcon:hexham,Hexham,E14000746
+ocd-division/country:uk/pcon:holborn_and_st_pancras,Holborn and St Pancras,E14000750
+ocd-division/country:uk/pcon:hornchurch_and_upminster,Hornchurch and Upminster,E14000751
+ocd-division/country:uk/pcon:sheffield_brightside_and_hillsborough,"Sheffield, Brightside and Hillsborough",E14000921
+ocd-division/country:uk/pcon:sheffield_hallam,"Sheffield, Hallam",E14000922
+ocd-division/country:uk/pcon:sheffield_heeley,"Sheffield, Heeley",E14000923
+ocd-division/country:uk/pcon:sherwood,Sherwood,E14000924
+ocd-division/country:uk/pcon:shipley,Shipley,E14000925
+ocd-division/country:uk/pcon:shrewsbury_and_atcham,Shrewsbury and Atcham,E14000926
+ocd-division/country:uk/pcon:sittingbourne_and_sheppey,Sittingbourne and Sheppey,E14000927
+ocd-division/country:uk/pcon:skipton_and_ripon,Skipton and Ripon,E14000928
+ocd-division/country:uk/pcon:sleaford_and_north_hykeham,Sleaford and North Hykeham,E14000929
+ocd-division/country:uk/pcon:hornsey_and_wood_green,Hornsey and Wood Green,E14000752
+ocd-division/country:uk/pcon:horsham,Horsham,E14000753
+ocd-division/country:uk/pcon:houghton_and_sunderland_south,Houghton and Sunderland South,E14000754
+ocd-division/country:uk/pcon:south_northamptonshire,South Northamptonshire,E14000942
+ocd-division/country:uk/pcon:south_ribble,South Ribble,E14000943
+ocd-division/country:uk/pcon:south_shields,South Shields,E14000944
+ocd-division/country:uk/pcon:south_staffordshire,South Staffordshire,E14000945
+ocd-division/country:uk/pcon:south_suffolk,South Suffolk,E14000946
+ocd-division/country:uk/pcon:south_swindon,South Swindon,E14000947
+ocd-division/country:uk/pcon:south_thanet,South Thanet,E14000948
+ocd-division/country:uk/pcon:south_west_bedfordshire,South West Bedfordshire,E14000949
+ocd-division/country:uk/pcon:south_west_devon,South West Devon,E14000950
+ocd-division/country:uk/pcon:south_west_hertfordshire,South West Hertfordshire,E14000951
+ocd-division/country:uk/pcon:south_west_norfolk,South West Norfolk,E14000952
+ocd-division/country:uk/pcon:south_west_surrey,South West Surrey,E14000953
+ocd-division/country:uk/pcon:south_west_wiltshire,South West Wiltshire,E14000954
+ocd-division/country:uk/pcon:hove,Hove,E14000755
+ocd-division/country:uk/pcon:huddersfield,Huddersfield,E14000756
+ocd-division/country:uk/pcon:huntingdon,Huntingdon,E14000757
+ocd-division/country:uk/pcon:hyndburn,Hyndburn,E14000758
+ocd-division/country:uk/pcon:ilford_north,Ilford North,E14000759
+ocd-division/country:uk/pcon:ilford_south,Ilford South,E14000760
+ocd-division/country:uk/pcon:ipswich,Ipswich,E14000761
+ocd-division/country:uk/pcon:isle_of_wight,Isle of Wight,E14000762
+ocd-division/country:uk/pcon:kingston_and_surbiton,Kingston and Surbiton,E14000770
+ocd-division/country:uk/pcon:kingston_upon_hull_east,Kingston upon Hull East,E14000771
+ocd-division/country:uk/pcon:kingston_upon_hull_north,Kingston upon Hull North,E14000772
+ocd-division/country:uk/pcon:kingston_upon_hull_west_and_hessle,Kingston upon Hull West and Hessle,E14000773
+ocd-division/country:uk/pcon:kingswood,Kingswood,E14000774
+ocd-division/country:uk/pcon:knowsley,Knowsley,E14000775
+ocd-division/country:uk/pcon:lancaster_and_fleetwood,Lancaster and Fleetwood,E14000776
+ocd-division/country:uk/pcon:leeds_central,Leeds Central,E14000777
+ocd-division/country:uk/pcon:leeds_east,Leeds East,E14000778
+ocd-division/country:uk/pcon:leeds_north_east,Leeds North East,E14000779
+ocd-division/country:uk/pcon:leeds_north_west,Leeds North West,E14000780
+ocd-division/country:uk/pcon:leeds_west,Leeds West,E14000781
+ocd-division/country:uk/pcon:leicester_east,Leicester East,E14000782
+ocd-division/country:uk/pcon:leicester_south,Leicester South,E14000783
+ocd-division/country:uk/pcon:leicester_west,Leicester West,E14000784
+ocd-division/country:uk/pcon:leigh,Leigh,E14000785
+ocd-division/country:uk/pcon:lewes,Lewes,E14000786
+ocd-division/country:uk/pcon:lewisham_east,Lewisham East,E14000787
+ocd-division/country:uk/pcon:lewisham_west_and_penge,Lewisham West and Penge,E14000788
+ocd-division/country:uk/pcon:lewisham_deptford,"Lewisham, Deptford",E14000789
+ocd-division/country:uk/pcon:leyton_and_wanstead,Leyton and Wanstead,E14000790
+ocd-division/country:uk/pcon:lichfield,Lichfield,E14000791
+ocd-division/country:uk/pcon:lincoln,Lincoln,E14000792
+ocd-division/country:uk/pcon:liverpool_riverside,"Liverpool, Riverside",E14000793
+ocd-division/country:uk/pcon:liverpool_walton,"Liverpool, Walton",E14000794
+ocd-division/country:uk/pcon:liverpool_wavertree,"Liverpool, Wavertree",E14000795
+ocd-division/country:uk/pcon:liverpool_west_derby,"Liverpool, West Derby",E14000796
+ocd-division/country:uk/pcon:loughborough,Loughborough,E14000797
+ocd-division/country:uk/pcon:louth_and_horncastle,Louth and Horncastle,E14000798
+ocd-division/country:uk/pcon:ludlow,Ludlow,E14000799
+ocd-division/country:uk/pcon:luton_south,Luton South,E14000801
+ocd-division/country:uk/pcon:macclesfield,Macclesfield,E14000802
+ocd-division/country:uk/pcon:maidenhead,Maidenhead,E14000803
+ocd-division/country:uk/pcon:maidstone_and_the_weald,Maidstone and The Weald,E14000804
+ocd-division/country:uk/pcon:makerfield,Makerfield,E14000805
+ocd-division/country:uk/pcon:maldon,Maldon,E14000806
+ocd-division/country:uk/pcon:manchester_central,Manchester Central,E14000807
+ocd-division/country:uk/pcon:manchester_gorton,"Manchester, Gorton",E14000808
+ocd-division/country:uk/pcon:manchester_withington,"Manchester, Withington",E14000809
+ocd-division/country:uk/pcon:mansfield,Mansfield,E14000810
+ocd-division/country:uk/pcon:meon_valley,Meon Valley,E14000811
+ocd-division/country:uk/pcon:meriden,Meriden,E14000812
+ocd-division/country:uk/pcon:mid_bedfordshire,Mid Bedfordshire,E14000813
+ocd-division/country:uk/pcon:mid_derbyshire,Mid Derbyshire,E14000814
+ocd-division/country:uk/pcon:mid_dorset_and_north_poole,Mid Dorset and North Poole,E14000815
+ocd-division/country:uk/pcon:mid_norfolk,Mid Norfolk,E14000816
+ocd-division/country:uk/pcon:mid_sussex,Mid Sussex,E14000817
+ocd-division/country:uk/pcon:mid_worcestershire,Mid Worcestershire,E14000818
+ocd-division/country:uk/pcon:middlesbrough,Middlesbrough,E14000819
+ocd-division/country:uk/pcon:middlesbrough_south_and_east_cleveland,Middlesbrough South and East Cleveland,E14000820
+ocd-division/country:uk/pcon:milton_keynes_north,Milton Keynes North,E14000821
+ocd-division/country:uk/pcon:milton_keynes_south,Milton Keynes South,E14000822
+ocd-division/country:uk/pcon:mitcham_and_morden,Mitcham and Morden,E14000823
+ocd-division/country:uk/pcon:mole_valley,Mole Valley,E14000824
+ocd-division/country:uk/pcon:morecambe_and_lunesdale,Morecambe and Lunesdale,E14000825
+ocd-division/country:uk/pcon:morley_and_outwood,Morley and Outwood,E14000826
+ocd-division/country:uk/pcon:new_forest_east,New Forest East,E14000827
+ocd-division/country:uk/pcon:new_forest_west,New Forest West,E14000828
+ocd-division/country:uk/pcon:newark,Newark,E14000829
+ocd-division/country:uk/pcon:newbury,Newbury,E14000830
+ocd-division/country:uk/pcon:newcastle_upon_tyne_central,Newcastle upon Tyne Central,E14000831
+ocd-division/country:uk/pcon:newcastle_upon_tyne_east,Newcastle upon Tyne East,E14000832
+ocd-division/country:uk/pcon:newcastle_upon_tyne_north,Newcastle upon Tyne North,E14000833
+ocd-division/country:uk/pcon:newcastle-under-lyme,Newcastle-under-Lyme,E14000834
+ocd-division/country:uk/pcon:newton_abbot,Newton Abbot,E14000835
+ocd-division/country:uk/pcon:normanton_pontefract_and_castleford,"Normanton, Pontefract and Castleford",E14000836
+ocd-division/country:uk/pcon:north_cornwall,North Cornwall,E14000837
+ocd-division/country:uk/pcon:north_devon,North Devon,E14000838
+ocd-division/country:uk/pcon:north_dorset,North Dorset,E14000839
+ocd-division/country:uk/pcon:north_durham,North Durham,E14000840
+ocd-division/country:uk/pcon:north_east_bedfordshire,North East Bedfordshire,E14000841
+ocd-division/country:uk/pcon:north_east_cambridgeshire,North East Cambridgeshire,E14000842
+ocd-division/country:uk/pcon:north_east_derbyshire,North East Derbyshire,E14000843
+ocd-division/country:uk/pcon:north_east_hampshire,North East Hampshire,E14000844
+ocd-division/country:uk/pcon:north_east_hertfordshire,North East Hertfordshire,E14000845
+ocd-division/country:uk/pcon:north_east_somerset,North East Somerset,E14000846
+ocd-division/country:uk/pcon:north_herefordshire,North Herefordshire,E14000847
+ocd-division/country:uk/pcon:north_norfolk,North Norfolk,E14000848
+ocd-division/country:uk/pcon:north_shropshire,North Shropshire,E14000849
+ocd-division/country:uk/pcon:north_somerset,North Somerset,E14000850
+ocd-division/country:uk/pcon:north_swindon,North Swindon,E14000851
+ocd-division/country:uk/pcon:north_thanet,North Thanet,E14000852
+ocd-division/country:uk/pcon:north_tyneside,North Tyneside,E14000853
+ocd-division/country:uk/pcon:north_warwickshire,North Warwickshire,E14000854
+ocd-division/country:uk/pcon:northampton_north,Northampton North,E14000861
+ocd-division/country:uk/pcon:northampton_south,Northampton South,E14000862
+ocd-division/country:uk/pcon:norwich_north,Norwich North,E14000863
+ocd-division/country:uk/pcon:norwich_south,Norwich South,E14000864
+ocd-division/country:uk/pcon:nottingham_east,Nottingham East,E14000865
+ocd-division/country:uk/pcon:streatham,Streatham,E14000978
+ocd-division/country:uk/pcon:stretford_and_urmston,Stretford and Urmston,E14000979
+ocd-division/country:uk/pcon:nottingham_north,Nottingham North,E14000866
+ocd-division/country:uk/pcon:stroud,Stroud,E14000980
+ocd-division/country:uk/pcon:suffolk_coastal,Suffolk Coastal,E14000981
+ocd-division/country:uk/pcon:sunderland_central,Sunderland Central,E14000982
+ocd-division/country:uk/pcon:surrey_heath,Surrey Heath,E14000983
+ocd-division/country:uk/pcon:nottingham_south,Nottingham South,E14000867
+ocd-division/country:uk/pcon:nuneaton,Nuneaton,E14000868
+ocd-division/country:uk/pcon:old_bexley_and_sidcup,Old Bexley and Sidcup,E14000869
+ocd-division/country:uk/pcon:oldham_east_and_saddleworth,Oldham East and Saddleworth,E14000870
+ocd-division/country:uk/pcon:oldham_west_and_royton,Oldham West and Royton,E14000871
+ocd-division/country:uk/pcon:orpington,Orpington,E14000872
+ocd-division/country:uk/pcon:oxford_east,Oxford East,E14000873
+ocd-division/country:uk/pcon:oxford_west_and_abingdon,Oxford West and Abingdon,E14000874
+ocd-division/country:uk/pcon:pendle,Pendle,E14000875
+ocd-division/country:uk/pcon:penistone_and_stocksbridge,Penistone and Stocksbridge,E14000876
+ocd-division/country:uk/pcon:penrith_and_the_border,Penrith and The Border,E14000877
+ocd-division/country:uk/pcon:peterborough,Peterborough,E14000878
+ocd-division/country:uk/pcon:plymouth_moor_view,"Plymouth, Moor View",E14000879
+ocd-division/country:uk/pcon:plymouth_sutton_and_devonport,"Plymouth, Sutton and Devonport",E14000880
+ocd-division/country:uk/pcon:poole,Poole,E14000881
+ocd-division/country:uk/pcon:poplar_and_limehouse,Poplar and Limehouse,E14000882
+ocd-division/country:uk/pcon:tooting,Tooting,E14000998
+ocd-division/country:uk/pcon:torbay,Torbay,E14000999
+ocd-division/country:uk/pcon:torridge_and_west_devon,Torridge and West Devon,E14001000
+ocd-division/country:uk/pcon:portsmouth_north,Portsmouth North,E14000883
+ocd-division/country:uk/pcon:richmond_park,Richmond Park,E14000896
+ocd-division/country:uk/pcon:rochdale,Rochdale,E14000897
+ocd-division/country:uk/pcon:rochester_and_strood,Rochester and Strood,E14000898
+ocd-division/country:uk/pcon:rochford_and_southend_east,Rochford and Southend East,E14000899
+ocd-division/country:uk/pcon:totnes,Totnes,E14001001
+ocd-division/country:uk/pcon:romford,Romford,E14000900
+ocd-division/country:uk/pcon:romsey_and_southampton_north,Romsey and Southampton North,E14000901
+ocd-division/country:uk/pcon:rossendale_and_darwen,Rossendale and Darwen,E14000902
+ocd-division/country:uk/pcon:rother_valley,Rother Valley,E14000903
+ocd-division/country:uk/pcon:rotherham,Rotherham,E14000904
+ocd-division/country:uk/pcon:rugby,Rugby,E14000905
+ocd-division/country:uk/pcon:ruislip_northwood_and_pinner,"Ruislip, Northwood and Pinner",E14000906
+ocd-division/country:uk/pcon:runnymede_and_weybridge,Runnymede and Weybridge,E14000907
+ocd-division/country:uk/pcon:rushcliffe,Rushcliffe,E14000908
+ocd-division/country:uk/pcon:rutland_and_melton,Rutland and Melton,E14000909
+ocd-division/country:uk/pcon:saffron_walden,Saffron Walden,E14000910
+ocd-division/country:uk/pcon:salford_and_eccles,Salford and Eccles,E14000911
+ocd-division/country:uk/pcon:salisbury,Salisbury,E14000912
+ocd-division/country:uk/pcon:scarborough_and_whitby,Scarborough and Whitby,E14000913
+ocd-division/country:uk/pcon:scunthorpe,Scunthorpe,E14000914
+ocd-division/country:uk/pcon:sedgefield,Sedgefield,E14000915
+ocd-division/country:uk/pcon:sefton_central,Sefton Central,E14000916
+ocd-division/country:uk/pcon:selby_and_ainsty,Selby and Ainsty,E14000917
+ocd-division/country:uk/pcon:sevenoaks,Sevenoaks,E14000918
+ocd-division/country:uk/pcon:sheffield_central,Sheffield Central,E14000919
+ocd-division/country:uk/pcon:sheffield_south_east,Sheffield South East,E14000920
+ocd-division/country:uk/pcon:slough,Slough,E14000930
+ocd-division/country:uk/pcon:solihull,Solihull,E14000931
+ocd-division/country:uk/pcon:somerton_and_frome,Somerton and Frome,E14000932
+ocd-division/country:uk/pcon:south_basildon_and_east_thurrock,South Basildon and East Thurrock,E14000933
+ocd-division/country:uk/pcon:south_cambridgeshire,South Cambridgeshire,E14000934
+ocd-division/country:uk/pcon:south_derbyshire,South Derbyshire,E14000935
+ocd-division/country:uk/pcon:south_dorset,South Dorset,E14000936
+ocd-division/country:uk/pcon:south_east_cambridgeshire,South East Cambridgeshire,E14000937
+ocd-division/country:uk/pcon:south_east_cornwall,South East Cornwall,E14000938
+ocd-division/country:uk/pcon:south_holland_and_the_deepings,South Holland and The Deepings,E14000939
+ocd-division/country:uk/pcon:south_leicestershire,South Leicestershire,E14000940
+ocd-division/country:uk/pcon:south_norfolk,South Norfolk,E14000941
+ocd-division/country:uk/pcon:southampton_itchen,"Southampton, Itchen",E14000955
+ocd-division/country:uk/pcon:southampton_test,"Southampton, Test",E14000956
+ocd-division/country:uk/pcon:southend_west,Southend West,E14000957
+ocd-division/country:uk/pcon:southport,Southport,E14000958
+ocd-division/country:uk/pcon:spelthorne,Spelthorne,E14000959
+ocd-division/country:uk/pcon:st_albans,St Albans,E14000960
+ocd-division/country:uk/pcon:st_austell_and_newquay,St Austell and Newquay,E14000961
+ocd-division/country:uk/pcon:st_helens_north,St Helens North,E14000962
+ocd-division/country:uk/pcon:st_helens_south_and_whiston,St Helens South and Whiston,E14000963
+ocd-division/country:uk/pcon:st_ives,St Ives,E14000964
+ocd-division/country:uk/pcon:stafford,Stafford,E14000965
+ocd-division/country:uk/pcon:staffordshire_moorlands,Staffordshire Moorlands,E14000966
+ocd-division/country:uk/pcon:stalybridge_and_hyde,Stalybridge and Hyde,E14000967
+ocd-division/country:uk/pcon:stevenage,Stevenage,E14000968
+ocd-division/country:uk/pcon:stockport,Stockport,E14000969
+ocd-division/country:uk/pcon:stockton_north,Stockton North,E14000970
+ocd-division/country:uk/pcon:stockton_south,Stockton South,E14000971
+ocd-division/country:uk/pcon:stoke-on-trent_central,Stoke-on-Trent Central,E14000972
+ocd-division/country:uk/pcon:stoke-on-trent_north,Stoke-on-Trent North,E14000973
+ocd-division/country:uk/pcon:stoke-on-trent_south,Stoke-on-Trent South,E14000974
+ocd-division/country:uk/pcon:stone,Stone,E14000975
+ocd-division/country:uk/pcon:stourbridge,Stourbridge,E14000976
+ocd-division/country:uk/pcon:stratford-on-avon,Stratford-on-Avon,E14000977
+ocd-division/country:uk/pcon:sutton_and_cheam,Sutton and Cheam,E14000984
+ocd-division/country:uk/pcon:sutton_coldfield,Sutton Coldfield,E14000985
+ocd-division/country:uk/pcon:tamworth,Tamworth,E14000986
+ocd-division/country:uk/pcon:tatton,Tatton,E14000987
+ocd-division/country:uk/pcon:taunton_deane,Taunton Deane,E14000988
+ocd-division/country:uk/pcon:telford,Telford,E14000989
+ocd-division/country:uk/pcon:tewkesbury,Tewkesbury,E14000990
+ocd-division/country:uk/pcon:the_cotswolds,The Cotswolds,E14000991
+ocd-division/country:uk/pcon:the_wrekin,The Wrekin,E14000992
+ocd-division/country:uk/pcon:thirsk_and_malton,Thirsk and Malton,E14000993
+ocd-division/country:uk/pcon:thornbury_and_yate,Thornbury and Yate,E14000994
+ocd-division/country:uk/pcon:thurrock,Thurrock,E14000995
+ocd-division/country:uk/pcon:tiverton_and_honiton,Tiverton and Honiton,E14000996
+ocd-division/country:uk/pcon:tonbridge_and_malling,Tonbridge and Malling,E14000997
+ocd-division/country:uk/pcon:tottenham,Tottenham,E14001002
+ocd-division/country:uk/pcon:truro_and_falmouth,Truro and Falmouth,E14001003
+ocd-division/country:uk/pcon:tunbridge_wells,Tunbridge Wells,E14001004
+ocd-division/country:uk/pcon:twickenham,Twickenham,E14001005
+ocd-division/country:uk/pcon:tynemouth,Tynemouth,E14001006
+ocd-division/country:uk/pcon:uxbridge_and_south_ruislip,Uxbridge and South Ruislip,E14001007
+ocd-division/country:uk/pcon:walsall_north,Walsall North,E14001011
+ocd-division/country:uk/pcon:walsall_south,Walsall South,E14001012
+ocd-division/country:uk/pcon:walthamstow,Walthamstow,E14001013
+ocd-division/country:uk/pcon:wansbeck,Wansbeck,E14001014
+ocd-division/country:uk/pcon:wantage,Wantage,E14001015
+ocd-division/country:uk/pcon:warley,Warley,E14001016
+ocd-division/country:uk/pcon:warrington_north,Warrington North,E14001017
+ocd-division/country:uk/pcon:warrington_south,Warrington South,E14001018
+ocd-division/country:uk/pcon:warwick_and_leamington,Warwick and Leamington,E14001019
+ocd-division/country:uk/pcon:washington_and_sunderland_west,Washington and Sunderland West,E14001020
+ocd-division/country:uk/pcon:watford,Watford,E14001021
+ocd-division/country:uk/pcon:waveney,Waveney,E14001022
+ocd-division/country:uk/pcon:wealden,Wealden,E14001023
+ocd-division/country:uk/pcon:weaver_vale,Weaver Vale,E14001024
+ocd-division/country:uk/pcon:wellingborough,Wellingborough,E14001025
+ocd-division/country:uk/pcon:wells,Wells,E14001026
+ocd-division/country:uk/pcon:welwyn_hatfield,Welwyn Hatfield,E14001027
+ocd-division/country:uk/pcon:wentworth_and_dearne,Wentworth and Dearne,E14001028
+ocd-division/country:uk/pcon:west_bromwich_east,West Bromwich East,E14001029
+ocd-division/country:uk/pcon:west_bromwich_west,West Bromwich West,E14001030
+ocd-division/country:uk/pcon:west_dorset,West Dorset,E14001031
+ocd-division/country:uk/pcon:west_ham,West Ham,E14001032
+ocd-division/country:uk/pcon:west_lancashire,West Lancashire,E14001033
+ocd-division/country:uk/pcon:west_suffolk,West Suffolk,E14001034
+ocd-division/country:uk/pcon:west_worcestershire,West Worcestershire,E14001035
+ocd-division/country:uk/pcon:westminster_north,Westminster North,E14001036
+ocd-division/country:uk/pcon:westmorland_and_lonsdale,Westmorland and Lonsdale,E14001037
+ocd-division/country:uk/pcon:weston-super-mare,Weston-Super-Mare,E14001038
+ocd-division/country:uk/pcon:wigan,Wigan,E14001039
+ocd-division/country:uk/pcon:wimbledon,Wimbledon,E14001040
+ocd-division/country:uk/pcon:winchester,Winchester,E14001041
+ocd-division/country:uk/pcon:windsor,Windsor,E14001042
+ocd-division/country:uk/pcon:wirral_south,Wirral South,E14001043
+ocd-division/country:uk/pcon:wirral_west,Wirral West,E14001044
+ocd-division/country:uk/pcon:witham,Witham,E14001045
+ocd-division/country:uk/pcon:witney,Witney,E14001046
+ocd-division/country:uk/pcon:woking,Woking,E14001047
+ocd-division/country:uk/pcon:wokingham,Wokingham,E14001048
+ocd-division/country:uk/pcon:wolverhampton_north_east,Wolverhampton North East,E14001049
+ocd-division/country:uk/pcon:wolverhampton_south_east,Wolverhampton South East,E14001050
+ocd-division/country:uk/pcon:wolverhampton_south_west,Wolverhampton South West,E14001051
+ocd-division/country:uk/pcon:worcester,Worcester,E14001052
+ocd-division/country:uk/pcon:workington,Workington,E14001053
+ocd-division/country:uk/pcon:worsley_and_eccles_south,Worsley and Eccles South,E14001054
+ocd-division/country:uk/pcon:worthing_west,Worthing West,E14001055
+ocd-division/country:uk/pcon:wycombe,Wycombe,E14001056
+ocd-division/country:uk/pcon:wyre_and_preston_north,Wyre and Preston North,E14001057
+ocd-division/country:uk/pcon:wyre_forest,Wyre Forest,E14001058
+ocd-division/country:uk/pcon:wythenshawe_and_sale_east,Wythenshawe and Sale East,E14001059
+ocd-division/country:uk/pcon:aberdeen_north,Aberdeen North,S14000001
+ocd-division/country:uk/pcon:aberdeen_south,Aberdeen South,S14000002
+ocd-division/country:uk/pcon:airdrie_and_shotts,Airdrie and Shotts,S14000003
+ocd-division/country:uk/pcon:angus,Angus,S14000004
+ocd-division/country:uk/pcon:argyll_and_bute,Argyll and Bute,S14000005
+ocd-division/country:uk/pcon:ayr_carrick_and_cumnock,"Ayr, Carrick and Cumnock",S14000006
+ocd-division/country:uk/pcon:banff_and_buchan,Banff and Buchan,S14000007
+ocd-division/country:uk/pcon:berwickshire_roxburgh_and_selkirk,"Berwickshire, Roxburgh and Selkirk",S14000008
+ocd-division/country:uk/pcon:caithness_sutherland_and_easter_ross,"Caithness, Sutherland and Easter Ross",S14000009
+ocd-division/country:uk/pcon:central_ayrshire,Central Ayrshire,S14000010
+ocd-division/country:uk/pcon:coatbridge_chryston_and_bellshill,"Coatbridge, Chryston and Bellshill",S14000011
+ocd-division/country:uk/pcon:cumbernauld_kilsyth_and_kirkintilloch_east,"Cumbernauld, Kilsyth and Kirkintilloch East",S14000012
+ocd-division/country:uk/pcon:dumfries_and_galloway,Dumfries and Galloway,S14000013
+ocd-division/country:uk/pcon:edinburgh_east,Edinburgh East,S14000022
+ocd-division/country:uk/pcon:edinburgh_south,Edinburgh South,S14000024
+ocd-division/country:uk/pcon:edinburgh_south_west,Edinburgh South West,S14000025
+ocd-division/country:uk/pcon:edinburgh_west,Edinburgh West,S14000026
+ocd-division/country:uk/pcon:na_h-eileanan_an_iar,Na h-Eileanan an Iar,S14000027
+ocd-division/country:uk/pcon:falkirk,Falkirk,S14000028
+ocd-division/country:uk/pcon:edinburgh_north_and_leith,Edinburgh North and Leith,S14000023
+ocd-division/country:uk/pcon:glasgow_central,Glasgow Central,S14000029
+ocd-division/country:uk/pcon:glasgow_north_east,Glasgow North East,S14000032
+ocd-division/country:uk/pcon:glasgow_east,Glasgow East,S14000030
+ocd-division/country:uk/pcon:alyn_and_deeside,Alyn and Deeside,W07000043
+ocd-division/country:uk/pcon:wrexham,Wrexham,W07000044
+ocd-division/country:uk/pcon:llanelli,Llanelli,W07000045
+ocd-division/country:uk/pcon:gower,Gower,W07000046
+ocd-division/country:uk/pcon:swansea_west,Swansea West,W07000047
+ocd-division/country:uk/pcon:swansea_east,Swansea East,W07000048
+ocd-division/country:uk/pcon:aberavon,Aberavon,W07000049
+ocd-division/country:uk/pcon:glasgow_north,Glasgow North,S14000031
+ocd-division/country:uk/pcon:glasgow_north_west,Glasgow North West,S14000033
+ocd-division/country:uk/pcon:cardiff_central,Cardiff Central,W07000050
+ocd-division/country:uk/pcon:cardiff_north,Cardiff North,W07000051
+ocd-division/country:uk/pcon:glasgow_south,Glasgow South,S14000034
+ocd-division/country:uk/pcon:rhondda,Rhondda,W07000052
+ocd-division/country:uk/pcon:torfaen,Torfaen,W07000053
+ocd-division/country:uk/pcon:monmouth,Monmouth,W07000054
+ocd-division/country:uk/pcon:newport_east,Newport East,W07000055
+ocd-division/country:uk/pcon:newport_west,Newport West,W07000056
+ocd-division/country:uk/pcon:arfon,Arfon,W07000057
+ocd-division/country:uk/pcon:aberconwy,Aberconwy,W07000058
+ocd-division/country:uk/pcon:clwyd_west,Clwyd West,W07000059
+ocd-division/country:uk/pcon:vale_of_clwyd,Vale of Clwyd,W07000060
+ocd-division/country:uk/pcon:dwyfor_meirionnydd,Dwyfor Meirionnydd,W07000061
+ocd-division/country:uk/pcon:clwyd_south,Clwyd South,W07000062
+ocd-division/country:uk/pcon:montgomeryshire,Montgomeryshire,W07000063
+ocd-division/country:uk/pcon:ceredigion,Ceredigion,W07000064
+ocd-division/country:uk/pcon:preseli_pembrokeshire,Preseli Pembrokeshire,W07000065
+ocd-division/country:uk/pcon:carmarthen_west_and_south_pembrokeshire,Carmarthen West and South Pembrokeshire,W07000066
+ocd-division/country:uk/pcon:carmarthen_east_and_dinefwr,Carmarthen East and Dinefwr,W07000067
+ocd-division/country:uk/pcon:brecon_and_radnorshire,Brecon and Radnorshire,W07000068
+ocd-division/country:uk/pcon:neath,Neath,W07000069
+ocd-division/country:uk/pcon:cynon_valley,Cynon Valley,W07000070
+ocd-division/country:uk/pcon:merthyr_tydfil_and_rhymney,Merthyr Tydfil and Rhymney,W07000071
+ocd-division/country:uk/pcon:blaenau_gwent,Blaenau Gwent,W07000072
+ocd-division/country:uk/pcon:glasgow_south_west,Glasgow South West,S14000035
+ocd-division/country:uk/pcon:glenrothes,Glenrothes,S14000036
+ocd-division/country:uk/pcon:gordon,Gordon,S14000037
+ocd-division/country:uk/pcon:inverclyde,Inverclyde,S14000038
+ocd-division/country:uk/pcon:inverness_nairn_badenoch_and_strathspey,"Inverness, Nairn, Badenoch and Strathspey",S14000039
+ocd-division/country:uk/pcon:kilmarnock_and_loudoun,Kilmarnock and Loudoun,S14000040
+ocd-division/country:uk/pcon:kirkcaldy_and_cowdenbeath,Kirkcaldy and Cowdenbeath,S14000041
+ocd-division/country:uk/pcon:lanark_and_hamilton_east,Lanark and Hamilton East,S14000042
+ocd-division/country:uk/pcon:linlithgow_and_east_falkirk,Linlithgow and East Falkirk,S14000043
+ocd-division/country:uk/pcon:livingston,Livingston,S14000044
+ocd-division/country:uk/pcon:midlothian,Midlothian,S14000045
+ocd-division/country:uk/pcon:moray,Moray,S14000046
+ocd-division/country:uk/pcon:motherwell_and_wishaw,Motherwell and Wishaw,S14000047
+ocd-division/country:uk/pcon:north_ayrshire_and_arran,North Ayrshire and Arran,S14000048
+ocd-division/country:uk/pcon:north_east_fife,North East Fife,S14000049
+ocd-division/country:uk/pcon:ochil_and_south_perthshire,Ochil and South Perthshire,S14000050
+ocd-division/country:uk/pcon:orkney_and_shetland,Orkney and Shetland,S14000051
+ocd-division/country:uk/pcon:paisley_and_renfrewshire_north,Paisley and Renfrewshire North,S14000052
+ocd-division/country:uk/pcon:paisley_and_renfrewshire_south,Paisley and Renfrewshire South,S14000053
+ocd-division/country:uk/pcon:perth_and_north_perthshire,Perth and North Perthshire,S14000054
+ocd-division/country:uk/pcon:ross_skye_and_lochaber,"Ross, Skye and Lochaber",S14000055
+ocd-division/country:uk/pcon:rutherglen_and_hamilton_west,Rutherglen and Hamilton West,S14000056
+ocd-division/country:uk/pcon:stirling,Stirling,S14000057
+ocd-division/country:uk/pcon:west_aberdeenshire_and_kincardine,West Aberdeenshire and Kincardine,S14000058
+ocd-division/country:uk/pcon:west_dunbartonshire,West Dunbartonshire,S14000059
+ocd-division/country:uk/pcon:ynys_mon,Ynys Mon,W07000041
+ocd-division/country:uk/pcon:delyn,Delyn,W07000042

--- a/scripts/country-uk/README.md
+++ b/scripts/country-uk/README.md
@@ -1,0 +1,23 @@
+# Open Civic Data Divisions: UK
+
+## Build
+
+```
+./scripts/country-uk/build.py
+./scripts/compile.py uk
+```
+
+## Division Types
+
+* `pcon`: UK Parliament Consitituencies
+* `spc`: Scottish Parliament Consitituencies
+* `spr`: Scottish Parliament Regions
+* `nawc`: National Assembly for Wales Consitituencies
+* `nawr`: National Assembly for Wales Regions
+* `cauth`: Combined Authorities
+* `pfa`: Police Force Areas
+
+## Notes
+
+* Data is sourced from the UK's [Office for National Statistics](https://www.ons.gov.uk/)
+* All areas have an OCD identifier and a [GSS code](https://en.wikipedia.org/wiki/ONS_coding_system#Current_GSS_coding_system)

--- a/scripts/country-uk/build.py
+++ b/scripts/country-uk/build.py
@@ -1,0 +1,5 @@
+from functions import make_csv_for_area_type
+from data import area_types
+
+for area_type in area_types:
+    make_csv_for_area_type(**area_type)

--- a/scripts/country-uk/build.py
+++ b/scripts/country-uk/build.py
@@ -1,5 +1,12 @@
+#!/usr/bin/env python3
+import sys
 from functions import make_csv_for_area_type
 from data import area_types
+
+
+if sys.version_info < (3, 0):
+    sys.stdout.write("Python 2.x not supported.\n")
+    sys.exit(1)
 
 for area_type in area_types:
     make_csv_for_area_type(**area_type)

--- a/scripts/country-uk/data.py
+++ b/scripts/country-uk/data.py
@@ -1,0 +1,89 @@
+# The UK Parliament (House of Commons) has members at consitituency level
+# in England, Wales, Scotland and Northern Ireland
+pcon = {
+    # data from: http://geoportal.statistics.gov.uk/datasets/westminster-parliamentary-constituencies-december-2017-full-extent-boundaries-in-the-uk-wgs84
+    'url': 'https://opendata.arcgis.com/datasets/5c582cef61d04618928639dd17e4f896_1.csv',
+    'gss_column': 'pcon17cd',
+    'name_column': 'pcon17nm',
+    'prefix': 'pcon',
+    'filename': 'uk_parliament_consitituencies.csv'
+}
+
+
+# The Scottish Parliament has members at both consitituency and regional levels
+spc = {
+    # data from: http://geoportal.statistics.gov.uk/datasets/scottish-parliamentary-constituencies-may-2016-full-extent-boundaries-in-scotland
+    'url': 'https://opendata.arcgis.com/datasets/00436d85fa664f0fb7dce4a1aff83f27_1.csv',
+    'gss_column': 'spc16cd',
+    'name_column': 'spc16nm',
+    'prefix': 'spc',
+    'filename': 'scottish_parliament_consitituencies.csv'
+}
+spr = {
+    # data from: http://geoportal.statistics.gov.uk/datasets/scottish-parliamentary-regions-may-2016-full-extent-boundaries-in-scotland
+    'url': 'https://opendata.arcgis.com/datasets/c890fc7b1ad14311bb71660ec6524c9e_1.csv',
+    'gss_column': 'spr16cd',
+    'name_column': 'spr16nm',
+    'prefix': 'spr',
+    'filename': 'scottish_parliament_regions.csv'
+}
+
+
+# The National Assembly for Wales has members
+# at both consitituency and regional levels
+nawc = {
+    # data from: http://geoportal.statistics.gov.uk/datasets/national-assembly-for-wales-constituencies-december-2017-wa-bfe
+    'url': 'https://opendata.arcgis.com/datasets/7a4dc40d6c9e4abf8d2fa3b369395d93_1.csv',
+    'gss_column': 'nawc17cd',
+    'name_column': 'nawc17nm',
+    'prefix': 'nawc',
+    'filename': 'naw_consitituencies.csv'
+}
+nawr = {
+    # data from: http://geoportal.statistics.gov.uk/datasets/national-assembly-for-wales-electoral-regions-december-2017-wa-bfe
+    'url': 'https://opendata.arcgis.com/datasets/d10026914aa64c4cadcfafad73f81bf7_1.csv',
+    'gss_column': 'nawer17cd',
+    'name_column': 'nawer17nm',
+    'prefix': 'nawr',
+    'filename': 'naw_regions.csv'
+}
+
+
+# Combined Authorities have a directly elected regional Mayor
+cauth = {
+    # data from: http://geoportal.statistics.gov.uk/datasets/combined-authorities-march-2017-full-extent-boundaries-in-england
+    'url': 'https://opendata.arcgis.com/datasets/89f12fc184d045a1a7ca9dd14fb4df3e_1.csv',
+    'gss_column': 'cauth17cd',
+    'name_column': 'cauth17nm',
+    'prefix': 'cauth',
+    'filename': 'combined_authorities.csv'
+}
+
+
+# Most Police Force areas in England and Wales have a
+# directly elected Police & Crime Commissioner
+pfa = {
+    # data from: http://geoportal.statistics.gov.uk/datasets/police-force-areas-december-2017-ew-bfe
+    'url': 'https://opendata.arcgis.com/datasets/bb12117b37134a03874c55175cf7f4bc_1.csv',
+    'gss_column': 'pfa17cd',
+    'name_column': 'pfa17nm',
+    'prefix': 'pfa',
+    'filename': 'police_force_areas.csv',
+    'exclude': [
+        # These areas don't elect a Police & Crime Commissioner:
+        'E23000001',  # Metropolitan Police
+        'E23000005',  # Greater Manchester
+        'E23000034',  # City of London
+    ]
+}
+
+
+area_types = [
+    pcon,
+    spc,
+    spr,
+    nawc,
+    nawr,
+    cauth,
+    pfa
+]

--- a/scripts/country-uk/functions.py
+++ b/scripts/country-uk/functions.py
@@ -1,0 +1,85 @@
+import csv
+import os
+import re
+import tempfile
+import urllib.request
+
+
+def get_csv_data(url):
+    tmp = tempfile.NamedTemporaryFile()
+    urllib.request.urlretrieve(url, tmp.name)
+    # utf-8-sig is important here because CSV files from ONS
+    # start with a Byte Order Mark character
+    f = open(tmp.name, 'rt', encoding='utf-8-sig')
+    reader = csv.DictReader(f, delimiter=',')
+    return list(reader)
+
+
+def write_csv(filename, csv_columns, dict_data):
+    with open(filename, 'w') as csv_file:
+        writer = csv.DictWriter(csv_file, fieldnames=csv_columns)
+        writer.writeheader()
+        for data in dict_data:
+            writer.writerow(data)
+
+
+def make_slug(name):
+    slug = name.lower()
+
+    # Make a couple of substitutions so we generate slightly nicer slugs:
+    # Strip away any dots or commas
+    slug = slug.replace('.', '').replace(',', '')
+
+    """
+    Replace '&' character with the word 'and'.
+
+    It is quite a common pattern for UK Electoral divisions
+    to have a name of the form 'This Place and That Place'
+    e.g: 'Bath and North East Somerset'
+
+    The word 'and' and the amphersand character are used inconsistently so
+    this will sometimes be written 'Bath and North East Somerset'
+    and sometimes 'Bath & North East Somerset'.
+
+    For the purpose of generating nicer slugs which are easier to read,
+    we'll standardise them all to use 'and' here.
+    """
+    slug = slug.replace('&', 'and')
+
+    # Follow OCD slugging rules:
+    slug = re.sub('\.? ', '_', slug)
+    slug = re.sub('[^\w0-9~_.-]', '~', slug, re.UNICODE)
+    return slug
+
+
+def make_id(prefix, name):
+    return 'ocd-division/country:uk/{prefix}:{slug}'.format(
+        prefix=prefix,
+        slug=make_slug(name)
+    )
+
+
+def make_csv_for_area_type(url, gss_column, name_column, prefix, filename, exclude=[]):
+    in_rows = get_csv_data(url)
+    out_rows = []
+
+    for in_row in in_rows:
+        out_row = {}
+        out_row['id'] = make_id(prefix, in_row[name_column])
+        out_row['name'] = in_row[name_column]
+        out_row['gss_code'] = in_row[gss_column]
+        if out_row['gss_code'] in exclude:
+            continue
+        out_rows.append(out_row)
+
+    directory = os.path.abspath(
+        os.path.join(os.path.dirname(__file__), '../../identifiers/country-uk')
+    )
+    if not os.path.exists(directory):
+        os.makedirs(directory)
+
+    write_csv(
+        os.path.abspath(os.path.join(directory, filename)),
+        ['id', 'name', 'gss_code'],
+        out_rows
+    )


### PR DESCRIPTION
This follows on from the conversation started in #152

**Done in this PR:**

I've started off by adding scripts to create ids from ONS data for:

* UK Parliament Consitituencies
* Scottish Parliament Consitituencies
* Scottish Parliament Regions
* National Assembly for Wales Consitituencies
* National Assembly for Wales Regions
* Combined Authorities
* Police Force Areas

I look forward to review/feedback on this.

**Possible Future Work:**

1. Ongoing maintenance

Inevitably at some point there will be changes to these divisions which we need to account for. The next substantial legislative change to impact these divisions is likely to be this review of UK Parliamentary Consitituencies:

* https://boundarycommissionforengland.independent.gov.uk/2018-review/
* https://en.wikipedia.org/wiki/Sixth_Periodic_Review_of_Westminster_constituencies

I'm happy to keep on top of this moving forwards.

2. GSS Code changes

At the moment everything has a _current_ GSS code. These boundaries are relatively stable and change quite infrequently, but many of the divisions in this dataset have had boundary changes at some point and hence it is useful to be able to map a division to >1 GSS codes based on a date range.

I have not attempted to deal with that here but I may look at using the [Code History Database](https://www.ons.gov.uk/methodology/geography/geographicalproducts/namescodesandlookups/codehistorydatabasechd) to do this as future work.

3. Add more division ids

As discussed in #152 there is a large body of division identifiers (mainly relevant to local elections) which have some additional complexity. Lets review the best way to manage them in light of future interest/use-cases.