### PR TITLE
Add Github action to run tests for pushes and pull requests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,16 @@
+name: Test
+
+# We want testing for new pull requests before they are merged.
+on: [push, pull_request]
+
+jobs:
+  test:
+    name: Run tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install Bazel
+        run: sudo apt install bazel
+      - name: Run tests
+        run: bazel test :all --test_output=errors

--- a/scripts/compile.py
+++ b/scripts/compile.py
@@ -42,7 +42,7 @@ def abort(msg):
 
 def open_csv(filename):
     """ return a DictReader iterable regardless of input CSV type """
-    fh = open(filename)
+    fh = open(filename, encoding='UTF-8')
     first_row = next(csv.reader(fh))
     if 'ocd-division/country' in first_row[0]:
         if len(first_row) == 2:
@@ -223,7 +223,7 @@ def main():
     # write output file
     output_file = args.output_csv or 'identifiers/country-{}.csv'.format(country)
     print('writing', output_file)
-    with open(output_file, 'w') as out:
+    with open(output_file, 'w', encoding='UTF-8') as out:
         out = csv.DictWriter(out, fieldnames=field_order)
         out.writeheader()
         for id_, row in sorted(ids.items()):

--- a/test/compile_test.py
+++ b/test/compile_test.py
@@ -26,7 +26,7 @@ class TestSourcesMatchCommittedCSV(unittest.TestCase):
     # Read what's in the repo.
     committed_csv_path = F'identifiers/country-{country_code}.csv'
     try:
-      with open(committed_csv_path, 'r') as committed_file:
+      with open(committed_csv_path, 'r', encoding='UTF-8') as committed_file:
         committed_csv = committed_file.read()
     except FileNotFoundError:
       # In the case that the commited csv file does not exist, we treat it as an
@@ -40,7 +40,7 @@ class TestSourcesMatchCommittedCSV(unittest.TestCase):
     ], check=True)
 
     # Read the output of the compiler.
-    with open(compiler_output_path, 'r') as compiler_output_file:
+    with open(compiler_output_path, 'r', encoding='UTF-8') as compiler_output_file:
       compiler_output = compiler_output_file.read()
 
     return committed_csv, compiler_output


### PR DESCRIPTION
This adds a github action that will invoke `bazel test :all`. Sample
results can be seen here:

- Passing: https://github.com/jrunningen/ocd-division-ids/actions/runs/513136468
- Failing: https://github.com/jrunningen/ocd-division-ids/actions/runs/513132397

This action will run for new pull requests, so the reveiwer is notified
of problems like the inputs not compiling, or the top-level country CSV
not being updated to match sources.

`compile.py` is also updated here to enforce UTF-8 encoding, which otherwise can differ by locale.