### PR TITLE
Add the EU as a region and update the compile script it.

### DIFF
--- a/identifiers/country-eu.csv
+++ b/identifiers/country-eu.csv
@@ -1,0 +1,30 @@
+id,name
+ocd-division/country:at,Austria
+ocd-division/country:be,Belgium
+ocd-division/country:bg,Bulgaria
+ocd-division/country:cy,Cyprus
+ocd-division/country:cz,Czechia
+ocd-division/country:de,Germany
+ocd-division/country:dk,Denmark
+ocd-division/country:ee,Estonia
+ocd-division/country:es,Spain
+ocd-division/country:fi,Finland
+ocd-division/country:fr,France
+ocd-division/country:gr,Greece
+ocd-division/country:hr,Croatia
+ocd-division/country:hu,Hungary
+ocd-division/country:ie,Ireland
+ocd-division/country:it,Italy
+ocd-division/country:lt,Lithuania
+ocd-division/country:lu,Luxembourg
+ocd-division/country:lv,Latvia
+ocd-division/country:mt,Malta
+ocd-division/country:nl,Netherlands
+ocd-division/country:pl,Poland
+ocd-division/country:pt,Portugal
+ocd-division/country:ro,Romania
+ocd-division/country:se,Sweden
+ocd-division/country:si,Slovenia
+ocd-division/country:sk,Slovakia
+ocd-division/country:uk,United Kingdom
+ocd-division/region:eu,European Union

--- a/identifiers/country-eu/countries.csv
+++ b/identifiers/country-eu/countries.csv
@@ -1,0 +1,30 @@
+id,name
+ocd-division/region:eu,European Union
+ocd-division/country:at,Austria
+ocd-division/country:be,Belgium
+ocd-division/country:bg,Bulgaria
+ocd-division/country:cy,Cyprus
+ocd-division/country:cz,Czechia
+ocd-division/country:de,Germany
+ocd-division/country:dk,Denmark
+ocd-division/country:ee,Estonia
+ocd-division/country:es,Spain
+ocd-division/country:fi,Finland
+ocd-division/country:fr,France
+ocd-division/country:gr,Greece
+ocd-division/country:hr,Croatia
+ocd-division/country:hu,Hungary
+ocd-division/country:ie,Ireland
+ocd-division/country:it,Italy
+ocd-division/country:lt,Lithuania
+ocd-division/country:lu,Luxembourg
+ocd-division/country:lv,Latvia
+ocd-division/country:mt,Malta
+ocd-division/country:nl,Netherlands
+ocd-division/country:pl,Poland
+ocd-division/country:pt,Portugal
+ocd-division/country:ro,Romania
+ocd-division/country:se,Sweden
+ocd-division/country:si,Slovenia
+ocd-division/country:sk,Slovakia
+ocd-division/country:uk,United Kingdom

--- a/scripts/compile.py
+++ b/scripts/compile.py
@@ -18,7 +18,7 @@ if sys.version_info < (3, 0):
 
 
 def validate_id(id_):
-    id_regex = re.compile(r'^ocd-division/country:[a-z]{2}(/[^\W\d]+:[\w.~-]+)*$', re.U)
+    id_regex = re.compile(r'^ocd-division/(country|region):[a-z]{2}(/[^\W\d]+:[\w.~-]+)*$', re.U)
     if not (id_regex.match(id_) and id_.lower() == id_):
         raise ValueError('invalid id: ' + id_)
 


### PR DESCRIPTION
This adds the EU as a "country" in the directory structure, but as a `region` in OCD-ID parlance. The European Parliament also has its own constituencies: https://en.wikipedia.org/wiki/European_Parliament_constituency

Eventually the plan is to add those, but for now we'll just add the countries which are part of the EU.

This also updates the compile script to allow `region` as a top-level tag, in addition to `country`.