### PR TITLE
Add ocd-ids for Costa Rica.

### DIFF
--- a/identifiers/country-cr/README
+++ b/identifiers/country-cr/README
@@ -1,0 +1,7 @@
+README
+
+File contents in `country-cr` directory:
+*   provinces.csv: contains 7 provinces subdivision of Costa Rica
+
+OCD ID Types used used:
+*   province : represents the province

--- a/identifiers/country-cr/provinces.csv
+++ b/identifiers/country-cr/provinces.csv
@@ -1,5 +1,4 @@
 id,name
-ocd-division/country:cr,Costa Rica
 ocd-division/country:cr/province:a,Alajuela
 ocd-division/country:cr/province:c,Cartago
 ocd-division/country:cr/province:g,Guanacaste


### PR DESCRIPTION
Code for provinces follows [ISO3166-2:CR](https://en.wikipedia.org/wiki/ISO_3166-2:CR).

Legislative Assembly of Costa Rica is made up of [multi-member seats allocated per province](https://en.wikipedia.org/wiki/Legislative_Assembly_of_Costa_Rica#Composition).