### PR TITLE
Update Hongkong OCD-IDs as per changes in 2021.

### DIFF
--- a/identifiers/country-hk.csv
+++ b/identifiers/country-hk.csv
@@ -29,16 +29,16 @@ ocd-division/country:hk/functional_constituency:textiles_and_garment,Textiles an
 ocd-division/country:hk/functional_constituency:tourism,Tourism,,
 ocd-division/country:hk/functional_constituency:transport,Transport,,
 ocd-division/country:hk/functional_constituency:wholesale_and_retail,Wholesale and Retail,,
-ocd-division/country:hk/geographical_constituency:hk_island,Hong Kong Island,,2021-06-01
-ocd-division/country:hk/geographical_constituency:hk_island_east,Hong Kong Island East,2021-06-01,
-ocd-division/country:hk/geographical_constituency:hk_island_west,Hong Kong Island West,2021-06-01,
-ocd-division/country:hk/geographical_constituency:kowloon_central,Kowloon Central,2021-06-01,
+ocd-division/country:hk/geographical_constituency:hk_island,Hong Kong Island,,2021-12-19
+ocd-division/country:hk/geographical_constituency:hk_island_east,Hong Kong Island East,2021-12-19,
+ocd-division/country:hk/geographical_constituency:hk_island_west,Hong Kong Island West,2021-12-19,
+ocd-division/country:hk/geographical_constituency:kowloon_central,Kowloon Central,2021-12-19,
 ocd-division/country:hk/geographical_constituency:kowloon_east,Kowloon East,,
 ocd-division/country:hk/geographical_constituency:kowloon_west,Kowloon West,,
-ocd-division/country:hk/geographical_constituency:new_territories_east,New Territories East,,2021-06-01
-ocd-division/country:hk/geographical_constituency:new_territories_north,New Territories North,2021-06-01,
-ocd-division/country:hk/geographical_constituency:new_territories_north_east,New Territories North East,2021-06-01,
-ocd-division/country:hk/geographical_constituency:new_territories_north_west,New Territories North West,2021-06-01,
-ocd-division/country:hk/geographical_constituency:new_territories_south_east,New Territories South East,2021-06-01,
-ocd-division/country:hk/geographical_constituency:new_territories_south_west,New Territories South West,2021-06-01,
-ocd-division/country:hk/geographical_constituency:new_territories_west,New Territories West,,2021-06-01
+ocd-division/country:hk/geographical_constituency:new_territories_east,New Territories East,,2021-12-19
+ocd-division/country:hk/geographical_constituency:new_territories_north,New Territories North,2021-12-19,
+ocd-division/country:hk/geographical_constituency:new_territories_north_east,New Territories North East,2021-12-19,
+ocd-division/country:hk/geographical_constituency:new_territories_north_west,New Territories North West,2021-12-19,
+ocd-division/country:hk/geographical_constituency:new_territories_south_east,New Territories South East,2021-12-19,
+ocd-division/country:hk/geographical_constituency:new_territories_south_west,New Territories South West,2021-12-19,
+ocd-division/country:hk/geographical_constituency:new_territories_west,New Territories West,,2021-12-19

