### PR TITLE
Add ocd-ids for constituencies in Kenya.

### DIFF
--- a/identifiers/country-ke/README
+++ b/identifiers/country-ke/README
@@ -1,0 +1,8 @@
+README
+
+File contents in `country-ke` directory:
+*   counties: contains 47 counties of Kenya
+*   national_assembly: contains 290 constituencies in Kenya for Kenyan National Assembly
+
+OCD ID Types used used:
+*   county: represents a county in Kenya

--- a/identifiers/country-ke/counties.csv
+++ b/identifiers/country-ke/counties.csv
@@ -1,0 +1,48 @@
+id,name
+ocd-division/country:ke/county:ke-01,Baringo
+ocd-division/country:ke/county:ke-02,Bomet
+ocd-division/country:ke/county:ke-03,Bungoma
+ocd-division/country:ke/county:ke-04,Busia
+ocd-division/country:ke/county:ke-05,Elgeyo/Marakwet
+ocd-division/country:ke/county:ke-06,Embu
+ocd-division/country:ke/county:ke-07,Garissa
+ocd-division/country:ke/county:ke-08,Homa Bay
+ocd-division/country:ke/county:ke-09,Isiolo
+ocd-division/country:ke/county:ke-10,Kajiado
+ocd-division/country:ke/county:ke-11,Kakamega
+ocd-division/country:ke/county:ke-12,Kericho
+ocd-division/country:ke/county:ke-13,Kiambu
+ocd-division/country:ke/county:ke-14,Kilifi
+ocd-division/country:ke/county:ke-15,Kirinyaga
+ocd-division/country:ke/county:ke-16,Kisii
+ocd-division/country:ke/county:ke-17,Kisumu
+ocd-division/country:ke/county:ke-18,Kitui
+ocd-division/country:ke/county:ke-19,Kwale
+ocd-division/country:ke/county:ke-20,Laikipia
+ocd-division/country:ke/county:ke-21,Lamu
+ocd-division/country:ke/county:ke-22,Machakos
+ocd-division/country:ke/county:ke-23,Makueni
+ocd-division/country:ke/county:ke-24,Mandera
+ocd-division/country:ke/county:ke-25,Marsabit
+ocd-division/country:ke/county:ke-26,Meru
+ocd-division/country:ke/county:ke-27,Migori
+ocd-division/country:ke/county:ke-28,Mombasa
+ocd-division/country:ke/county:ke-29,Murang'a
+ocd-division/country:ke/county:ke-30,Nairobi City
+ocd-division/country:ke/county:ke-31,Nakuru
+ocd-division/country:ke/county:ke-32,Nandi
+ocd-division/country:ke/county:ke-33,Narok
+ocd-division/country:ke/county:ke-34,Nyamira
+ocd-division/country:ke/county:ke-35,Nyandarua
+ocd-division/country:ke/county:ke-36,Nyeri
+ocd-division/country:ke/county:ke-37,Samburu
+ocd-division/country:ke/county:ke-38,Siaya
+ocd-division/country:ke/county:ke-39,Taita/Taveta
+ocd-division/country:ke/county:ke-40,Tana River
+ocd-division/country:ke/county:ke-41,Tharaka-Nithi
+ocd-division/country:ke/county:ke-42,Trans Nzoia
+ocd-division/country:ke/county:ke-43,Turkana
+ocd-division/country:ke/county:ke-44,Uasin Gishu
+ocd-division/country:ke/county:ke-45,Vihiga
+ocd-division/country:ke/county:ke-46,Wajir
+ocd-division/country:ke/county:ke-47,West Pokot

--- a/identifiers/country-ke/national_assembly.csv
+++ b/identifiers/country-ke/national_assembly.csv
@@ -1,19 +1,15 @@
 id,name
-ocd-division/country:ke,Kenya
-ocd-division/country:ke/county:ke-01,Baringo
 ocd-division/country:ke/county:ke-01/ed:baringo_central,Baringo Central
 ocd-division/country:ke/county:ke-01/ed:baringo_north,Baringo North
 ocd-division/country:ke/county:ke-01/ed:baringo_south,Baringo South
 ocd-division/country:ke/county:ke-01/ed:eldama_ravine,Eldama Ravine
 ocd-division/country:ke/county:ke-01/ed:mogotio,Mogotio
 ocd-division/country:ke/county:ke-01/ed:tiaty,Tiaty
