### PR TITLE
Update NZ ValidTo and ValidFrom due to change in election dates.

### DIFF
--- a/identifiers/country-nz.csv
+++ b/identifiers/country-nz.csv
@@ -1,32 +1,32 @@
 id,name,validFrom,validTo
 ocd-division/country:nz,New Zealand,,
 ocd-division/country:nz/general_electorate:auckland_central,Auckland Central,,
-ocd-division/country:nz/general_electorate:banks_peninsula,Banks Peninsula,2020-09-19,
+ocd-division/country:nz/general_electorate:banks_peninsula,Banks Peninsula,2020-10-17,
 ocd-division/country:nz/general_electorate:bay_of_plenty,Bay of Plenty,,
 ocd-division/country:nz/general_electorate:botany,Botany,,
 ocd-division/country:nz/general_electorate:christchurch_central,Christchurch Central,,
 ocd-division/country:nz/general_electorate:christchurch_east,Christchurch East,,
-ocd-division/country:nz/general_electorate:clutha-southland,Clutha-Southland,,2020-09-18
+ocd-division/country:nz/general_electorate:clutha-southland,Clutha-Southland,,2020-10-16
 ocd-division/country:nz/general_electorate:coromandel,Coromandel,,
-ocd-division/country:nz/general_electorate:dunedin,Dunedin,2020-09-19,
-ocd-division/country:nz/general_electorate:dunedin_north,Dunedin North,,2020-09-18
-ocd-division/country:nz/general_electorate:dunedin_south,Dunedin South,,2020-09-18
+ocd-division/country:nz/general_electorate:dunedin,Dunedin,2020-10-17,
+ocd-division/country:nz/general_electorate:dunedin_north,Dunedin North,,2020-10-16
+ocd-division/country:nz/general_electorate:dunedin_south,Dunedin South,,2020-10-16
 ocd-division/country:nz/general_electorate:east_coast,East Coast,,
 ocd-division/country:nz/general_electorate:east_coast_bays,East Coast Bays,,
 ocd-division/country:nz/general_electorate:epsom,Epsom,,
 ocd-division/country:nz/general_electorate:hamilton_east,Hamilton East,,
 ocd-division/country:nz/general_electorate:hamilton_west,Hamilton West,,
-ocd-division/country:nz/general_electorate:helensville,Helensville,,2020-09-18
-ocd-division/country:nz/general_electorate:hunua,Hunua,,2020-09-18
+ocd-division/country:nz/general_electorate:helensville,Helensville,,2020-10-16
+ocd-division/country:nz/general_electorate:hunua,Hunua,,2020-10-16
 ocd-division/country:nz/general_electorate:hutt_south,Hutt South,,
 ocd-division/country:nz/general_electorate:ilam,Ilam,,
 ocd-division/country:nz/general_electorate:invercargill,Invercargill,,
 ocd-division/country:nz/general_electorate:kaikoura,Kaikoura,,
-ocd-division/country:nz/general_electorate:kaipara_ki_mahurangi,Kaipara Ki Mahurangi,2020-09-19,
+ocd-division/country:nz/general_electorate:kaipara_ki_mahurangi,Kaipara Ki Mahurangi,2020-10-17,
 ocd-division/country:nz/general_electorate:kelston,Kelston,,
 ocd-division/country:nz/general_electorate:mana,Mana,,
 ocd-division/country:nz/general_electorate:mangere,Mangere,,
-ocd-division/country:nz/general_electorate:manukau_east,Manukau East,,2020-09-18
+ocd-division/country:nz/general_electorate:manukau_east,Manukau East,,2020-10-16
 ocd-division/country:nz/general_electorate:manurewa,Manurewa,,
 ocd-division/country:nz/general_electorate:maungakiekie,Maungakiekie,,
 ocd-division/country:nz/general_electorate:mt_albert,Mt Albert,,
@@ -42,21 +42,21 @@ ocd-division/country:nz/general_electorate:ohariu,Ohariu,,
 ocd-division/country:nz/general_electorate:otaki,Otaki,,
 ocd-division/country:nz/general_electorate:pakuranga,Pakuranga,,
 ocd-division/country:nz/general_electorate:palmerston_north,Palmerston North,,
-ocd-division/country:nz/general_electorate:panmure-otahuhu,Panmure-Otahuhu,2020-09-19,
+ocd-division/country:nz/general_electorate:panmure-otahuhu,Panmure-Otahuhu,2020-10-17,
 ocd-division/country:nz/general_electorate:papakura,Papakura,,
