### PR TITLE
Add test that checks if updates have been compiled

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *swp
 cache/*
 __pycache__
+bazel-*

--- a/BUILD
+++ b/BUILD
@@ -1,0 +1,8 @@
+py_test(
+    name = "compile_test",
+    srcs = ["test/compile_test.py"],
+    data = glob([
+        "identifiers/**/*.csv",
+    ]) + ["scripts/compile.py"],
+    main = "test/compile_test.py",
+)

--- a/README.md
+++ b/README.md
@@ -3,3 +3,9 @@
 The goal of this project is to assign somewhat predictable and globally unique identifiers to political divisions.
 
 The canonical documentation of OCD-IDs is expressed as [OCDEP 2: Open Civic Data Divisions](http://docs.opencivicdata.org/en/latest/proposals/0002.html).
+
+Tests can be run with [Bazel](https://bazel.build/):
+
+```
+$ bazel test :all --test_output=errors
+```

--- a/scripts/compile.py
+++ b/scripts/compile.py
@@ -78,6 +78,7 @@ COUNTRY_UNIQUE_FIELDS = {
 def main():
     parser = argparse.ArgumentParser(description='combine component CSV files into one')
     parser.add_argument('country', type=str, default=None, help='country to compile')
+    parser.add_argument('--output_csv', type=str, default=None, help='output location for compiled csv')
     args = parser.parse_args()
     country = args.country.lower()
 
@@ -220,7 +221,7 @@ def main():
     field_order += sorted(all_keys)
 
     # write output file
-    output_file = 'identifiers/country-{}.csv'.format(country)
+    output_file = args.output_csv or 'identifiers/country-{}.csv'.format(country)
     print('writing', output_file)
     with open(output_file, 'w') as out:
         out = csv.DictWriter(out, fieldnames=field_order)

--- a/test/compile_test.py
+++ b/test/compile_test.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+
+# Run this test from the root of the repository, as:
+# $ bazel test :all --test_output=errors
+
+import difflib
+import os
+import re
+import subprocess
+import unittest
+
+
+class TestSourcesMatchCommittedCSV(unittest.TestCase):
+  """Check that what's committed matches the output of the compiler.
+
+  Any change to this repository that modifies sources for some country's data
+  (the stuff in identifiers/*/*.csv) should also modify the corresponding
+  compiled output (identifiers/country-??.csv), such that they match.
+
+  This test runs the compiler, and compares its output to what's been
+  committed, ensuring they are equal. If this test fails, you need to re-run
+  the compiler for your country, and commit the result.
+  """
+
+  def get_committed_and_compiled_data(self, country_code):
+    # Read what's in the repo.
+    committed_csv_path = F'identifiers/country-{country_code}.csv'
+    try:
+      with open(committed_csv_path, 'r') as committed_file:
+        committed_csv = committed_file.read()
+    except FileNotFoundError:
+      # In the case that the commited csv file does not exist, we treat it as an
+      # empty string.
+      committed_csv = ''
+
+    # Run the compiler with temp output.
+    compiler_output_path = os.path.join(os.getenv('TEST_TMPDIR'), F"out-{country_code}.csv")
+    subprocess.run([
+        './scripts/compile.py', F'--output_csv={compiler_output_path}', country_code
+    ], check=True)
+
+    # Read the output of the compiler.
+    with open(compiler_output_path, 'r') as compiler_output_file:
+      compiler_output = compiler_output_file.read()
+
+    return committed_csv, compiler_output
+
+  def test_all_countries(self):
+    _, csv_source_dirs, _ = list(os.walk('identifiers'))[0]
+    mismatches = []
+    for dirname in csv_source_dirs:
+      # Ignore any files that don't match the expected pattern.
+      m = re.match(r'country-(..)', dirname)
+      if m:
+        country_code = m.group(1)
+        committed_csv, compiler_output = self.get_committed_and_compiled_data(
+            country_code)
+        if committed_csv != compiler_output:
+          mismatches.append(country_code)
+    # Rather than assert as we go, which would bail out on the first failure, we
+    # compile a list of all the mismatching countries, and print a message that
+    # summarizes what to do.
+    error_msg = ('The following countries must be recompiled to match their '
+                 'source files:\n  ' + '\n  '.join(mismatches) +
+                 '\n\nPlease run the following commands to rebuild:\n  ' +
+                 '\n  '.join([f'./scripts/compile.py {cc}' for cc in mismatches]))
+    self.assertEqual(mismatches, [], error_msg)
+
+
+if __name__ == '__main__':
+  unittest.main()


### PR DESCRIPTION
The new test can be run with Bazel, from the root of the repository:

```
$ bazel test :all --test_output=errors
```

Any change to this repository that modifies sources for some country's data (the stuff in `identifiers/*/*.csv`) should also modify the corresponding compiled output (`identifiers/country-??.csv`), such that they match.

This test runs the compiler for every country, and compares its output to what's been committed, ensuring they are equal. If this test fails, you need to re-run the compiler for your country, and commit the result.

The test currently fails for countries `mt`, `co`, and `au`. We can follow up with fixes to the data to make the test pass.

Sample output of the test can be seen at https://gist.github.com/jrunningen/4e59a37f83bcf099011e63029176ac8a