--- a/identifiers/country-hk.csv
+++ b/identifiers/country-hk.csv
@@ -1,36 +1,44 @@
-id,name
-ocd-division/country:hk,Hong Kong
-ocd-division/country:hk/functional_constituency:accountancy,Accountancy
-ocd-division/country:hk/functional_constituency:agriculture_and_fisheries,Agriculture and Fisheries
-ocd-division/country:hk/functional_constituency:architectural_surveying_and_planning,"Architectural, Surveying, Planning and Landscape"
-ocd-division/country:hk/functional_constituency:catering,Catering
-ocd-division/country:hk/functional_constituency:commercial_first,Commercial (First)
-ocd-division/country:hk/functional_constituency:commercial_second,Commercial (Second)
-ocd-division/country:hk/functional_constituency:district_council_first,District Council (First)
-ocd-division/country:hk/functional_constituency:district_council_second,District Council (Second)
-ocd-division/country:hk/functional_constituency:education,Education
-ocd-division/country:hk/functional_constituency:engineering,Engineering
-ocd-division/country:hk/functional_constituency:finance,Finance
-ocd-division/country:hk/functional_constituency:financial_services,Financial Services
-ocd-division/country:hk/functional_constituency:health_services,Health Services
-ocd-division/country:hk/functional_constituency:heung_yee_kuk,Heung Yee Kuk
-ocd-division/country:hk/functional_constituency:import_and_export,Import and Export
-ocd-division/country:hk/functional_constituency:industrial_first,Industrial (First)
-ocd-division/country:hk/functional_constituency:industrial_second,Industrial (Second)
-ocd-division/country:hk/functional_constituency:information_technology,Information Technology
-ocd-division/country:hk/functional_constituency:insurance,Insurance
-ocd-division/country:hk/functional_constituency:labour,Labour
-ocd-division/country:hk/functional_constituency:legal,Legal
-ocd-division/country:hk/functional_constituency:medical,Medical
-ocd-division/country:hk/functional_constituency:real_estate_and_construction,Real Estate and Construction
-ocd-division/country:hk/functional_constituency:social_welfare,Social Welfare
-ocd-division/country:hk/functional_constituency:sports_performing_arts_culture_and_publication,"Sports, Performing Arts, Culture and Publication"
-ocd-division/country:hk/functional_constituency:textiles_and_garment,Textiles and Garment
-ocd-division/country:hk/functional_constituency:tourism,Tourism
-ocd-division/country:hk/functional_constituency:transport,Transport
-ocd-division/country:hk/functional_constituency:wholesale_and_retail,Wholesale and Retail
-ocd-division/country:hk/geographical_constituency:hk_island,Hong Kong Island
-ocd-division/country:hk/geographical_constituency:kowloon_east,Kowloon East
-ocd-division/country:hk/geographical_constituency:kowloon_west,Kowloon West
-ocd-division/country:hk/geographical_constituency:new_territories_east,New Territories East
-ocd-division/country:hk/geographical_constituency:new_territories_west,New Territories West
+id,name,validFrom,validTo
+ocd-division/country:hk,Hong Kong,,
+ocd-division/country:hk/functional_constituency:accountancy,Accountancy,,
+ocd-division/country:hk/functional_constituency:agriculture_and_fisheries,Agriculture and Fisheries,,
+ocd-division/country:hk/functional_constituency:architectural_surveying_and_planning,"Architectural, Surveying, Planning and Landscape",,
+ocd-division/country:hk/functional_constituency:catering,Catering,,
+ocd-division/country:hk/functional_constituency:commercial_first,Commercial (First),,
+ocd-division/country:hk/functional_constituency:commercial_second,Commercial (Second),,
+ocd-division/country:hk/functional_constituency:district_council_first,District Council (First),,
+ocd-division/country:hk/functional_constituency:district_council_second,District Council (Second),,
+ocd-division/country:hk/functional_constituency:education,Education,,
+ocd-division/country:hk/functional_constituency:engineering,Engineering,,
+ocd-division/country:hk/functional_constituency:finance,Finance,,
+ocd-division/country:hk/functional_constituency:financial_services,Financial Services,,
+ocd-division/country:hk/functional_constituency:health_services,Health Services,,
+ocd-division/country:hk/functional_constituency:heung_yee_kuk,Heung Yee Kuk,,
+ocd-division/country:hk/functional_constituency:import_and_export,Import and Export,,
+ocd-division/country:hk/functional_constituency:industrial_first,Industrial (First),,
+ocd-division/country:hk/functional_constituency:industrial_second,Industrial (Second),,
+ocd-division/country:hk/functional_constituency:information_technology,Information Technology,,
+ocd-division/country:hk/functional_constituency:insurance,Insurance,,
+ocd-division/country:hk/functional_constituency:labour,Labour,,
+ocd-division/country:hk/functional_constituency:legal,Legal,,
+ocd-division/country:hk/functional_constituency:medical,Medical,,
+ocd-division/country:hk/functional_constituency:real_estate_and_construction,Real Estate and Construction,,
+ocd-division/country:hk/functional_constituency:social_welfare,Social Welfare,,
+ocd-division/country:hk/functional_constituency:sports_performing_arts_culture_and_publication,"Sports, Performing Arts, Culture and Publication",,
+ocd-division/country:hk/functional_constituency:textiles_and_garment,Textiles and Garment,,
+ocd-division/country:hk/functional_constituency:tourism,Tourism,,
+ocd-division/country:hk/functional_constituency:transport,Transport,,
+ocd-division/country:hk/functional_constituency:wholesale_and_retail,Wholesale and Retail,,
+ocd-division/country:hk/geographical_constituency:hk_island,Hong Kong Island,,2021-06-01
+ocd-division/country:hk/geographical_constituency:hk_island_east,Hong Kong Island East,2021-06-01,
+ocd-division/country:hk/geographical_constituency:hk_island_west,Hong Kong Island West,2021-06-01,
+ocd-division/country:hk/geographical_constituency:kowloon_central,Kowloon Central,2021-06-01,
+ocd-division/country:hk/geographical_constituency:kowloon_east,Kowloon East,,
+ocd-division/country:hk/geographical_constituency:kowloon_west,Kowloon West,,
+ocd-division/country:hk/geographical_constituency:new_territories_east,New Territories East,,
+ocd-division/country:hk/geographical_constituency:new_territories_north,New Territories North,2021-06-01,
+ocd-division/country:hk/geographical_constituency:new_territories_north_east,New Territories North East,2021-06-01,
+ocd-division/country:hk/geographical_constituency:new_territories_north_west,New Territories North West,2021-06-01,
+ocd-division/country:hk/geographical_constituency:new_territories_south_east,New Territories South East,2021-06-01,
+ocd-division/country:hk/geographical_constituency:new_territories_south_west,New Territories South West,2021-06-01,
+ocd-division/country:hk/geographical_constituency:new_territories_west,New Territories West,,