-ocd-division/country:ke/county:ke-02,Bomet
 ocd-division/country:ke/county:ke-02/ed:bomet_central,Bomet Central
 ocd-division/country:ke/county:ke-02/ed:bomet_east,Bomet East
 ocd-division/country:ke/county:ke-02/ed:chepalungu,Chepalungu
 ocd-division/country:ke/county:ke-02/ed:konoin,Konoin
 ocd-division/country:ke/county:ke-02/ed:sotik,Sotik
-ocd-division/country:ke/county:ke-03,Bungoma
 ocd-division/country:ke/county:ke-03/ed:bumula,Bumula
 ocd-division/country:ke/county:ke-03/ed:kabuchai,Kabuchai
 ocd-division/country:ke/county:ke-03/ed:kanduyi,Kanduyi
@@ -23,7 +19,6 @@ ocd-division/country:ke/county:ke-03/ed:sirisia,Sirisia
 ocd-division/country:ke/county:ke-03/ed:tongaren,Tongaren
 ocd-division/country:ke/county:ke-03/ed:webuye_east,Webuye East
 ocd-division/country:ke/county:ke-03/ed:webuye_west,Webuye West
-ocd-division/country:ke/county:ke-04,Busia
 ocd-division/country:ke/county:ke-04/ed:budalangi,Budalangi
 ocd-division/country:ke/county:ke-04/ed:butula,Butula
 ocd-division/country:ke/county:ke-04/ed:funyula,Funyula
@@ -31,24 +26,20 @@ ocd-division/country:ke/county:ke-04/ed:matayos,Matayos
 ocd-division/country:ke/county:ke-04/ed:nambale,Nambale
 ocd-division/country:ke/county:ke-04/ed:teso_north,Teso North
 ocd-division/country:ke/county:ke-04/ed:teso_south,Teso South
-ocd-division/country:ke/county:ke-05,Elgeyo/Marakwet
 ocd-division/country:ke/county:ke-05/ed:keiyo_north,Keiyo North
 ocd-division/country:ke/county:ke-05/ed:keiyo_south,Keiyo South
 ocd-division/country:ke/county:ke-05/ed:marakwet_east,Marakwet East
 ocd-division/country:ke/county:ke-05/ed:marakwet_west,Marakwet West
-ocd-division/country:ke/county:ke-06,Embu
 ocd-division/country:ke/county:ke-06/ed:manyatta,Manyatta
 ocd-division/country:ke/county:ke-06/ed:mbeere_north,Mbeere North
 ocd-division/country:ke/county:ke-06/ed:mbeere_south,Mbeere South
 ocd-division/country:ke/county:ke-06/ed:runyenjes,Runyenjes
-ocd-division/country:ke/county:ke-07,Garissa
 ocd-division/country:ke/county:ke-07/ed:balambala,Balambala
 ocd-division/country:ke/county:ke-07/ed:dadaab,Dadaab
 ocd-division/country:ke/county:ke-07/ed:fafi,Fafi
 ocd-division/country:ke/county:ke-07/ed:garissa_township,Garissa Township
 ocd-division/country:ke/county:ke-07/ed:ijara,Ijara
 ocd-division/country:ke/county:ke-07/ed:lagdera,Lagdera
-ocd-division/country:ke/county:ke-08,Homa Bay
 ocd-division/country:ke/county:ke-08/ed:homa_bay_town,Homa Bay Town
 ocd-division/country:ke/county:ke-08/ed:kabondo_kasipul,Kabondo Kasipul
 ocd-division/country:ke/county:ke-08/ed:karachuonyo,Karachuonyo
@@ -57,16 +48,13 @@ ocd-division/country:ke/county:ke-08/ed:mbita,Mbita
 ocd-division/country:ke/county:ke-08/ed:ndhiwa,Ndhiwa
 ocd-division/country:ke/county:ke-08/ed:rangwe,Rangwe
 ocd-division/country:ke/county:ke-08/ed:suba,Suba
