### PR TITLE
Add ocd-ids for Sri Lanka.

### DIFF
--- a/identifiers/country-lk/README
+++ b/identifiers/country-lk/README
@@ -1,0 +1,7 @@
+README
+
+File contents in `country-lk` directory:
+*   electoral_districts.csv: contains 22 multi-member electoral districts for Sri Lankan Parliament
+
+OCD ID Types used used:
+*   ed : represents the electoral district

--- a/identifiers/country-lk/electoral_districts.csv
+++ b/identifiers/country-lk/electoral_districts.csv
@@ -1,5 +1,4 @@
 id,name
-ocd-division/country:lk,Sri Lanka
 ocd-division/country:lk/ed:ampara,Ampara
 ocd-division/country:lk/ed:anuradhapura,Anuradhapura
 ocd-division/country:lk/ed:badulla,Badulla


### PR DESCRIPTION
Sri-Lanka has a unicameral parliament called Shri Lanka Parlimenthuwa, with a total of 225 seats.
- 196 elected from 22 multi-member constituencies
- 29 elected from national proportional list

Reference: https://en.wikipedia.org/wiki/Parliament_of_Sri_Lanka#Members_and_elections