-ocd-division/country:nz/general_electorate:port_hills,Port Hills,,2020-09-18
-ocd-division/country:nz/general_electorate:port_waikato,Port Waikato,2020-09-19,
+ocd-division/country:nz/general_electorate:port_hills,Port Hills,,2020-10-16
+ocd-division/country:nz/general_electorate:port_waikato,Port Waikato,2020-10-17,
 ocd-division/country:nz/general_electorate:rangitata,Rangitata,,
 ocd-division/country:nz/general_electorate:rangitikei,Rangitikei,,
-ocd-division/country:nz/general_electorate:remutaka,Remutaka,2020-09-19,
-ocd-division/country:nz/general_electorate:rimutaka,Rimutaka,,2020-09-18
-ocd-division/country:nz/general_electorate:rodney,Rodney,,2020-09-18
+ocd-division/country:nz/general_electorate:remutaka,Remutaka,2020-10-17,
+ocd-division/country:nz/general_electorate:rimutaka,Rimutaka,,2020-10-16
+ocd-division/country:nz/general_electorate:rodney,Rodney,,2020-10-16
 ocd-division/country:nz/general_electorate:rongotai,Rongotai,,
 ocd-division/country:nz/general_electorate:rotorua,Rotorua,,
 ocd-division/country:nz/general_electorate:selwyn,Selwyn,,
-ocd-division/country:nz/general_electorate:southland,Southland,2020-09-19,
-ocd-division/country:nz/general_electorate:taieri,Taieri,2020-09-19,
-ocd-division/country:nz/general_electorate:takanini,Takanini,2020-09-19,
+ocd-division/country:nz/general_electorate:southland,Southland,2020-10-17,
+ocd-division/country:nz/general_electorate:taieri,Taieri,2020-10-17,
+ocd-division/country:nz/general_electorate:takanini,Takanini,2020-10-17,
 ocd-division/country:nz/general_electorate:tamaki,Tamaki,,
 ocd-division/country:nz/general_electorate:taranaki-king_country,Taranaki-King Country,,
 ocd-division/country:nz/general_electorate:taupo,Taupo,,
@@ -71,7 +71,7 @@ ocd-division/country:nz/general_electorate:waitaki,Waitaki,,
 ocd-division/country:nz/general_electorate:wellington_central,Wellington Central,,
 ocd-division/country:nz/general_electorate:west_coast-tasman,West Coast-Tasman,,
 ocd-division/country:nz/general_electorate:whanganui,Whanganui,,
-ocd-division/country:nz/general_electorate:whangaparaoa,Whangaparaoa,2020-09-19,
+ocd-division/country:nz/general_electorate:whangaparaoa,Whangaparaoa,2020-10-17,
 ocd-division/country:nz/general_electorate:whangarei,Whangarei,,
 ocd-division/country:nz/general_electorate:wigram,Wigram,,
 ocd-division/country:nz/maori_electorate:hauraki-waikato,Hauraki-Waikato,,

--- a/identifiers/country-nz/parliament_electorates.csv
+++ b/identifiers/country-nz/parliament_electorates.csv
@@ -5,22 +5,22 @@ ocd-division/country:nz/general_electorate:bay_of_plenty,Bay of Plenty,,
 ocd-division/country:nz/general_electorate:botany,Botany,,
 ocd-division/country:nz/general_electorate:christchurch_central,Christchurch Central,,
 ocd-division/country:nz/general_electorate:christchurch_east,Christchurch East,,
-ocd-division/country:nz/general_electorate:clutha-southland,Clutha-Southland,,2020-09-18
-ocd-division/country:nz/general_electorate:southland,Southland,2020-09-19,
+ocd-division/country:nz/general_electorate:clutha-southland,Clutha-Southland,,2020-10-16
+ocd-division/country:nz/general_electorate:southland,Southland,2020-10-17,
 ocd-division/country:nz/general_electorate:coromandel,Coromandel,,
-ocd-division/country:nz/general_electorate:dunedin_north,Dunedin North,,2020-09-18
-ocd-division/country:nz/general_electorate:dunedin_south,Dunedin South,,2020-09-18
-ocd-division/country:nz/general_electorate:dunedin,Dunedin,2020-09-19,
-ocd-division/country:nz/general_electorate:taieri,Taieri,2020-09-19,
+ocd-division/country:nz/general_electorate:dunedin_north,Dunedin North,,2020-10-16
+ocd-division/country:nz/general_electorate:dunedin_south,Dunedin South,,2020-10-16
+ocd-division/country:nz/general_electorate:dunedin,Dunedin,2020-10-17,
+ocd-division/country:nz/general_electorate:taieri,Taieri,2020-10-17,
 ocd-division/country:nz/general_electorate:east_coast,East Coast,,
 ocd-division/country:nz/general_electorate:east_coast_bays,East Coast Bays,,
 ocd-division/country:nz/general_electorate:epsom,Epsom,,
 ocd-division/country:nz/general_electorate:hamilton_east,Hamilton East,,
 ocd-division/country:nz/general_electorate:hamilton_west,Hamilton West,,