-ocd-division/country:ke/county:ke-09,Isiolo
 ocd-division/country:ke/county:ke-09/ed:isiolo_north,Isiolo North
 ocd-division/country:ke/county:ke-09/ed:isiolo_south,Isiolo South
-ocd-division/country:ke/county:ke-10,Kajiado
 ocd-division/country:ke/county:ke-10/ed:kajiado_central,Kajiado Central
 ocd-division/country:ke/county:ke-10/ed:kajiado_east,Kajiado East
 ocd-division/country:ke/county:ke-10/ed:kajiado_north,Kajiado North
 ocd-division/country:ke/county:ke-10/ed:kajiado_south,Kajiado South
 ocd-division/country:ke/county:ke-10/ed:kajiado_west,Kajiado West
-ocd-division/country:ke/county:ke-11,Kakamega
 ocd-division/country:ke/county:ke-11/ed:butere,Butere
 ocd-division/country:ke/county:ke-11/ed:ikolomani,Ikolomani
 ocd-division/country:ke/county:ke-11/ed:khwisero,Khwisero
@@ -79,14 +67,12 @@ ocd-division/country:ke/county:ke-11/ed:mumias_east,Mumias East
 ocd-division/country:ke/county:ke-11/ed:mumias_west,Mumias West
 ocd-division/country:ke/county:ke-11/ed:navakholo,Navakholo
 ocd-division/country:ke/county:ke-11/ed:shinyalu,Shinyalu
-ocd-division/country:ke/county:ke-12,Kericho
 ocd-division/country:ke/county:ke-12/ed:ainamoi,Ainamoi
 ocd-division/country:ke/county:ke-12/ed:belgut,Belgut
 ocd-division/country:ke/county:ke-12/ed:bureti,Bureti
 ocd-division/country:ke/county:ke-12/ed:kipkelion_east,Kipkelion East
 ocd-division/country:ke/county:ke-12/ed:kipkelion_west,Kipkelion West
 ocd-division/country:ke/county:ke-12/ed:sigowet_soin,Sigowet–Soin
-ocd-division/country:ke/county:ke-13,Kiambu
 ocd-division/country:ke/county:ke-13/ed:gatundu_north,Gatundu North
 ocd-division/country:ke/county:ke-13/ed:gatundu_south,Gatundu South
 ocd-division/country:ke/county:ke-13/ed:githunguri,Githunguri
@@ -99,7 +85,6 @@ ocd-division/country:ke/county:ke-13/ed:lari,Lari
 ocd-division/country:ke/county:ke-13/ed:limuru,Limuru
 ocd-division/country:ke/county:ke-13/ed:ruiru,Ruiru
 ocd-division/country:ke/county:ke-13/ed:thika_town,Thika Town
-ocd-division/country:ke/county:ke-14,Kilifi
 ocd-division/country:ke/county:ke-14/ed:ganze,Ganze
 ocd-division/country:ke/county:ke-14/ed:kaloleni,Kaloleni
 ocd-division/country:ke/county:ke-14/ed:kilifi_north,Kilifi North
@@ -107,12 +92,10 @@ ocd-division/country:ke/county:ke-14/ed:kilifi_south,Kilifi South
 ocd-division/country:ke/county:ke-14/ed:magarini,Magarini
 ocd-division/country:ke/county:ke-14/ed:malindi,Malindi
 ocd-division/country:ke/county:ke-14/ed:rabai,Rabai
-ocd-division/country:ke/county:ke-15,Kirinyaga
 ocd-division/country:ke/county:ke-15/ed:gichugu,Gichugu
 ocd-division/country:ke/county:ke-15/ed:kirinyaga_central,Kirinyaga Central
 ocd-division/country:ke/county:ke-15/ed:mwea,Mwea
 ocd-division/country:ke/county:ke-15/ed:ndia,Ndia
-ocd-division/country:ke/county:ke-16,Kisii
 ocd-division/country:ke/county:ke-16/ed:bobasi,Bobasi
 ocd-division/country:ke/county:ke-16/ed:bomachoge_borabu,Bomachoge Borabu
 ocd-division/country:ke/county:ke-16/ed:bomachoge_chache,Bomachoge Chache