--- a/identifiers/country-hk.csv
+++ b/identifiers/country-hk.csv
@@ -35,10 +35,10 @@ ocd-division/country:hk/geographical_constituency:hk_island_west,Hong Kong Islan
 ocd-division/country:hk/geographical_constituency:kowloon_central,Kowloon Central,2021-06-01,
 ocd-division/country:hk/geographical_constituency:kowloon_east,Kowloon East,,
 ocd-division/country:hk/geographical_constituency:kowloon_west,Kowloon West,,
-ocd-division/country:hk/geographical_constituency:new_territories_east,New Territories East,,
+ocd-division/country:hk/geographical_constituency:new_territories_east,New Territories East,,2021-06-01
 ocd-division/country:hk/geographical_constituency:new_territories_north,New Territories North,2021-06-01,
 ocd-division/country:hk/geographical_constituency:new_territories_north_east,New Territories North East,2021-06-01,
 ocd-division/country:hk/geographical_constituency:new_territories_north_west,New Territories North West,2021-06-01,
 ocd-division/country:hk/geographical_constituency:new_territories_south_east,New Territories South East,2021-06-01,
 ocd-division/country:hk/geographical_constituency:new_territories_south_west,New Territories South West,2021-06-01,
-ocd-division/country:hk/geographical_constituency:new_territories_west,New Territories West,,
+ocd-division/country:hk/geographical_constituency:new_territories_west,New Territories West,,2021-06-01

--- a/identifiers/country-hk/geographical_constituencies.csv
+++ b/identifiers/country-hk/geographical_constituencies.csv
@@ -1,6 +1,14 @@
-id,name
-ocd-division/country:hk/geographical_constituency:hk_island,Hong Kong Island
-ocd-division/country:hk/geographical_constituency:kowloon_west,Kowloon West
-ocd-division/country:hk/geographical_constituency:kowloon_east,Kowloon East
-ocd-division/country:hk/geographical_constituency:new_territories_west,New Territories West
-ocd-division/country:hk/geographical_constituency:new_territories_east,New Territories East
+id,name,validFrom,validTo
+ocd-division/country:hk/geographical_constituency:hk_island,Hong Kong Island,,2021-06-01
+ocd-division/country:hk/geographical_constituency:hk_island_east,Hong Kong Island East,2021-06-01,
+ocd-division/country:hk/geographical_constituency:hk_island_west,Hong Kong Island West,2021-06-01,
+ocd-division/country:hk/geographical_constituency:kowloon_central,Kowloon Central,2021-06-01,
+ocd-division/country:hk/geographical_constituency:kowloon_east,Kowloon East,,
+ocd-division/country:hk/geographical_constituency:kowloon_west,Kowloon West,,
+ocd-division/country:hk/geographical_constituency:new_territories_east,New Territories East,,
+ocd-division/country:hk/geographical_constituency:new_territories_north,New Territories North,2021-06-01,
+ocd-division/country:hk/geographical_constituency:new_territories_north_east,New Territories North East,2021-06-01,
+ocd-division/country:hk/geographical_constituency:new_territories_north_west,New Territories North West,2021-06-01,
+ocd-division/country:hk/geographical_constituency:new_territories_south_east,New Territories South East,2021-06-01,
+ocd-division/country:hk/geographical_constituency:new_territories_south_west,New Territories South West,2021-06-01,
+ocd-division/country:hk/geographical_constituency:new_territories_west,New Territories West,,

--- a/identifiers/country-hk/geographical_constituencies.csv
+++ b/identifiers/country-hk/geographical_constituencies.csv
@@ -5,10 +5,10 @@ ocd-division/country:hk/geographical_constituency:hk_island_west,Hong Kong Islan
 ocd-division/country:hk/geographical_constituency:kowloon_central,Kowloon Central,2021-06-01,
 ocd-division/country:hk/geographical_constituency:kowloon_east,Kowloon East,,
 ocd-division/country:hk/geographical_constituency:kowloon_west,Kowloon West,,