-ocd-division/country:nz/general_electorate:helensville,Helensville,,2020-09-18
-ocd-division/country:nz/general_electorate:kaipara_ki_mahurangi,Kaipara Ki Mahurangi,2020-09-19,
-ocd-division/country:nz/general_electorate:hunua,Hunua,,2020-09-18
-ocd-division/country:nz/general_electorate:port_waikato,Port Waikato,2020-09-19,
+ocd-division/country:nz/general_electorate:helensville,Helensville,,2020-10-16
+ocd-division/country:nz/general_electorate:kaipara_ki_mahurangi,Kaipara Ki Mahurangi,2020-10-17,
+ocd-division/country:nz/general_electorate:hunua,Hunua,,2020-10-16
+ocd-division/country:nz/general_electorate:port_waikato,Port Waikato,2020-10-17,
 ocd-division/country:nz/general_electorate:hutt_south,Hutt South,,
 ocd-division/country:nz/general_electorate:ilam,Ilam,,
 ocd-division/country:nz/general_electorate:invercargill,Invercargill,,
@@ -28,8 +28,8 @@ ocd-division/country:nz/general_electorate:kaikoura,Kaikoura,,
 ocd-division/country:nz/general_electorate:kelston,Kelston,,
 ocd-division/country:nz/general_electorate:mana,Mana,,
 ocd-division/country:nz/general_electorate:mangere,Mangere,,
-ocd-division/country:nz/general_electorate:manukau_east,Manukau East,,2020-09-18
-ocd-division/country:nz/general_electorate:panmure-otahuhu,Panmure-Otahuhu,2020-09-19,
+ocd-division/country:nz/general_electorate:manukau_east,Manukau East,,2020-10-16
+ocd-division/country:nz/general_electorate:panmure-otahuhu,Panmure-Otahuhu,2020-10-17,
 ocd-division/country:nz/general_electorate:manurewa,Manurewa,,
 ocd-division/country:nz/general_electorate:maungakiekie,Maungakiekie,,
 ocd-division/country:nz/general_electorate:mt_albert,Mt Albert,,
@@ -46,18 +46,18 @@ ocd-division/country:nz/general_electorate:otaki,Otaki,,
 ocd-division/country:nz/general_electorate:pakuranga,Pakuranga,,
 ocd-division/country:nz/general_electorate:palmerston_north,Palmerston North,,
 ocd-division/country:nz/general_electorate:papakura,Papakura,,
-ocd-division/country:nz/general_electorate:port_hills,Port Hills,,2020-09-18
-ocd-division/country:nz/general_electorate:banks_peninsula,Banks Peninsula,2020-09-19,
+ocd-division/country:nz/general_electorate:port_hills,Port Hills,,2020-10-16
+ocd-division/country:nz/general_electorate:banks_peninsula,Banks Peninsula,2020-10-17,
 ocd-division/country:nz/general_electorate:rangitata,Rangitata,,
 ocd-division/country:nz/general_electorate:rangitikei,Rangitikei,,
-ocd-division/country:nz/general_electorate:rimutaka,Rimutaka,,2020-09-18
-ocd-division/country:nz/general_electorate:remutaka,Remutaka,2020-09-19,
-ocd-division/country:nz/general_electorate:rodney,Rodney,,2020-09-18
-ocd-division/country:nz/general_electorate:whangaparaoa,Whangaparaoa,2020-09-19,
+ocd-division/country:nz/general_electorate:rimutaka,Rimutaka,,2020-10-16
+ocd-division/country:nz/general_electorate:remutaka,Remutaka,2020-10-17,
+ocd-division/country:nz/general_electorate:rodney,Rodney,,2020-10-16
+ocd-division/country:nz/general_electorate:whangaparaoa,Whangaparaoa,2020-10-17,
 ocd-division/country:nz/general_electorate:rongotai,Rongotai,,
 ocd-division/country:nz/general_electorate:rotorua,Rotorua,,
 ocd-division/country:nz/general_electorate:selwyn,Selwyn,,
-ocd-division/country:nz/general_electorate:takanini,Takanini,2020-09-19,
+ocd-division/country:nz/general_electorate:takanini,Takanini,2020-10-17,
 ocd-division/country:nz/general_electorate:tamaki,Tamaki,,
 ocd-division/country:nz/general_electorate:taranaki-king_country,Taranaki-King Country,,
 ocd-division/country:nz/general_electorate:taupo,Taupo,,


### PR DESCRIPTION
New Zealand postponed the election dates, hence the ValidFrom for new constituencies should follow.

Source: https://www.bbc.com/news/world-asia-53796434