@@ -122,7 +105,6 @@ ocd-division/country:ke/county:ke-16/ed:kitutu_chache_south,Kitutu Chache South
 ocd-division/country:ke/county:ke-16/ed:nyaribari_chache,Nyaribari Chache
 ocd-division/country:ke/county:ke-16/ed:nyaribari_masaba,Nyaribari Masaba
 ocd-division/country:ke/county:ke-16/ed:south_mugirango,South Mugirango
-ocd-division/country:ke/county:ke-17,Kisumu
 ocd-division/country:ke/county:ke-17/ed:kisumu_central,Kisumu Central
 ocd-division/country:ke/county:ke-17/ed:kisumu_east,Kisumu East
 ocd-division/country:ke/county:ke-17/ed:kisumu_west,Kisumu West
@@ -130,7 +112,6 @@ ocd-division/country:ke/county:ke-17/ed:muhoroni,Muhoroni
 ocd-division/country:ke/county:ke-17/ed:nyakach,Nyakach
 ocd-division/country:ke/county:ke-17/ed:nyando,Nyando
 ocd-division/country:ke/county:ke-17/ed:seme,Seme
-ocd-division/country:ke/county:ke-18,Kitui
 ocd-division/country:ke/county:ke-18/ed:kitui_central,Kitui Central
 ocd-division/country:ke/county:ke-18/ed:kitui_east,Kitui East
 ocd-division/country:ke/county:ke-18/ed:kitui_rural,Kitui Rural
@@ -139,19 +120,15 @@ ocd-division/country:ke/county:ke-18/ed:kitui_west,Kitui West
 ocd-division/country:ke/county:ke-18/ed:mwingi_central,Mwingi Central
 ocd-division/country:ke/county:ke-18/ed:mwingi_north,Mwingi North
 ocd-division/country:ke/county:ke-18/ed:mwingi_west,Mwingi West
-ocd-division/country:ke/county:ke-19,Kwale
 ocd-division/country:ke/county:ke-19/ed:kinango,Kinango
 ocd-division/country:ke/county:ke-19/ed:lunga_lunga,Lunga Lunga
 ocd-division/country:ke/county:ke-19/ed:matuga,Matuga
 ocd-division/country:ke/county:ke-19/ed:msambweni,Msambweni
-ocd-division/country:ke/county:ke-20,Laikipia
 ocd-division/country:ke/county:ke-20/ed:laikipia_east,Laikipia East
 ocd-division/country:ke/county:ke-20/ed:laikipia_north,Laikipia North
 ocd-division/country:ke/county:ke-20/ed:laikipia_west,Laikipia West
-ocd-division/country:ke/county:ke-21,Lamu
 ocd-division/country:ke/county:ke-21/ed:lamu_east,Lamu East
 ocd-division/country:ke/county:ke-21/ed:lamu_west,Lamu West
-ocd-division/country:ke/county:ke-22,Machakos
 ocd-division/country:ke/county:ke-22/ed:kangundo,Kangundo
 ocd-division/country:ke/county:ke-22/ed:kathiani,Kathiani
 ocd-division/country:ke/county:ke-22/ed:machakos_town,Machakos Town
@@ -160,26 +137,22 @@ ocd-division/country:ke/county:ke-22/ed:matungulu,Matungulu
 ocd-division/country:ke/county:ke-22/ed:mavoko,Mavoko
 ocd-division/country:ke/county:ke-22/ed:mwala,Mwala
 ocd-division/country:ke/county:ke-22/ed:yatta,Yatta
-ocd-division/country:ke/county:ke-23,Makueni
 ocd-division/country:ke/county:ke-23/ed:kaiti,Kaiti
 ocd-division/country:ke/county:ke-23/ed:kibwezi_east,Kibwezi East
 ocd-division/country:ke/county:ke-23/ed:kibwezi_west,Kibwezi West
 ocd-division/country:ke/county:ke-23/ed:kilome,Kilome
 ocd-division/country:ke/county:ke-23/ed:makueni,Makueni
 ocd-division/country:ke/county:ke-23/ed:mbooni,Mbooni
