### PR TITLE
Updates type for LA metro sectors IDs (la_metro_sector)

### DIFF
--- a/identifiers/country-us/state-ca-local_gov.csv
+++ b/identifiers/country-us/state-ca-local_gov.csv
@@ -100,10 +100,10 @@ ocd-division/country:us/state:ca/county:los_angeles/school_board_district:4,Los 
 ocd-division/country:us/state:ca/county:los_angeles/school_board_district:5,Los Angeles CA Unified School Board district 5
 ocd-division/country:us/state:ca/county:los_angeles/school_board_district:6,Los Angeles CA Unified School Board district 6
 ocd-division/country:us/state:ca/county:los_angeles/school_board_district:7,Los Angeles CA Unified School Board district 7
-ocd-division/country:us/state:ca/county:los_angeles/la_metro_sector:san_gabriel_valley,Los Angeles CA county supervisor San Gabriel Valley
-ocd-division/country:us/state:ca/county:los_angeles/la_metro_sector:southeast_long_beach,Los Angeles CA county supervisor Southeast Long Beach
-ocd-division/country:us/state:ca/county:los_angeles/la_metro_sector:southwest_corridor,Los Angeles CA county supervisor Southwest Corridor
-ocd-division/country:us/state:ca/county:los_angeles/la_metro_sector:north_county_san_fernando_valley,Los Angeles CA county supervisor North County/San Fernando Valley
+ocd-division/country:us/state:ca/county:los_angeles/transit:san_gabriel_valley,Los Angeles CA county supervisor San Gabriel Valley
+ocd-division/country:us/state:ca/county:los_angeles/transit:southeast_long_beach,Los Angeles CA county supervisor Southeast Long Beach
+ocd-division/country:us/state:ca/county:los_angeles/transit:southwest_corridor,Los Angeles CA county supervisor Southwest Corridor
+ocd-division/country:us/state:ca/county:los_angeles/transit:north_county_san_fernando_valley,Los Angeles CA county supervisor North County/San Fernando Valley
 ocd-division/country:us/state:ca/county:madera/council_district:1,Madera County Supervisor District 1
 ocd-division/country:us/state:ca/county:madera/council_district:2,Madera County Supervisor District 2
 ocd-division/country:us/state:ca/county:madera/council_district:3,Madera County Supervisor District 3


### PR DESCRIPTION
There were 4 IDs introduced in https://github.com/opencivicdata/ocd-division-ids/pull/139 which contain OCD ID types (`la_metro_sector`) that are specific to one region, and therefore conceptually invalid. The OCD ID type should only provide the nature of the district, while the value should provide the specific location. 

I'd like to propose updating these IDs to instead use type `transit`. These districts appear to refer to service areas of the LA county metro system (https://media.metro.net/about_us/service_sectors/images/map_service_councils.pdf), therefore the generic type `transit` seems most suitable.