-ocd-division/country:hk/geographical_constituency:new_territories_east,New Territories East,,
+ocd-division/country:hk/geographical_constituency:new_territories_east,New Territories East,,2021-06-01
 ocd-division/country:hk/geographical_constituency:new_territories_north,New Territories North,2021-06-01,
 ocd-division/country:hk/geographical_constituency:new_territories_north_east,New Territories North East,2021-06-01,
 ocd-division/country:hk/geographical_constituency:new_territories_north_west,New Territories North West,2021-06-01,
 ocd-division/country:hk/geographical_constituency:new_territories_south_east,New Territories South East,2021-06-01,
 ocd-division/country:hk/geographical_constituency:new_territories_south_west,New Territories South West,2021-06-01,
-ocd-division/country:hk/geographical_constituency:new_territories_west,New Territories West,,
+ocd-division/country:hk/geographical_constituency:new_territories_west,New Territories West,,2021-06-01

--- a/identifiers/country-hk/geographical_constituencies.csv
+++ b/identifiers/country-hk/geographical_constituencies.csv
@@ -1,14 +1,14 @@
 id,name,validFrom,validTo
-ocd-division/country:hk/geographical_constituency:hk_island,Hong Kong Island,,2021-06-01
-ocd-division/country:hk/geographical_constituency:hk_island_east,Hong Kong Island East,2021-06-01,
-ocd-division/country:hk/geographical_constituency:hk_island_west,Hong Kong Island West,2021-06-01,
-ocd-division/country:hk/geographical_constituency:kowloon_central,Kowloon Central,2021-06-01,
+ocd-division/country:hk/geographical_constituency:hk_island,Hong Kong Island,,2021-12-19
+ocd-division/country:hk/geographical_constituency:hk_island_east,Hong Kong Island East,2021-12-19,
+ocd-division/country:hk/geographical_constituency:hk_island_west,Hong Kong Island West,2021-12-19,
+ocd-division/country:hk/geographical_constituency:kowloon_central,Kowloon Central,2021-12-19,
 ocd-division/country:hk/geographical_constituency:kowloon_east,Kowloon East,,
 ocd-division/country:hk/geographical_constituency:kowloon_west,Kowloon West,,
-ocd-division/country:hk/geographical_constituency:new_territories_east,New Territories East,,2021-06-01
-ocd-division/country:hk/geographical_constituency:new_territories_north,New Territories North,2021-06-01,
-ocd-division/country:hk/geographical_constituency:new_territories_north_east,New Territories North East,2021-06-01,
-ocd-division/country:hk/geographical_constituency:new_territories_north_west,New Territories North West,2021-06-01,
-ocd-division/country:hk/geographical_constituency:new_territories_south_east,New Territories South East,2021-06-01,
-ocd-division/country:hk/geographical_constituency:new_territories_south_west,New Territories South West,2021-06-01,
-ocd-division/country:hk/geographical_constituency:new_territories_west,New Territories West,,2021-06-01
+ocd-division/country:hk/geographical_constituency:new_territories_east,New Territories East,,2021-12-19
+ocd-division/country:hk/geographical_constituency:new_territories_north,New Territories North,2021-12-19,
+ocd-division/country:hk/geographical_constituency:new_territories_north_east,New Territories North East,2021-12-19,
+ocd-division/country:hk/geographical_constituency:new_territories_north_west,New Territories North West,2021-12-19,
+ocd-division/country:hk/geographical_constituency:new_territories_south_east,New Territories South East,2021-12-19,
+ocd-division/country:hk/geographical_constituency:new_territories_south_west,New Territories South West,2021-12-19,
+ocd-division/country:hk/geographical_constituency:new_territories_west,New Territories West,,2021-12-19


### PR DESCRIPTION
There are updates to HongKong's constituencies:

Abolished:
- Hong Kong Island is abolished [link](https://en.wikipedia.org/wiki/Hong_Kong_Island_(1998_constituency))
- New Territories West is abolished [link](https://en.wikipedia.org/wiki/New_Territories_West_(1998_constituency))
- New Territories East is abolished [link](https://en.wikipedia.org/wiki/New_Territories_East_(1998_constituency))

New list for Hong Kong geographical constituencies: [here](https://en.wikipedia.org/wiki/List_of_constituencies_of_Hong_Kong#2021%E2%80%93present)

Official press release for the update: https://www.info.gov.hk/gia/general/202106/01/P2021060100370.htm