-ocd-division/country:ke/county:ke-24,Mandera
 ocd-division/country:ke/county:ke-24/ed:banissa,Banissa
 ocd-division/country:ke/county:ke-24/ed:lafey,Lafey
 ocd-division/country:ke/county:ke-24/ed:mandera_east,Mandera East
 ocd-division/country:ke/county:ke-24/ed:mandera_north,Mandera North
 ocd-division/country:ke/county:ke-24/ed:mandera_south,Mandera South
 ocd-division/country:ke/county:ke-24/ed:mandera_west,Mandera West
-ocd-division/country:ke/county:ke-25,Marsabit
 ocd-division/country:ke/county:ke-25/ed:laisamis,Laisamis
 ocd-division/country:ke/county:ke-25/ed:moyale,Moyale
 ocd-division/country:ke/county:ke-25/ed:north_horr,North Horr
 ocd-division/country:ke/county:ke-25/ed:saku,Saku
-ocd-division/country:ke/county:ke-26,Meru
 ocd-division/country:ke/county:ke-26/ed:buuri,Buuri
 ocd-division/country:ke/county:ke-26/ed:central_imenti,Central Imenti
 ocd-division/country:ke/county:ke-26/ed:igembe_central,Igembe Central
@@ -189,7 +162,6 @@ ocd-division/country:ke/county:ke-26/ed:north_imenti,North Imenti
 ocd-division/country:ke/county:ke-26/ed:south_imenti,South Imenti
 ocd-division/country:ke/county:ke-26/ed:tigania_east,Tigania East
 ocd-division/country:ke/county:ke-26/ed:tigania_west,Tigania West
-ocd-division/country:ke/county:ke-27,Migori
 ocd-division/country:ke/county:ke-27/ed:awendo,Awendo
 ocd-division/country:ke/county:ke-27/ed:kuria_east,Kuria East
 ocd-division/country:ke/county:ke-27/ed:kuria_west,Kuria West
@@ -198,14 +170,12 @@ ocd-division/country:ke/county:ke-27/ed:rongo,Rongo
 ocd-division/country:ke/county:ke-27/ed:suna_east,Suna East
 ocd-division/country:ke/county:ke-27/ed:suna_west,Suna West
 ocd-division/country:ke/county:ke-27/ed:uriri,Uriri
-ocd-division/country:ke/county:ke-28,Mombasa
 ocd-division/country:ke/county:ke-28/ed:changamwe,Changamwe
 ocd-division/country:ke/county:ke-28/ed:jomvu,Jomvu
 ocd-division/country:ke/county:ke-28/ed:kisauni,Kisauni
 ocd-division/country:ke/county:ke-28/ed:likoni,Likoni
 ocd-division/country:ke/county:ke-28/ed:mvita,Mvita
 ocd-division/country:ke/county:ke-28/ed:nyali,Nyali
-ocd-division/country:ke/county:ke-29,Murang'a
 ocd-division/country:ke/county:ke-29/ed:gatanga,Gatanga
 ocd-division/country:ke/county:ke-29/ed:kandara,Kandara
 ocd-division/country:ke/county:ke-29/ed:kangema,Kangema
@@ -213,7 +183,6 @@ ocd-division/country:ke/county:ke-29/ed:kigumo,Kigumo
 ocd-division/country:ke/county:ke-29/ed:kiharu,Kiharu
 ocd-division/country:ke/county:ke-29/ed:maragwa,Maragwa
 ocd-division/country:ke/county:ke-29/ed:mathioya,Mathioya
-ocd-division/country:ke/county:ke-30,Nairobi City
 ocd-division/country:ke/county:ke-30/ed:dagoretti_north,Dagoretti North
 ocd-division/country:ke/county:ke-30/ed:dagoretti_south,Dagoretti South
 ocd-division/country:ke/county:ke-30/ed:embakasi_central,Embakasi Central
@@ -231,7 +200,6 @@ ocd-division/country:ke/county:ke-30/ed:roysambu,Roysambu
 ocd-division/country:ke/county:ke-30/ed:ruaraka,Ruaraka
 ocd-division/country:ke/county:ke-30/ed:starehe,Starehe
 ocd-division/country:ke/county:ke-30/ed:westlands,Westlands
-ocd-division/country:ke/county:ke-31,Nakuru
 ocd-division/country:ke/county:ke-31/ed:bahati,Bahati
 ocd-division/country:ke/county:ke-31/ed:gilgil,Gilgil
 ocd-division/country:ke/county:ke-31/ed:kuresoi_north,Kuresoi North
