### PR TITLE
Fixes broken OCD ID documentation hyperlink in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The goal of this project is to assign somewhat predictable and globally unique identifiers to political divisions.
 
-The canonical documentation of OCD-IDs is expressed as [OCDEP 2: Open Civic Data Divisions](http://docs.opencivicdata.org/en/latest/proposals/0002.html).
+The canonical documentation of OCD-IDs is expressed as [OCDEP 2: Open Civic Data Divisions](https://opencivicdata.readthedocs.io/en/latest/proposals/0002.html).
 
 Tests can be run with [Bazel](https://bazel.build/):
 


### PR DESCRIPTION
The opencivicdata.org domain no longer resolves, and was migrated to readthedocs in the past. This updates the URL for the canonical OCD ID documentation to point to the readthedocs version.