@@ -243,96 +211,80 @@ ocd-division/country:ke/county:ke-31/ed:nakuru_town_west,Nakuru Town West
 ocd-division/country:ke/county:ke-31/ed:njoro,Njoro
 ocd-division/country:ke/county:ke-31/ed:rongai,Rongai
 ocd-division/country:ke/county:ke-31/ed:subukia,Subukia
-ocd-division/country:ke/county:ke-32,Nandi
 ocd-division/country:ke/county:ke-32/ed:aldai,Aldai
 ocd-division/country:ke/county:ke-32/ed:chesumei,Chesumei
 ocd-division/country:ke/county:ke-32/ed:emgwen,Emgwen
 ocd-division/country:ke/county:ke-32/ed:mosop,Mosop
 ocd-division/country:ke/county:ke-32/ed:nandi_hills,Nandi Hills
 ocd-division/country:ke/county:ke-32/ed:tinderet,Tinderet
-ocd-division/country:ke/county:ke-33,Narok
 ocd-division/country:ke/county:ke-33/ed:emurua_dikirr,Emurua Dikirr
 ocd-division/country:ke/county:ke-33/ed:kilgoris,Kilgoris
 ocd-division/country:ke/county:ke-33/ed:narok_east,Narok East
 ocd-division/country:ke/county:ke-33/ed:narok_north,Narok North
 ocd-division/country:ke/county:ke-33/ed:narok_south,Narok South
 ocd-division/country:ke/county:ke-33/ed:narok_west,Narok West
-ocd-division/country:ke/county:ke-34,Nyamira
 ocd-division/country:ke/county:ke-34/ed:borabu,Borabu
 ocd-division/country:ke/county:ke-34/ed:kitutu_masaba,Kitutu Masaba
 ocd-division/country:ke/county:ke-34/ed:north_mugirango,North Mugirango
 ocd-division/country:ke/county:ke-34/ed:west_mugirango,West Mugirango
-ocd-division/country:ke/county:ke-35,Nyandarua
 ocd-division/country:ke/county:ke-35/ed:kinangop,Kinangop
 ocd-division/country:ke/county:ke-35/ed:kipipiri,Kipipiri
 ocd-division/country:ke/county:ke-35/ed:ndaragwa,Ndaragwa
 ocd-division/country:ke/county:ke-35/ed:ol_jorok,Ol Jorok
 ocd-division/country:ke/county:ke-35/ed:ol_kalou,Ol Kalou
-ocd-division/country:ke/county:ke-36,Nyeri
 ocd-division/country:ke/county:ke-36/ed:kieni,Kieni
 ocd-division/country:ke/county:ke-36/ed:mathira,Mathira
 ocd-division/country:ke/county:ke-36/ed:mukurweini,Mukurweini
 ocd-division/country:ke/county:ke-36/ed:nyeri_town,Nyeri Town
 ocd-division/country:ke/county:ke-36/ed:othaya,Othaya
 ocd-division/country:ke/county:ke-36/ed:tetu,Tetu
-ocd-division/country:ke/county:ke-37,Samburu
 ocd-division/country:ke/county:ke-37/ed:samburu_east,Samburu East
 ocd-division/country:ke/county:ke-37/ed:samburu_north,Samburu North
 ocd-division/country:ke/county:ke-37/ed:samburu_west,Samburu West
-ocd-division/country:ke/county:ke-38,Siaya
 ocd-division/country:ke/county:ke-38/ed:alego_usonga,Alego Usonga
 ocd-division/country:ke/county:ke-38/ed:bondo,Bondo
 ocd-division/country:ke/county:ke-38/ed:gem,Gem
 ocd-division/country:ke/county:ke-38/ed:rarieda,Rarieda
 ocd-division/country:ke/county:ke-38/ed:ugenya,Ugenya
 ocd-division/country:ke/county:ke-38/ed:ugunja,Ugunja
-ocd-division/country:ke/county:ke-39,Taita/Taveta
 ocd-division/country:ke/county:ke-39/ed:mwatate,Mwatate
 ocd-division/country:ke/county:ke-39/ed:taveta,Taveta
 ocd-division/country:ke/county:ke-39/ed:voi,Voi
 ocd-division/country:ke/county:ke-39/ed:wundanyi,Wundanyi
-ocd-division/country:ke/county:ke-40,Tana River
 ocd-division/country:ke/county:ke-40/ed:bura,Bura
 ocd-division/country:ke/county:ke-40/ed:galole,Galole
 ocd-division/country:ke/county:ke-40/ed:garsen,Garsen
-ocd-division/country:ke/county:ke-41,Tharaka-Nithi
 ocd-division/country:ke/county:ke-41/ed:chuka_igambangombe,Chuka/Igambang'ombe
 ocd-division/country:ke/county:ke-41/ed:maara,Maara
 ocd-division/country:ke/county:ke-41/ed:tharaka,Tharaka
-ocd-division/country:ke/county:ke-42,Trans Nzoia
 ocd-division/country:ke/county:ke-42/ed:cherangany,Cherangany
 ocd-division/country:ke/county:ke-42/ed:endebess,Endebess
 ocd-division/country:ke/county:ke-42/ed:kiminini,Kiminini
 ocd-division/country:ke/county:ke-42/ed:kwanza,Kwanza
 ocd-division/country:ke/county:ke-42/ed:saboti,Saboti
-ocd-division/country:ke/county:ke-43,Turkana
 ocd-division/country:ke/county:ke-43/ed:loima,Loima
 ocd-division/country:ke/county:ke-43/ed:turkana_central,Turkana Central
 ocd-division/country:ke/county:ke-43/ed:turkana_east,Turkana East
 ocd-division/country:ke/county:ke-43/ed:turkana_north,Turkana North
 ocd-division/country:ke/county:ke-43/ed:turkana_south,Turkana South
 ocd-division/country:ke/county:ke-43/ed:turkana_west,Turkana West
-ocd-division/country:ke/county:ke-44,Uasin Gishu
 ocd-division/country:ke/county:ke-44/ed:ainabkoi,Ainabkoi
 ocd-division/country:ke/county:ke-44/ed:kapseret,Kapseret
 ocd-division/country:ke/county:ke-44/ed:kesses,Kesses
 ocd-division/country:ke/county:ke-44/ed:moiben,Moiben
 ocd-division/country:ke/county:ke-44/ed:soy,Soy
 ocd-division/country:ke/county:ke-44/ed:turbo,Turbo
-ocd-division/country:ke/county:ke-45,Vihiga
 ocd-division/country:ke/county:ke-45/ed:emuhaya,Emuhaya
 ocd-division/country:ke/county:ke-45/ed:hamisi,Hamisi
 ocd-division/country:ke/county:ke-45/ed:luanda,Luanda
 ocd-division/country:ke/county:ke-45/ed:sabatia,Sabatia
 ocd-division/country:ke/county:ke-45/ed:vihiga,Vihiga
-ocd-division/country:ke/county:ke-46,Wajir
 ocd-division/country:ke/county:ke-46/ed:eldas,Eldas
 ocd-division/country:ke/county:ke-46/ed:tarbaj,Tarbaj
 ocd-division/country:ke/county:ke-46/ed:wajir_east,Wajir East
 ocd-division/country:ke/county:ke-46/ed:wajir_north,Wajir North
 ocd-division/country:ke/county:ke-46/ed:wajir_south,Wajir South
 ocd-division/country:ke/county:ke-46/ed:wajir_west,Wajir West
-ocd-division/country:ke/county:ke-47,West Pokot
 ocd-division/country:ke/county:ke-47/ed:kacheliba,Kacheliba
 ocd-division/country:ke/county:ke-47/ed:kapenguria,Kapenguria
 ocd-division/country:ke/county:ke-47/ed:pokot_south,Pokot South


### PR DESCRIPTION
Adding the following data:
- 47 counties of Kenya
- 290 constituencies for the National Assembly of Kenya

Source: 
- [Wikipedia](https://en.wikipedia.org/wiki/List_of_constituencies_of_Kenya#:~:text=Constituencies%20of%20Kenya%20are%20used,delineated%20based%20on%20population%20numbers)
- [ISO 3166-2 KE](https://www.iso.org/obp/ui/#iso:code:3166:KE)