### PR TITLE
Add OCD ID's for Kenya

### DIFF
--- a/identifiers/country-ke.csv
+++ b/identifiers/country-ke.csv
@@ -1,2 +1,1789 @@
 id,name
 ocd-division/country:ke,Kenya
+ocd-division/country:ke/county:ke-01,Mombasa
+ocd-division/country:ke/county:ke-01/ed:changamwe,Changamwe
+ocd-division/country:ke/county:ke-01/ed:changamwe/ward:airport,Airport
+ocd-division/country:ke/county:ke-01/ed:changamwe/ward:chaani,Chaani
+ocd-division/country:ke/county:ke-01/ed:changamwe/ward:changamwe,Changamwe
+ocd-division/country:ke/county:ke-01/ed:changamwe/ward:kipevu,Kipevu
+ocd-division/country:ke/county:ke-01/ed:changamwe/ward:port_reitz,Port Reitz
+ocd-division/country:ke/county:ke-01/ed:jomvu,Jomvu
+ocd-division/country:ke/county:ke-01/ed:jomvu/ward:jomvu_kuu,Jomvu Kuu
+ocd-division/country:ke/county:ke-01/ed:jomvu/ward:mikindani,Mikindani
+ocd-division/country:ke/county:ke-01/ed:jomvu/ward:miritini,Miritini
+ocd-division/country:ke/county:ke-01/ed:kisauni,Kisauni
+ocd-division/country:ke/county:ke-01/ed:kisauni/ward:bamburi,Bamburi
+ocd-division/country:ke/county:ke-01/ed:kisauni/ward:junda,Junda
+ocd-division/country:ke/county:ke-01/ed:kisauni/ward:magogoni,Magogoni
+ocd-division/country:ke/county:ke-01/ed:kisauni/ward:mjambere,Mjambere
+ocd-division/country:ke/county:ke-01/ed:kisauni/ward:mtopanga,Mtopanga
+ocd-division/country:ke/county:ke-01/ed:kisauni/ward:mwakirunge,Mwakirunge
+ocd-division/country:ke/county:ke-01/ed:kisauni/ward:shanzu,Shanzu
+ocd-division/country:ke/county:ke-01/ed:likoni,Likoni
+ocd-division/country:ke/county:ke-01/ed:likoni/ward:bofu,Bofu
+ocd-division/country:ke/county:ke-01/ed:likoni/ward:likoni,Likoni
+ocd-division/country:ke/county:ke-01/ed:likoni/ward:mtongwe,Mtongwe
+ocd-division/country:ke/county:ke-01/ed:likoni/ward:shika_adabu,Shika Adabu
+ocd-division/country:ke/county:ke-01/ed:likoni/ward:timbwani,Timbwani
+ocd-division/country:ke/county:ke-01/ed:mvita,Mvita
+ocd-division/country:ke/county:ke-01/ed:mvita/ward:majengo,Majengo
+ocd-division/country:ke/county:ke-01/ed:mvita/ward:mji_wa_kale_makadara,Mji Wa Kale-Makadara
+ocd-division/country:ke/county:ke-01/ed:mvita/ward:shimanzi_ganjoni,Shimanzi-Ganjoni
+ocd-division/country:ke/county:ke-01/ed:mvita/ward:tononoka,Tononoka
+ocd-division/country:ke/county:ke-01/ed:mvita/ward:tudor,Tudor
+ocd-division/country:ke/county:ke-01/ed:nyali,Nyali
+ocd-division/country:ke/county:ke-01/ed:nyali/ward:frere_town,Frere Town
+ocd-division/country:ke/county:ke-01/ed:nyali/ward:kadzandani,Kadzandani
+ocd-division/country:ke/county:ke-01/ed:nyali/ward:kongowea,Kongowea
+ocd-division/country:ke/county:ke-01/ed:nyali/ward:mkomani,Mkomani
+ocd-division/country:ke/county:ke-01/ed:nyali/ward:ziwa_la_ngombe,Ziwa La Ng’ombe
+ocd-division/country:ke/county:ke-02,Kwale
+ocd-division/country:ke/county:ke-02/ed:kinango,Kinango
+ocd-division/country:ke/county:ke-02/ed:kinango/ward:chengoni_samburu,Chengoni-Samburu
+ocd-division/country:ke/county:ke-02/ed:kinango/ward:kasemeni,Kasemeni
+ocd-division/country:ke/county:ke-02/ed:kinango/ward:kinango,Kinango
+ocd-division/country:ke/county:ke-02/ed:kinango/ward:mackinnon_road,Mackinnon Road
+ocd-division/country:ke/county:ke-02/ed:kinango/ward:mwavumbo,Mwavumbo
+ocd-division/country:ke/county:ke-02/ed:kinango/ward:ndavaya,Ndavaya
+ocd-division/country:ke/county:ke-02/ed:kinango/ward:puma,Puma
+ocd-division/country:ke/county:ke-02/ed:lungalunga,Lungalunga
+ocd-division/country:ke/county:ke-02/ed:lungalunga/ward:dzombo,Dzombo
+ocd-division/country:ke/county:ke-02/ed:lungalunga/ward:mwereni,Mwereni
+ocd-division/country:ke/county:ke-02/ed:lungalunga/ward:pongwe_kikoneni,Pongwe-Kikoneni
+ocd-division/country:ke/county:ke-02/ed:lungalunga/ward:vanga,Vanga
+ocd-division/country:ke/county:ke-02/ed:matuga,Matuga
+ocd-division/country:ke/county:ke-02/ed:matuga/ward:kubo_south,Kubo South
+ocd-division/country:ke/county:ke-02/ed:matuga/ward:mkongani,Mkongani
+ocd-division/country:ke/county:ke-02/ed:matuga/ward:tiwi,Tiwi
+ocd-division/country:ke/county:ke-02/ed:matuga/ward:tsimba_golini,Tsimba Golini
+ocd-division/country:ke/county:ke-02/ed:matuga/ward:waa,Waa
+ocd-division/country:ke/county:ke-02/ed:msambweni,Msambweni
+ocd-division/country:ke/county:ke-02/ed:msambweni/ward:gombato_bongwe,Gombato Bongwe
+ocd-division/country:ke/county:ke-02/ed:msambweni/ward:kinondo,Kinondo
+ocd-division/country:ke/county:ke-02/ed:msambweni/ward:ramisi,Ramisi
+ocd-division/country:ke/county:ke-02/ed:msambweni/ward:ukunda,Ukunda
+ocd-division/country:ke/county:ke-03,Kilifi
+ocd-division/country:ke/county:ke-03/ed:ganze,Ganze
+ocd-division/country:ke/county:ke-03/ed:ganze/ward:bamba,Bamba
+ocd-division/country:ke/county:ke-03/ed:ganze/ward:ganze,Ganze
+ocd-division/country:ke/county:ke-03/ed:ganze/ward:jaribuni,Jaribuni
+ocd-division/country:ke/county:ke-03/ed:ganze/ward:sokoke,Sokoke
+ocd-division/country:ke/county:ke-03/ed:kaloleni,Kaloleni
+ocd-division/country:ke/county:ke-03/ed:kaloleni/ward:kaloleni,Kaloleni
+ocd-division/country:ke/county:ke-03/ed:kaloleni/ward:kayafungo,Kayafungo
+ocd-division/country:ke/county:ke-03/ed:kaloleni/ward:mariakani,Mariakani
+ocd-division/country:ke/county:ke-03/ed:kaloleni/ward:mwanamwinga,Mwanamwinga
+ocd-division/country:ke/county:ke-03/ed:kilifi_north,Kilifi North
+ocd-division/country:ke/county:ke-03/ed:kilifi_north/ward:dabaso,Dabaso
+ocd-division/country:ke/county:ke-03/ed:kilifi_north/ward:kibarani,Kibarani
+ocd-division/country:ke/county:ke-03/ed:kilifi_north/ward:matsangoni,Matsangoni
+ocd-division/country:ke/county:ke-03/ed:kilifi_north/ward:mnarani,Mnarani
+ocd-division/country:ke/county:ke-03/ed:kilifi_north/ward:sokoni,Sokoni
+ocd-division/country:ke/county:ke-03/ed:kilifi_north/ward:tezo,Tezo
+ocd-division/country:ke/county:ke-03/ed:kilifi_north/ward:watamu,Watamu
+ocd-division/country:ke/county:ke-03/ed:kilifi_south,Kilifi South
+ocd-division/country:ke/county:ke-03/ed:kilifi_south/ward:chasimba,Chasimba
+ocd-division/country:ke/county:ke-03/ed:kilifi_south/ward:junju,Junju
+ocd-division/country:ke/county:ke-03/ed:kilifi_south/ward:mtepeni,Mtepeni
+ocd-division/country:ke/county:ke-03/ed:kilifi_south/ward:mwarakaya,Mwarakaya
+ocd-division/country:ke/county:ke-03/ed:kilifi_south/ward:shimo_la_tewa,Shimo La Tewa
+ocd-division/country:ke/county:ke-03/ed:magarini,Magarini
+ocd-division/country:ke/county:ke-03/ed:magarini/ward:adu,Adu
+ocd-division/country:ke/county:ke-03/ed:magarini/ward:garashi,Garashi
+ocd-division/country:ke/county:ke-03/ed:magarini/ward:gongoni,Gongoni
+ocd-division/country:ke/county:ke-03/ed:magarini/ward:magarini,Magarini
+ocd-division/country:ke/county:ke-03/ed:magarini/ward:marafa,Marafa
+ocd-division/country:ke/county:ke-03/ed:magarini/ward:sabaki,Sabaki
+ocd-division/country:ke/county:ke-03/ed:malindi,Malindi
+ocd-division/country:ke/county:ke-03/ed:malindi/ward:ganda,Ganda
+ocd-division/country:ke/county:ke-03/ed:malindi/ward:jilore,Jilore
+ocd-division/country:ke/county:ke-03/ed:malindi/ward:kakuyuni,Kakuyuni
+ocd-division/country:ke/county:ke-03/ed:malindi/ward:malindi_town,Malindi Town
+ocd-division/country:ke/county:ke-03/ed:malindi/ward:shella,Shella
+ocd-division/country:ke/county:ke-03/ed:rabai,Rabai
+ocd-division/country:ke/county:ke-03/ed:rabai/ward:kambe_ribe,Kambe-Ribe
+ocd-division/country:ke/county:ke-03/ed:rabai/ward:mwawesa,Mwawesa
+ocd-division/country:ke/county:ke-03/ed:rabai/ward:rabai_kisurutini,Rabai-Kisurutini
+ocd-division/country:ke/county:ke-03/ed:rabai/ward:ruruma,Ruruma
+ocd-division/country:ke/county:ke-04,Tana River
+ocd-division/country:ke/county:ke-04/ed:bura,Bura
+ocd-division/country:ke/county:ke-04/ed:bura/ward:bangale,Bangale
+ocd-division/country:ke/county:ke-04/ed:bura/ward:chewele,Chewele
+ocd-division/country:ke/county:ke-04/ed:bura/ward:hirimani,Hirimani
+ocd-division/country:ke/county:ke-04/ed:bura/ward:madogo,Madogo
+ocd-division/country:ke/county:ke-04/ed:bura/ward:sala,Sala
+ocd-division/country:ke/county:ke-04/ed:galole,Galole
+ocd-division/country:ke/county:ke-04/ed:galole/ward:chewani,Chewani
+ocd-division/country:ke/county:ke-04/ed:galole/ward:kinakomba,Kinakomba
+ocd-division/country:ke/county:ke-04/ed:galole/ward:mikinduni,Mikinduni
+ocd-division/country:ke/county:ke-04/ed:galole/ward:wayu,Wayu
+ocd-division/country:ke/county:ke-04/ed:garsen,Garsen
+ocd-division/country:ke/county:ke-04/ed:garsen/ward:garsen_central,Garsen Central
+ocd-division/country:ke/county:ke-04/ed:garsen/ward:garsen_north,Garsen North
+ocd-division/country:ke/county:ke-04/ed:garsen/ward:garsen_south,Garsen South
+ocd-division/country:ke/county:ke-04/ed:garsen/ward:garsen_west,Garsen West
+ocd-division/country:ke/county:ke-04/ed:garsen/ward:kipini_east,Kipini East
+ocd-division/country:ke/county:ke-04/ed:garsen/ward:kipini_west,Kipini West
+ocd-division/country:ke/county:ke-05,Lamu
+ocd-division/country:ke/county:ke-05/ed:lamu_east,Lamu East
+ocd-division/country:ke/county:ke-05/ed:lamu_east/ward:basuba,Basuba
+ocd-division/country:ke/county:ke-05/ed:lamu_east/ward:faza,Faza
+ocd-division/country:ke/county:ke-05/ed:lamu_east/ward:kiunga,Kiunga
+ocd-division/country:ke/county:ke-05/ed:lamu_west,Lamu West
+ocd-division/country:ke/county:ke-05/ed:lamu_west/ward:bahari,Bahari
+ocd-division/country:ke/county:ke-05/ed:lamu_west/ward:hindi,Hindi
+ocd-division/country:ke/county:ke-05/ed:lamu_west/ward:hongwe,Hongwe
+ocd-division/country:ke/county:ke-05/ed:lamu_west/ward:mkomani,Mkomani
+ocd-division/country:ke/county:ke-05/ed:lamu_west/ward:mkunumbi,Mkunumbi
+ocd-division/country:ke/county:ke-05/ed:lamu_west/ward:shella,Shella
+ocd-division/country:ke/county:ke-05/ed:lamu_west/ward:witu,Witu
+ocd-division/country:ke/county:ke-06,Taita Taveta
+ocd-division/country:ke/county:ke-06/ed:mwatate,Mwatate
+ocd-division/country:ke/county:ke-06/ed:mwatate/ward:bura,Bura
+ocd-division/country:ke/county:ke-06/ed:mwatate/ward:chawia,Chawia
+ocd-division/country:ke/county:ke-06/ed:mwatate/ward:mwatate,Mwatate
+ocd-division/country:ke/county:ke-06/ed:mwatate/ward:ronge,Rong’e
+ocd-division/country:ke/county:ke-06/ed:mwatate/ward:wusi_kishamba,Wusi-Kishamba
+ocd-division/country:ke/county:ke-06/ed:taveta,Taveta
+ocd-division/country:ke/county:ke-06/ed:taveta/ward:bomani,Bomani
+ocd-division/country:ke/county:ke-06/ed:taveta/ward:chala,Chala
+ocd-division/country:ke/county:ke-06/ed:taveta/ward:mahoo,Mahoo
+ocd-division/country:ke/county:ke-06/ed:taveta/ward:mata,Mata
+ocd-division/country:ke/county:ke-06/ed:taveta/ward:mboghoni,Mboghoni
+ocd-division/country:ke/county:ke-06/ed:voi,Voi
+ocd-division/country:ke/county:ke-06/ed:voi/ward:kaloleni,Kaloleni
+ocd-division/country:ke/county:ke-06/ed:voi/ward:kasigau,Kasigau
+ocd-division/country:ke/county:ke-06/ed:voi/ward:marungu,Marungu
+ocd-division/country:ke/county:ke-06/ed:voi/ward:mbololo,Mbololo
+ocd-division/country:ke/county:ke-06/ed:voi/ward:ngolia,Ngolia
+ocd-division/country:ke/county:ke-06/ed:voi/ward:sagalla,Sagalla
+ocd-division/country:ke/county:ke-06/ed:wundanyi,Wundanyi
+ocd-division/country:ke/county:ke-06/ed:wundanyi/ward:mwanda_mgange,Mwanda-Mgange
+ocd-division/country:ke/county:ke-06/ed:wundanyi/ward:werugha,Werugha
+ocd-division/country:ke/county:ke-06/ed:wundanyi/ward:wumingu_kishushe,Wumingu-Kishushe
+ocd-division/country:ke/county:ke-06/ed:wundanyi/ward:wundanyi_mbale,Wundanyi-Mbale
+ocd-division/country:ke/county:ke-07,Garissa
+ocd-division/country:ke/county:ke-07/ed:balambala,Balambala
+ocd-division/country:ke/county:ke-07/ed:balambala/ward:balambala,Balambala
+ocd-division/country:ke/county:ke-07/ed:balambala/ward:danyere,Danyere
+ocd-division/country:ke/county:ke-07/ed:balambala/ward:jara_jara,Jara Jara
+ocd-division/country:ke/county:ke-07/ed:balambala/ward:saka,Saka
+ocd-division/country:ke/county:ke-07/ed:balambala/ward:sankuri,Sankuri
+ocd-division/country:ke/county:ke-07/ed:dadaab,Dadaab
+ocd-division/country:ke/county:ke-07/ed:dadaab/ward:abakaile,Abakaile
+ocd-division/country:ke/county:ke-07/ed:dadaab/ward:dadaab,Dadaab
+ocd-division/country:ke/county:ke-07/ed:dadaab/ward:damajale,Damajale
+ocd-division/country:ke/county:ke-07/ed:dadaab/ward:dertu,Dertu
+ocd-division/country:ke/county:ke-07/ed:dadaab/ward:labasigale,Labasigale
+ocd-division/country:ke/county:ke-07/ed:dadaab/ward:liboi,Liboi
+ocd-division/country:ke/county:ke-07/ed:fafi,Fafi
+ocd-division/country:ke/county:ke-07/ed:fafi/ward:bura,Bura
+ocd-division/country:ke/county:ke-07/ed:fafi/ward:dekaharia,Dekaharia
+ocd-division/country:ke/county:ke-07/ed:fafi/ward:fafi,Fafi
+ocd-division/country:ke/county:ke-07/ed:fafi/ward:jarajila,Jarajila
+ocd-division/country:ke/county:ke-07/ed:fafi/ward:nanighi,Nanighi
+ocd-division/country:ke/county:ke-07/ed:garissa_township,Garissa Township
+ocd-division/country:ke/county:ke-07/ed:garissa_township/ward:galbet,Galbet
+ocd-division/country:ke/county:ke-07/ed:garissa_township/ward:iftin,Iftin
+ocd-division/country:ke/county:ke-07/ed:garissa_township/ward:township,Township
+ocd-division/country:ke/county:ke-07/ed:garissa_township/ward:waberi,Waberi
+ocd-division/country:ke/county:ke-07/ed:ijara,Ijara
+ocd-division/country:ke/county:ke-07/ed:ijara/ward:hulugho,Hulugho
+ocd-division/country:ke/county:ke-07/ed:ijara/ward:ijara,Ijara
+ocd-division/country:ke/county:ke-07/ed:ijara/ward:masalani,Masalani
+ocd-division/country:ke/county:ke-07/ed:ijara/ward:sangailu,Sangailu
+ocd-division/country:ke/county:ke-07/ed:lagdera,Lagdera
+ocd-division/country:ke/county:ke-07/ed:lagdera/ward:baraki,Baraki
+ocd-division/country:ke/county:ke-07/ed:lagdera/ward:benane,Benane
+ocd-division/country:ke/county:ke-07/ed:lagdera/ward:goreale,Goreale
+ocd-division/country:ke/county:ke-07/ed:lagdera/ward:maalimin,Maalimin
+ocd-division/country:ke/county:ke-07/ed:lagdera/ward:modogashe,Modogashe
+ocd-division/country:ke/county:ke-07/ed:lagdera/ward:sabena,Sabena
+ocd-division/country:ke/county:ke-08,Wajir
+ocd-division/country:ke/county:ke-08/ed:eldas,Eldas
+ocd-division/country:ke/county:ke-08/ed:eldas/ward:della,Della
+ocd-division/country:ke/county:ke-08/ed:eldas/ward:eldas,Eldas
+ocd-division/country:ke/county:ke-08/ed:eldas/ward:elnur_tula_tula,Elnur-Tula Tula
+ocd-division/country:ke/county:ke-08/ed:eldas/ward:lakoley_south_basir,Lakoley South-Basir
+ocd-division/country:ke/county:ke-08/ed:tarbaj,Tarbaj
+ocd-division/country:ke/county:ke-08/ed:tarbaj/ward:elben,Elben
+ocd-division/country:ke/county:ke-08/ed:tarbaj/ward:sarman,Sarman
+ocd-division/country:ke/county:ke-08/ed:tarbaj/ward:tarbaj,Tarbaj
+ocd-division/country:ke/county:ke-08/ed:tarbaj/ward:wargadud,Wargadud
+ocd-division/country:ke/county:ke-08/ed:wajir_east,Wajir East
+ocd-division/country:ke/county:ke-08/ed:wajir_east/ward:barwago,Barwago
+ocd-division/country:ke/county:ke-08/ed:wajir_east/ward:khorof_harar,Khorof-Harar
+ocd-division/country:ke/county:ke-08/ed:wajir_east/ward:township,Township
+ocd-division/country:ke/county:ke-08/ed:wajir_east/ward:wagberi,Wagberi
+ocd-division/country:ke/county:ke-08/ed:wajir_north,Wajir North
+ocd-division/country:ke/county:ke-08/ed:wajir_north/ward:batalu,Batalu
+ocd-division/country:ke/county:ke-08/ed:wajir_north/ward:bute,Bute
+ocd-division/country:ke/county:ke-08/ed:wajir_north/ward:danaba,Danaba
+ocd-division/country:ke/county:ke-08/ed:wajir_north/ward:godoma,Godoma
+ocd-division/country:ke/county:ke-08/ed:wajir_north/ward:gurar,Gurar
+ocd-division/country:ke/county:ke-08/ed:wajir_north/ward:korondile,Korondile
+ocd-division/country:ke/county:ke-08/ed:wajir_north/ward:malkagufu,Malkagufu
+ocd-division/country:ke/county:ke-08/ed:wajir_south,Wajir South
+ocd-division/country:ke/county:ke-08/ed:wajir_south/ward:benane,Benane
+ocd-division/country:ke/county:ke-08/ed:wajir_south/ward:burder,Burder
+ocd-division/country:ke/county:ke-08/ed:wajir_south/ward:dadaja_bulla,Dadaja Bulla
+ocd-division/country:ke/county:ke-08/ed:wajir_south/ward:diif,Diif
+ocd-division/country:ke/county:ke-08/ed:wajir_south/ward:habasswein,Habasswein
+ocd-division/country:ke/county:ke-08/ed:wajir_south/ward:ibrahim_ure,Ibrahim Ure
+ocd-division/country:ke/county:ke-08/ed:wajir_south/ward:lagboghol_south,Lagboghol South
+ocd-division/country:ke/county:ke-08/ed:wajir_west,Wajir West
+ocd-division/country:ke/county:ke-08/ed:wajir_west/ward:adamasajide,Adamasajide
+ocd-division/country:ke/county:ke-08/ed:wajir_west/ward:arbajahan,Arbajahan
+ocd-division/country:ke/county:ke-08/ed:wajir_west/ward:ganyure_wagalla,Ganyure-Wagalla
+ocd-division/country:ke/county:ke-08/ed:wajir_west/ward:hadado_athibohol,Hadado-Athibohol
+ocd-division/country:ke/county:ke-09,Mandera
+ocd-division/country:ke/county:ke-09/ed:banissa,Banissa
+ocd-division/country:ke/county:ke-09/ed:banissa/ward:banissa,Banissa
+ocd-division/country:ke/county:ke-09/ed:banissa/ward:derkhale,Derkhale
+ocd-division/country:ke/county:ke-09/ed:banissa/ward:guba,Guba
+ocd-division/country:ke/county:ke-09/ed:banissa/ward:kiliwehiri,Kiliwehiri
+ocd-division/country:ke/county:ke-09/ed:banissa/ward:malkamari,Malkamari
+ocd-division/country:ke/county:ke-09/ed:lafey,Lafey
+ocd-division/country:ke/county:ke-09/ed:lafey/ward:alango_gof,Alango Gof
+ocd-division/country:ke/county:ke-09/ed:lafey/ward:fino,Fino
+ocd-division/country:ke/county:ke-09/ed:lafey/ward:lafey,Lafey
+ocd-division/country:ke/county:ke-09/ed:lafey/ward:libehia,Libehia
+ocd-division/country:ke/county:ke-09/ed:lafey/ward:waranqara,Waranqara
+ocd-division/country:ke/county:ke-09/ed:mandera_east,Mandera East
+ocd-division/country:ke/county:ke-09/ed:mandera_east/ward:arabia,Arabia
+ocd-division/country:ke/county:ke-09/ed:mandera_east/ward:bulla_mpya,Bulla Mpya
+ocd-division/country:ke/county:ke-09/ed:mandera_east/ward:khalalio,Khalalio
+ocd-division/country:ke/county:ke-09/ed:mandera_east/ward:neboi,Neboi
+ocd-division/country:ke/county:ke-09/ed:mandera_east/ward:township,Township
+ocd-division/country:ke/county:ke-09/ed:mandera_north,Mandera North
+ocd-division/country:ke/county:ke-09/ed:mandera_north/ward:ashabito,Ashabito
+ocd-division/country:ke/county:ke-09/ed:mandera_north/ward:guticha,Guticha
+ocd-division/country:ke/county:ke-09/ed:mandera_north/ward:morothile,Morothile
+ocd-division/country:ke/county:ke-09/ed:mandera_north/ward:rhamu,Rhamu
+ocd-division/country:ke/county:ke-09/ed:mandera_north/ward:rhamu_dimtu,Rhamu-Dimtu
+ocd-division/country:ke/county:ke-09/ed:mandera_south,Mandera South
+ocd-division/country:ke/county:ke-09/ed:mandera_south/ward:elwak_north,Elwak North
+ocd-division/country:ke/county:ke-09/ed:mandera_south/ward:elwak_south,Elwak South
+ocd-division/country:ke/county:ke-09/ed:mandera_south/ward:kutulo,Kutulo
+ocd-division/country:ke/county:ke-09/ed:mandera_south/ward:shimbir_fatuma,Shimbir Fatuma
+ocd-division/country:ke/county:ke-09/ed:mandera_south/ward:wargadud,Wargadud
+ocd-division/country:ke/county:ke-09/ed:mandera_west,Mandera West
+ocd-division/country:ke/county:ke-09/ed:mandera_west/ward:dandu,Dandu
+ocd-division/country:ke/county:ke-09/ed:mandera_west/ward:gither,Gither
+ocd-division/country:ke/county:ke-09/ed:mandera_west/ward:lagsure,Lagsure
+ocd-division/country:ke/county:ke-09/ed:mandera_west/ward:takaba,Takaba
+ocd-division/country:ke/county:ke-09/ed:mandera_west/ward:takaba_south,Takaba South
+ocd-division/country:ke/county:ke-10,Marsabit
+ocd-division/country:ke/county:ke-10/ed:laisamis,Laisamis
+ocd-division/country:ke/county:ke-10/ed:laisamis/ward:kargi_south_horr,Kargi-South Horr
+ocd-division/country:ke/county:ke-10/ed:laisamis/ward:korr_ngurunit,Korr-Ngurunit
+ocd-division/country:ke/county:ke-10/ed:laisamis/ward:laisamis,Laisamis
+ocd-division/country:ke/county:ke-10/ed:laisamis/ward:logo_logo,Logo Logo
+ocd-division/country:ke/county:ke-10/ed:laisamis/ward:loiyangalani,Loiyangalani
+ocd-division/country:ke/county:ke-10/ed:moyale,Moyale
+ocd-division/country:ke/county:ke-10/ed:moyale/ward:butiye,Butiye
+ocd-division/country:ke/county:ke-10/ed:moyale/ward:golbo,Golbo
+ocd-division/country:ke/county:ke-10/ed:moyale/ward:heillu_manyatta,Heillu-Manyatta
+ocd-division/country:ke/county:ke-10/ed:moyale/ward:moyale_township,Moyale Township
+ocd-division/country:ke/county:ke-10/ed:moyale/ward:obbu,Obbu
+ocd-division/country:ke/county:ke-10/ed:moyale/ward:sololo,Sololo
+ocd-division/country:ke/county:ke-10/ed:moyale/ward:uran,Uran
+ocd-division/country:ke/county:ke-10/ed:north_horr,North Horr
+ocd-division/country:ke/county:ke-10/ed:north_horr/ward:dukana,Dukana
+ocd-division/country:ke/county:ke-10/ed:north_horr/ward:illeret,Illeret
+ocd-division/country:ke/county:ke-10/ed:north_horr/ward:maikona,Maikona
+ocd-division/country:ke/county:ke-10/ed:north_horr/ward:north_horr,North Horr
+ocd-division/country:ke/county:ke-10/ed:north_horr/ward:turbi,Turbi
+ocd-division/country:ke/county:ke-10/ed:saku,Saku
+ocd-division/country:ke/county:ke-10/ed:saku/ward:karare,Karare
+ocd-division/country:ke/county:ke-10/ed:saku/ward:marsabit_central,Marsabit Central
+ocd-division/country:ke/county:ke-10/ed:saku/ward:sagante_jaldesa,Sagante-Jaldesa
+ocd-division/country:ke/county:ke-11,Isiolo
+ocd-division/country:ke/county:ke-11/ed:isiolo_north,Isiolo North
+ocd-division/country:ke/county:ke-11/ed:isiolo_north/ward:bulla_pesa,Bulla Pesa
+ocd-division/country:ke/county:ke-11/ed:isiolo_north/ward:burat,Burat
+ocd-division/country:ke/county:ke-11/ed:isiolo_north/ward:chari,Chari
+ocd-division/country:ke/county:ke-11/ed:isiolo_north/ward:cherab,Cherab
+ocd-division/country:ke/county:ke-11/ed:isiolo_north/ward:ngare_mara,Ngare Mara
+ocd-division/country:ke/county:ke-11/ed:isiolo_north/ward:oldo_nyiro,Oldo-Nyiro
+ocd-division/country:ke/county:ke-11/ed:isiolo_north/ward:wabera,Wabera
+ocd-division/country:ke/county:ke-11/ed:isiolo_south,Isiolo South
+ocd-division/country:ke/county:ke-11/ed:isiolo_south/ward:garbatulla,Garbatulla
+ocd-division/country:ke/county:ke-11/ed:isiolo_south/ward:kinna,Kinna
+ocd-division/country:ke/county:ke-11/ed:isiolo_south/ward:sericho,Sericho
+ocd-division/country:ke/county:ke-12,Meru
+ocd-division/country:ke/county:ke-12/ed:buuri,Buuri
+ocd-division/country:ke/county:ke-12/ed:buuri/ward:kibirichia,Kibirichia
+ocd-division/country:ke/county:ke-12/ed:buuri/ward:kiirua_naari,Kiirua-Naari
+ocd-division/country:ke/county:ke-12/ed:buuri/ward:kisima,Kisima
+ocd-division/country:ke/county:ke-12/ed:buuri/ward:ruiri_rwarera,Ruiri-Rwarera
+ocd-division/country:ke/county:ke-12/ed:buuri/ward:timau,Timau
+ocd-division/country:ke/county:ke-12/ed:central_imenti,Central Imenti
+ocd-division/country:ke/county:ke-12/ed:central_imenti/ward:abothuguchi_central,Abothuguchi Central
+ocd-division/country:ke/county:ke-12/ed:central_imenti/ward:abothuguchi_west,Abothuguchi West
+ocd-division/country:ke/county:ke-12/ed:central_imenti/ward:kiagu,Kiagu
+ocd-division/country:ke/county:ke-12/ed:central_imenti/ward:mwanganthia,Mwanganthia
+ocd-division/country:ke/county:ke-12/ed:igembe_central,Igembe Central
+ocd-division/country:ke/county:ke-12/ed:igembe_central/ward:akirangondu,Akirang’ondu
+ocd-division/country:ke/county:ke-12/ed:igembe_central/ward:athiru_ruujine,Athiru Ruujine
+ocd-division/country:ke/county:ke-12/ed:igembe_central/ward:igembe_east,Igembe East
+ocd-division/country:ke/county:ke-12/ed:igembe_central/ward:kangeta,Kangeta
+ocd-division/country:ke/county:ke-12/ed:igembe_central/ward:njia,Njia
+ocd-division/country:ke/county:ke-12/ed:igembe_north,Igembe North
+ocd-division/country:ke/county:ke-12/ed:igembe_north/ward:amwathi,Amwathi
+ocd-division/country:ke/county:ke-12/ed:igembe_north/ward:antuambui,Antuambui
+ocd-division/country:ke/county:ke-12/ed:igembe_north/ward:antubetwe_kiongo,Antubetwe Kiongo
+ocd-division/country:ke/county:ke-12/ed:igembe_north/ward:naathu,Naathu
+ocd-division/country:ke/county:ke-12/ed:igembe_north/ward:ntunene,Ntunene
+ocd-division/country:ke/county:ke-12/ed:igembe_south,Igembe South
+ocd-division/country:ke/county:ke-12/ed:igembe_south/ward:akachiu,Akachiu
+ocd-division/country:ke/county:ke-12/ed:igembe_south/ward:athiru_gaiti,Athiru Gaiti
+ocd-division/country:ke/county:ke-12/ed:igembe_south/ward:kanuni,Kanuni
+ocd-division/country:ke/county:ke-12/ed:igembe_south/ward:kiegoi_antubochiu,Kiegoi-Antubochiu
+ocd-division/country:ke/county:ke-12/ed:igembe_south/ward:maua,Maua
+ocd-division/country:ke/county:ke-12/ed:north_imenti,North Imenti
+ocd-division/country:ke/county:ke-12/ed:north_imenti/ward:municipality,Municipality
+ocd-division/country:ke/county:ke-12/ed:north_imenti/ward:ntima_east,Ntima East
+ocd-division/country:ke/county:ke-12/ed:north_imenti/ward:ntima_west,Ntima West
+ocd-division/country:ke/county:ke-12/ed:north_imenti/ward:nyaki_east,Nyaki East
+ocd-division/country:ke/county:ke-12/ed:north_imenti/ward:nyaki_west,Nyaki West
+ocd-division/country:ke/county:ke-12/ed:south_imenti,South Imenti
+ocd-division/country:ke/county:ke-12/ed:south_imenti/ward:abogeta_east,Abogeta East
+ocd-division/country:ke/county:ke-12/ed:south_imenti/ward:abogeta_west,Abogeta West
+ocd-division/country:ke/county:ke-12/ed:south_imenti/ward:igoji_east,Igoji East
+ocd-division/country:ke/county:ke-12/ed:south_imenti/ward:igoji_west,Igoji West
+ocd-division/country:ke/county:ke-12/ed:south_imenti/ward:mitunguu,Mitunguu
+ocd-division/country:ke/county:ke-12/ed:south_imenti/ward:nkuene,Nkuene
+ocd-division/country:ke/county:ke-12/ed:tigania_east,Tigania East
+ocd-division/country:ke/county:ke-12/ed:tigania_east/ward:karama,Karama
+ocd-division/country:ke/county:ke-12/ed:tigania_east/ward:kiguchwa,Kiguchwa
+ocd-division/country:ke/county:ke-12/ed:tigania_east/ward:mikinduri,Mikinduri
+ocd-division/country:ke/county:ke-12/ed:tigania_east/ward:muthara,Muthara
+ocd-division/country:ke/county:ke-12/ed:tigania_east/ward:thangatha,Thangatha
+ocd-division/country:ke/county:ke-12/ed:tigania_west,Tigania West
+ocd-division/country:ke/county:ke-12/ed:tigania_west/ward:akithii,Akithii
+ocd-division/country:ke/county:ke-12/ed:tigania_west/ward:athwana,Athwana
+ocd-division/country:ke/county:ke-12/ed:tigania_west/ward:kianjai,Kianjai
+ocd-division/country:ke/county:ke-12/ed:tigania_west/ward:mbeu,Mbeu
+ocd-division/country:ke/county:ke-12/ed:tigania_west/ward:nkomo,Nkomo
+ocd-division/country:ke/county:ke-13,Tharaka - Nithi
+ocd-division/country:ke/county:ke-13/ed:chuka_igambangombe,Chuka Igambang'Ombe
+ocd-division/country:ke/county:ke-13/ed:chuka_igambangombe/ward:igambangombe,Igambang’ombe
+ocd-division/country:ke/county:ke-13/ed:chuka_igambangombe/ward:karingani,Karingani
+ocd-division/country:ke/county:ke-13/ed:chuka_igambangombe/ward:magumoni,Magumoni
+ocd-division/country:ke/county:ke-13/ed:chuka_igambangombe/ward:mariani,Mariani
+ocd-division/country:ke/county:ke-13/ed:chuka_igambangombe/ward:mugwe,Mugwe
+ocd-division/country:ke/county:ke-13/ed:maara,Maara
+ocd-division/country:ke/county:ke-13/ed:maara/ward:chogoria,Chogoria
+ocd-division/country:ke/county:ke-13/ed:maara/ward:ganga,Ganga
+ocd-division/country:ke/county:ke-13/ed:maara/ward:mitheru,Mitheru
+ocd-division/country:ke/county:ke-13/ed:maara/ward:muthambi,Muthambi
+ocd-division/country:ke/county:ke-13/ed:maara/ward:mwimbi,Mwimbi
+ocd-division/country:ke/county:ke-13/ed:tharaka,Tharaka
+ocd-division/country:ke/county:ke-13/ed:tharaka/ward:chiakariga,Chiakariga
+ocd-division/country:ke/county:ke-13/ed:tharaka/ward:gatunga,Gatunga
+ocd-division/country:ke/county:ke-13/ed:tharaka/ward:marimanti,Marimanti
+ocd-division/country:ke/county:ke-13/ed:tharaka/ward:mukothima,Mukothima
+ocd-division/country:ke/county:ke-13/ed:tharaka/ward:nkondi,Nkondi
+ocd-division/country:ke/county:ke-14,Embu
+ocd-division/country:ke/county:ke-14/ed:manyatta,Manyatta
+ocd-division/country:ke/county:ke-14/ed:manyatta/ward:gaturi_south,Gaturi South
+ocd-division/country:ke/county:ke-14/ed:manyatta/ward:kirimari,Kirimari
+ocd-division/country:ke/county:ke-14/ed:manyatta/ward:kithimu,Kithimu
+ocd-division/country:ke/county:ke-14/ed:manyatta/ward:mbeti_north,Mbeti North
+ocd-division/country:ke/county:ke-14/ed:manyatta/ward:nginda,Nginda
+ocd-division/country:ke/county:ke-14/ed:manyatta/ward:ruguru_ngandori,Ruguru-Ngandori
+ocd-division/country:ke/county:ke-14/ed:mbeere_north,Mbeere North
+ocd-division/country:ke/county:ke-14/ed:mbeere_north/ward:evurore,Evurore
+ocd-division/country:ke/county:ke-14/ed:mbeere_north/ward:muminji,Muminji
+ocd-division/country:ke/county:ke-14/ed:mbeere_north/ward:nthawa,Nthawa
+ocd-division/country:ke/county:ke-14/ed:mbeere_south,Mbeere South
+ocd-division/country:ke/county:ke-14/ed:mbeere_south/ward:kiambere,Kiambere
+ocd-division/country:ke/county:ke-14/ed:mbeere_south/ward:makima,Makima
+ocd-division/country:ke/county:ke-14/ed:mbeere_south/ward:mavuria,Mavuria
+ocd-division/country:ke/county:ke-14/ed:mbeere_south/ward:mbeti_south,Mbeti South
+ocd-division/country:ke/county:ke-14/ed:mbeere_south/ward:mwea,Mwea
+ocd-division/country:ke/county:ke-14/ed:runyenjes,Runyenjes
+ocd-division/country:ke/county:ke-14/ed:runyenjes/ward:central_ward,Central Ward
+ocd-division/country:ke/county:ke-14/ed:runyenjes/ward:gaturi_north,Gaturi North
+ocd-division/country:ke/county:ke-14/ed:runyenjes/ward:kagaari_north,Kagaari North
+ocd-division/country:ke/county:ke-14/ed:runyenjes/ward:kagaari_south,Kagaari South
+ocd-division/country:ke/county:ke-14/ed:runyenjes/ward:kyeni_north,Kyeni North
+ocd-division/country:ke/county:ke-14/ed:runyenjes/ward:kyeni_south,Kyeni South
+ocd-division/country:ke/county:ke-15,Kitui
+ocd-division/country:ke/county:ke-15/ed:kitui_central,Kitui Central
+ocd-division/country:ke/county:ke-15/ed:kitui_central/ward:kyangwithya_east,Kyangwithya East
+ocd-division/country:ke/county:ke-15/ed:kitui_central/ward:kyangwithya_west,Kyangwithya West
+ocd-division/country:ke/county:ke-15/ed:kitui_central/ward:miambani,Miambani
+ocd-division/country:ke/county:ke-15/ed:kitui_central/ward:mulango,Mulango
+ocd-division/country:ke/county:ke-15/ed:kitui_central/ward:township,Township
+ocd-division/country:ke/county:ke-15/ed:kitui_east,Kitui East
+ocd-division/country:ke/county:ke-15/ed:kitui_east/ward:chuluni,Chuluni
+ocd-division/country:ke/county:ke-15/ed:kitui_east/ward:endau_malalani,Endau-Malalani
+ocd-division/country:ke/county:ke-15/ed:kitui_east/ward:mutito_kaliku,Mutito-Kaliku
+ocd-division/country:ke/county:ke-15/ed:kitui_east/ward:nzambani,Nzambani
+ocd-division/country:ke/county:ke-15/ed:kitui_east/ward:voo_kyamatu,Voo-Kyamatu
+ocd-division/country:ke/county:ke-15/ed:kitui_east/ward:zombe_mwitika,Zombe-Mwitika
+ocd-division/country:ke/county:ke-15/ed:kitui_rural,Kitui Rural
+ocd-division/country:ke/county:ke-15/ed:kitui_rural/ward:kanyangi,Kanyangi
+ocd-division/country:ke/county:ke-15/ed:kitui_rural/ward:kisasi,Kisasi
+ocd-division/country:ke/county:ke-15/ed:kitui_rural/ward:kwavonza_yatta,Kwavonza-Yatta
+ocd-division/country:ke/county:ke-15/ed:kitui_rural/ward:mbitini,Mbitini
+ocd-division/country:ke/county:ke-15/ed:kitui_south,Kitui South
+ocd-division/country:ke/county:ke-15/ed:kitui_south/ward:athi,Athi
+ocd-division/country:ke/county:ke-15/ed:kitui_south/ward:ikanga_kyatune,Ikanga-Kyatune
+ocd-division/country:ke/county:ke-15/ed:kitui_south/ward:ikutha,Ikutha
+ocd-division/country:ke/county:ke-15/ed:kitui_south/ward:kanziko,Kanziko
+ocd-division/country:ke/county:ke-15/ed:kitui_south/ward:mutha,Mutha
+ocd-division/country:ke/county:ke-15/ed:kitui_south/ward:mutomo,Mutomo
+ocd-division/country:ke/county:ke-15/ed:kitui_west,Kitui West
+ocd-division/country:ke/county:ke-15/ed:kitui_west/ward:kauwi,Kauwi
+ocd-division/country:ke/county:ke-15/ed:kitui_west/ward:kwa_mutonga_kithumula,Kwa Mutonga-Kithumula
+ocd-division/country:ke/county:ke-15/ed:kitui_west/ward:matinyani,Matinyani
+ocd-division/country:ke/county:ke-15/ed:kitui_west/ward:mutonguni,Mutonguni
+ocd-division/country:ke/county:ke-15/ed:mwingi_central,Mwingi Central
+ocd-division/country:ke/county:ke-15/ed:mwingi_central/ward:central,Central
+ocd-division/country:ke/county:ke-15/ed:mwingi_central/ward:kivou,Kivou
+ocd-division/country:ke/county:ke-15/ed:mwingi_central/ward:mui,Mui
+ocd-division/country:ke/county:ke-15/ed:mwingi_central/ward:nguni,Nguni
+ocd-division/country:ke/county:ke-15/ed:mwingi_central/ward:nuu,Nuu
+ocd-division/country:ke/county:ke-15/ed:mwingi_central/ward:waita,Waita
+ocd-division/country:ke/county:ke-15/ed:mwingi_north,Mwingi North
+ocd-division/country:ke/county:ke-15/ed:mwingi_north/ward:kyuso,Kyuso
+ocd-division/country:ke/county:ke-15/ed:mwingi_north/ward:mumoni,Mumoni
+ocd-division/country:ke/county:ke-15/ed:mwingi_north/ward:ngomeni,Ngomeni
+ocd-division/country:ke/county:ke-15/ed:mwingi_north/ward:tharaka,Tharaka
+ocd-division/country:ke/county:ke-15/ed:mwingi_north/ward:tseikuru,Tseikuru
+ocd-division/country:ke/county:ke-15/ed:mwingi_west,Mwingi West
+ocd-division/country:ke/county:ke-15/ed:mwingi_west/ward:kiomo_kyethani,Kiomo-Kyethani
+ocd-division/country:ke/county:ke-15/ed:mwingi_west/ward:kyome_thaana,Kyome-Thaana
+ocd-division/country:ke/county:ke-15/ed:mwingi_west/ward:migwani,Migwani
+ocd-division/country:ke/county:ke-15/ed:mwingi_west/ward:nguutani,Nguutani
+ocd-division/country:ke/county:ke-16,Machakos
+ocd-division/country:ke/county:ke-16/ed:kangundo,Kangundo
+ocd-division/country:ke/county:ke-16/ed:kangundo/ward:kangundo_central,Kangundo Central
+ocd-division/country:ke/county:ke-16/ed:kangundo/ward:kangundo_east,Kangundo East
+ocd-division/country:ke/county:ke-16/ed:kangundo/ward:kangundo_north,Kangundo North
+ocd-division/country:ke/county:ke-16/ed:kangundo/ward:kangundo_west,Kangundo West
+ocd-division/country:ke/county:ke-16/ed:kathiani,Kathiani
+ocd-division/country:ke/county:ke-16/ed:kathiani/ward:kathiani_central,Kathiani Central
+ocd-division/country:ke/county:ke-16/ed:kathiani/ward:lower_kaewa_kaani,Lower Kaewa-Kaani
+ocd-division/country:ke/county:ke-16/ed:kathiani/ward:mitaboni,Mitaboni
+ocd-division/country:ke/county:ke-16/ed:kathiani/ward:upper_kaewa_iveti,Upper Kaewa-Iveti
+ocd-division/country:ke/county:ke-16/ed:machakos_town,Machakos Town
+ocd-division/country:ke/county:ke-16/ed:machakos_town/ward:kalama,Kalama
+ocd-division/country:ke/county:ke-16/ed:machakos_town/ward:kola,Kola
+ocd-division/country:ke/county:ke-16/ed:machakos_town/ward:machakos_central,Machakos Central
+ocd-division/country:ke/county:ke-16/ed:machakos_town/ward:mua,Mua
+ocd-division/country:ke/county:ke-16/ed:machakos_town/ward:mumbuni_north,Mumbuni North
+ocd-division/country:ke/county:ke-16/ed:machakos_town/ward:mutituni,Mutituni
+ocd-division/country:ke/county:ke-16/ed:machakos_town/ward:muvuti_kiima_kimwe,Muvuti-Kiima-Kimwe
+ocd-division/country:ke/county:ke-16/ed:masinga,Masinga
+ocd-division/country:ke/county:ke-16/ed:masinga/ward:ekalakala,Ekalakala
+ocd-division/country:ke/county:ke-16/ed:masinga/ward:kivaa,Kivaa
+ocd-division/country:ke/county:ke-16/ed:masinga/ward:masinga_central,Masinga Central
+ocd-division/country:ke/county:ke-16/ed:masinga/ward:muthesya,Muthesya
+ocd-division/country:ke/county:ke-16/ed:masinga/ward:ndithini,Ndithini
+ocd-division/country:ke/county:ke-16/ed:matungulu,Matungulu
+ocd-division/country:ke/county:ke-16/ed:matungulu/ward:kyeleni,Kyeleni
+ocd-division/country:ke/county:ke-16/ed:matungulu/ward:matungulu_east,Matungulu East
+ocd-division/country:ke/county:ke-16/ed:matungulu/ward:matungulu_north,Matungulu North
+ocd-division/country:ke/county:ke-16/ed:matungulu/ward:matungulu_west,Matungulu West
+ocd-division/country:ke/county:ke-16/ed:matungulu/ward:tala,Tala
+ocd-division/country:ke/county:ke-16/ed:mavoko,Mavoko
+ocd-division/country:ke/county:ke-16/ed:mavoko/ward:athi_river,Athi River
+ocd-division/country:ke/county:ke-16/ed:mavoko/ward:kinanie,Kinanie
+ocd-division/country:ke/county:ke-16/ed:mavoko/ward:muthwani,Muthwani
+ocd-division/country:ke/county:ke-16/ed:mavoko/ward:syokimau_mulolongo,Syokimau-Mulolongo
+ocd-division/country:ke/county:ke-16/ed:mwala,Mwala
+ocd-division/country:ke/county:ke-16/ed:mwala/ward:kibauni,Kibauni
+ocd-division/country:ke/county:ke-16/ed:mwala/ward:makutano_mwala,Makutano- Mwala
+ocd-division/country:ke/county:ke-16/ed:mwala/ward:masii,Masii
+ocd-division/country:ke/county:ke-16/ed:mwala/ward:mbiuni,Mbiuni
+ocd-division/country:ke/county:ke-16/ed:mwala/ward:muthetheni,Muthetheni
+ocd-division/country:ke/county:ke-16/ed:mwala/ward:wamunyu,Wamunyu
+ocd-division/country:ke/county:ke-16/ed:yatta,Yatta
+ocd-division/country:ke/county:ke-16/ed:yatta/ward:ikombe,Ikombe
+ocd-division/country:ke/county:ke-16/ed:yatta/ward:katangi,Katangi
+ocd-division/country:ke/county:ke-16/ed:yatta/ward:kithimani,Kithimani
+ocd-division/country:ke/county:ke-16/ed:yatta/ward:matuu,Matuu
+ocd-division/country:ke/county:ke-16/ed:yatta/ward:ndalani,Ndalani
+ocd-division/country:ke/county:ke-17,Makueni
+ocd-division/country:ke/county:ke-17/ed:kaiti,Kaiti
+ocd-division/country:ke/county:ke-17/ed:kaiti/ward:ilima,Ilima
+ocd-division/country:ke/county:ke-17/ed:kaiti/ward:kee,Kee
+ocd-division/country:ke/county:ke-17/ed:kaiti/ward:kilungu,Kilungu
+ocd-division/country:ke/county:ke-17/ed:kaiti/ward:ukia,Ukia
+ocd-division/country:ke/county:ke-17/ed:kibwezi_east,Kibwezi East
+ocd-division/country:ke/county:ke-17/ed:kibwezi_east/ward:ivingoni_nzambani,Ivingoni-Nzambani
+ocd-division/country:ke/county:ke-17/ed:kibwezi_east/ward:masongaleni,Masongaleni
+ocd-division/country:ke/county:ke-17/ed:kibwezi_east/ward:mtito_andei,Mtito Andei
+ocd-division/country:ke/county:ke-17/ed:kibwezi_east/ward:thange,Thange
+ocd-division/country:ke/county:ke-17/ed:kibwezi_west,Kibwezi West
+ocd-division/country:ke/county:ke-17/ed:kibwezi_west/ward:emali_mulala,Emali-Mulala
+ocd-division/country:ke/county:ke-17/ed:kibwezi_west/ward:kikumbulyu_north,Kikumbulyu North
+ocd-division/country:ke/county:ke-17/ed:kibwezi_west/ward:kikumbulyu_south,Kikumbulyu South
+ocd-division/country:ke/county:ke-17/ed:kibwezi_west/ward:makindu,Makindu
+ocd-division/country:ke/county:ke-17/ed:kibwezi_west/ward:nguu_masumba,Nguu-Masumba
+ocd-division/country:ke/county:ke-17/ed:kibwezi_west/ward:nguumo,Nguumo
+ocd-division/country:ke/county:ke-17/ed:kilome,Kilome
+ocd-division/country:ke/county:ke-17/ed:kilome/ward:kasikeu,Kasikeu
+ocd-division/country:ke/county:ke-17/ed:kilome/ward:kiima_kiu_kalanzoni,Kiima Kiu-Kalanzoni
+ocd-division/country:ke/county:ke-17/ed:kilome/ward:mukaa,Mukaa
+ocd-division/country:ke/county:ke-17/ed:makueni,Makueni
+ocd-division/country:ke/county:ke-17/ed:makueni/ward:kathonzweni,Kathonzweni
+ocd-division/country:ke/county:ke-17/ed:makueni/ward:kitise_kithuki,Kitise-Kithuki
+ocd-division/country:ke/county:ke-17/ed:makueni/ward:mavindini,Mavindini
+ocd-division/country:ke/county:ke-17/ed:makueni/ward:mbitini,Mbitini
+ocd-division/country:ke/county:ke-17/ed:makueni/ward:muvau_kikuumini,Muvau-Kikuumini
+ocd-division/country:ke/county:ke-17/ed:makueni/ward:nzaui_kilili_kalamba,Nzaui-Kilili-Kalamba
+ocd-division/country:ke/county:ke-17/ed:makueni/ward:wote,Wote
+ocd-division/country:ke/county:ke-17/ed:mbooni,Mbooni
+ocd-division/country:ke/county:ke-17/ed:mbooni/ward:kalawa,Kalawa
+ocd-division/country:ke/county:ke-17/ed:mbooni/ward:kiteta_kisau,Kiteta-Kisau
+ocd-division/country:ke/county:ke-17/ed:mbooni/ward:kithungo_kitundu,Kithungo-Kitundu
+ocd-division/country:ke/county:ke-17/ed:mbooni/ward:mbooni,Mbooni
+ocd-division/country:ke/county:ke-17/ed:mbooni/ward:tulimani,Tulimani
+ocd-division/country:ke/county:ke-17/ed:mbooni/ward:waia_kako,Waia-Kako
+ocd-division/country:ke/county:ke-18,Nyandarua
+ocd-division/country:ke/county:ke-18/ed:kinangop,Kinangop
+ocd-division/country:ke/county:ke-18/ed:kinangop/ward:engineer,Engineer
+ocd-division/country:ke/county:ke-18/ed:kinangop/ward:gathara,Gathara
+ocd-division/country:ke/county:ke-18/ed:kinangop/ward:githabai,Githabai
+ocd-division/country:ke/county:ke-18/ed:kinangop/ward:magumu,Magumu
+ocd-division/country:ke/county:ke-18/ed:kinangop/ward:murungaru,Murungaru
+ocd-division/country:ke/county:ke-18/ed:kinangop/ward:njabini_kiburu,Njabini\Kiburu
+ocd-division/country:ke/county:ke-18/ed:kinangop/ward:north_kinangop,North Kinangop
+ocd-division/country:ke/county:ke-18/ed:kinangop/ward:nyakio,Nyakio
+ocd-division/country:ke/county:ke-18/ed:kipipiri,Kipipiri
+ocd-division/country:ke/county:ke-18/ed:kipipiri/ward:geta,Geta
+ocd-division/country:ke/county:ke-18/ed:kipipiri/ward:githioro,Githioro
+ocd-division/country:ke/county:ke-18/ed:kipipiri/ward:kipipiri,Kipipiri
+ocd-division/country:ke/county:ke-18/ed:kipipiri/ward:wanjohi,Wanjohi
+ocd-division/country:ke/county:ke-18/ed:ndaragwa,Ndaragwa
+ocd-division/country:ke/county:ke-18/ed:ndaragwa/ward:central,Central
+ocd-division/country:ke/county:ke-18/ed:ndaragwa/ward:kiriita,Kiriita
+ocd-division/country:ke/county:ke-18/ed:ndaragwa/ward:leshau_pondo,Leshau-Pondo
+ocd-division/country:ke/county:ke-18/ed:ndaragwa/ward:shamata,Shamata
+ocd-division/country:ke/county:ke-18/ed:ol_jorok,Ol Jorok
+ocd-division/country:ke/county:ke-18/ed:ol_jorok/ward:charagita,Charagita
+ocd-division/country:ke/county:ke-18/ed:ol_jorok/ward:gathanji,Gathanji
+ocd-division/country:ke/county:ke-18/ed:ol_jorok/ward:gatimu,Gatimu
+ocd-division/country:ke/county:ke-18/ed:ol_jorok/ward:weru,Weru
+ocd-division/country:ke/county:ke-18/ed:ol_kalou,Ol Kalou
+ocd-division/country:ke/county:ke-18/ed:ol_kalou/ward:kaimbaga,Kaimbaga
+ocd-division/country:ke/county:ke-18/ed:ol_kalou/ward:kanjuiri_range,Kanjuiri Range
+ocd-division/country:ke/county:ke-18/ed:ol_kalou/ward:karau,Karau
+ocd-division/country:ke/county:ke-18/ed:ol_kalou/ward:mirangine,Mirangine
+ocd-division/country:ke/county:ke-18/ed:ol_kalou/ward:rurii,Rurii
+ocd-division/country:ke/county:ke-19,Nyeri
+ocd-division/country:ke/county:ke-19/ed:kieni,Kieni
+ocd-division/country:ke/county:ke-19/ed:kieni/ward:gakawa,Gakawa
+ocd-division/country:ke/county:ke-19/ed:kieni/ward:gatarakwa,Gatarakwa
+ocd-division/country:ke/county:ke-19/ed:kieni/ward:kabaru,Kabaru
+ocd-division/country:ke/county:ke-19/ed:kieni/ward:mugunda,Mugunda
+ocd-division/country:ke/county:ke-19/ed:kieni/ward:mweiga,Mweiga
+ocd-division/country:ke/county:ke-19/ed:kieni/ward:mwiyogo_endarasha,Mwiyogo-Endarasha
+ocd-division/country:ke/county:ke-19/ed:kieni/ward:naromoru_kiamathaga,Naromoru Kiamathaga
+ocd-division/country:ke/county:ke-19/ed:kieni/ward:thegu_river,Thegu River
+ocd-division/country:ke/county:ke-19/ed:mathira,Mathira
+ocd-division/country:ke/county:ke-19/ed:mathira/ward:iriaini,Iriaini
+ocd-division/country:ke/county:ke-19/ed:mathira/ward:karatina_town,Karatina Town
+ocd-division/country:ke/county:ke-19/ed:mathira/ward:kirimukuyu,Kirimukuyu
+ocd-division/country:ke/county:ke-19/ed:mathira/ward:konyu,Konyu
+ocd-division/country:ke/county:ke-19/ed:mathira/ward:magutu,Magutu
+ocd-division/country:ke/county:ke-19/ed:mathira/ward:ruguru,Ruguru
+ocd-division/country:ke/county:ke-19/ed:mukurweini,Mukurweini
+ocd-division/country:ke/county:ke-19/ed:mukurweini/ward:gikondi,Gikondi
+ocd-division/country:ke/county:ke-19/ed:mukurweini/ward:mukurwe_ini_central,Mukurwe-Ini Central
+ocd-division/country:ke/county:ke-19/ed:mukurweini/ward:mukurwe_ini_west,Mukurwe-Ini West
+ocd-division/country:ke/county:ke-19/ed:mukurweini/ward:rugi,Rugi
+ocd-division/country:ke/county:ke-19/ed:nyeri_town,Nyeri Town
+ocd-division/country:ke/county:ke-19/ed:nyeri_town/ward:gatitu_muruguru,Gatitu-Muruguru
+ocd-division/country:ke/county:ke-19/ed:nyeri_town/ward:kamakwa_mukaro,Kamakwa-Mukaro
+ocd-division/country:ke/county:ke-19/ed:nyeri_town/ward:kiganjo_mathari,Kiganjo-Mathari
+ocd-division/country:ke/county:ke-19/ed:nyeri_town/ward:ruingu,Ruing’u
+ocd-division/country:ke/county:ke-19/ed:nyeri_town/ward:rware,Rware
+ocd-division/country:ke/county:ke-19/ed:othaya,Othaya
+ocd-division/country:ke/county:ke-19/ed:othaya/ward:chinga,Chinga
+ocd-division/country:ke/county:ke-19/ed:othaya/ward:iria_ini,Iria-Ini
+ocd-division/country:ke/county:ke-19/ed:othaya/ward:karima,Karima
+ocd-division/country:ke/county:ke-19/ed:othaya/ward:mahiga,Mahiga
+ocd-division/country:ke/county:ke-19/ed:tetu,Tetu
+ocd-division/country:ke/county:ke-19/ed:tetu/ward:aguthi_gaaki,Aguthi-Gaaki
+ocd-division/country:ke/county:ke-19/ed:tetu/ward:dedan_kimanthi,Dedan Kimanthi
+ocd-division/country:ke/county:ke-19/ed:tetu/ward:wamagana,Wamagana
+ocd-division/country:ke/county:ke-20,Kirinyaga
+ocd-division/country:ke/county:ke-20/ed:gichugu,Gichugu
+ocd-division/country:ke/county:ke-20/ed:gichugu/ward:baragwi,Baragwi
+ocd-division/country:ke/county:ke-20/ed:gichugu/ward:kabare,Kabare
+ocd-division/country:ke/county:ke-20/ed:gichugu/ward:karumandi,Karumandi
+ocd-division/country:ke/county:ke-20/ed:gichugu/ward:ngariama,Ngariama
+ocd-division/country:ke/county:ke-20/ed:gichugu/ward:njukiini,Njukiini
+ocd-division/country:ke/county:ke-20/ed:kirinyaga_central,Kirinyaga Central
+ocd-division/country:ke/county:ke-20/ed:kirinyaga_central/ward:inoi,Inoi
+ocd-division/country:ke/county:ke-20/ed:kirinyaga_central/ward:kanyekini,Kanyekini
+ocd-division/country:ke/county:ke-20/ed:kirinyaga_central/ward:kerugoya,Kerugoya
+ocd-division/country:ke/county:ke-20/ed:kirinyaga_central/ward:mutira,Mutira
+ocd-division/country:ke/county:ke-20/ed:mwea,Mwea
+ocd-division/country:ke/county:ke-20/ed:mwea/ward:gathigiriri,Gathigiriri
+ocd-division/country:ke/county:ke-20/ed:mwea/ward:kangai,Kangai
+ocd-division/country:ke/county:ke-20/ed:mwea/ward:murinduko,Murinduko
+ocd-division/country:ke/county:ke-20/ed:mwea/ward:mutithi,Mutithi
+ocd-division/country:ke/county:ke-20/ed:mwea/ward:nyangati,Nyangati
+ocd-division/country:ke/county:ke-20/ed:mwea/ward:tebere,Tebere
+ocd-division/country:ke/county:ke-20/ed:mwea/ward:thiba,Thiba
+ocd-division/country:ke/county:ke-20/ed:mwea/ward:wamumu,Wamumu
+ocd-division/country:ke/county:ke-20/ed:ndia,Ndia
+ocd-division/country:ke/county:ke-20/ed:ndia/ward:kariti,Kariti
+ocd-division/country:ke/county:ke-20/ed:ndia/ward:kiine,Kiine
+ocd-division/country:ke/county:ke-20/ed:ndia/ward:mukure,Mukure
+ocd-division/country:ke/county:ke-21,Murang'a
+ocd-division/country:ke/county:ke-21/ed:gatanga,Gatanga
+ocd-division/country:ke/county:ke-21/ed:gatanga/ward:gatanga,Gatanga
+ocd-division/country:ke/county:ke-21/ed:gatanga/ward:ithanga,Ithanga
+ocd-division/country:ke/county:ke-21/ed:gatanga/ward:kakuzi_mitubiri,Kakuzi-Mitubiri
+ocd-division/country:ke/county:ke-21/ed:gatanga/ward:kariara,Kariara
+ocd-division/country:ke/county:ke-21/ed:gatanga/ward:kihumbu_ini,Kihumbu-Ini
+ocd-division/country:ke/county:ke-21/ed:gatanga/ward:mugumo_ini,Mugumo-Ini
+ocd-division/country:ke/county:ke-21/ed:kandara,Kandara
+ocd-division/country:ke/county:ke-21/ed:kandara/ward:gaichanjiru,Gaichanjiru
+ocd-division/country:ke/county:ke-21/ed:kandara/ward:ithiru,Ithiru
+ocd-division/country:ke/county:ke-21/ed:kandara/ward:kagundu_ini,Kagundu-Ini
+ocd-division/country:ke/county:ke-21/ed:kandara/ward:muruka,Muruka
+ocd-division/country:ke/county:ke-21/ed:kandara/ward:ngararia,Ng’araria
+ocd-division/country:ke/county:ke-21/ed:kandara/ward:ruchu,Ruchu
+ocd-division/country:ke/county:ke-21/ed:kangema,Kangema
+ocd-division/country:ke/county:ke-21/ed:kangema/ward:kanyenya_ini,Kanyenya-Ini
+ocd-division/country:ke/county:ke-21/ed:kangema/ward:muguru,Muguru
+ocd-division/country:ke/county:ke-21/ed:kangema/ward:rwathia,Rwathia
+ocd-division/country:ke/county:ke-21/ed:kigumo,Kigumo
+ocd-division/country:ke/county:ke-21/ed:kigumo/ward:kahumbu,Kahumbu
+ocd-division/country:ke/county:ke-21/ed:kigumo/ward:kangari,Kangari
+ocd-division/country:ke/county:ke-21/ed:kigumo/ward:kigumo,Kigumo
+ocd-division/country:ke/county:ke-21/ed:kigumo/ward:kinyona,Kinyona
+ocd-division/country:ke/county:ke-21/ed:kigumo/ward:muthithi,Muthithi
+ocd-division/country:ke/county:ke-21/ed:kiharu,Kiharu
+ocd-division/country:ke/county:ke-21/ed:kiharu/ward:gaturi,Gaturi
+ocd-division/country:ke/county:ke-21/ed:kiharu/ward:mbiri,Mbiri
+ocd-division/country:ke/county:ke-21/ed:kiharu/ward:mugoiri,Mugoiri
+ocd-division/country:ke/county:ke-21/ed:kiharu/ward:murarandia,Murarandia
+ocd-division/country:ke/county:ke-21/ed:kiharu/ward:township,Township
+ocd-division/country:ke/county:ke-21/ed:kiharu/ward:wangu,Wangu
+ocd-division/country:ke/county:ke-21/ed:maragwa,Maragwa
+ocd-division/country:ke/county:ke-21/ed:maragwa/ward:ichagaki,Ichagaki
+ocd-division/country:ke/county:ke-21/ed:maragwa/ward:kamahuha,Kamahuha
+ocd-division/country:ke/county:ke-21/ed:maragwa/ward:kambiti,Kambiti
+ocd-division/country:ke/county:ke-21/ed:maragwa/ward:kimorori_wempa,Kimorori-Wempa
+ocd-division/country:ke/county:ke-21/ed:maragwa/ward:makuyu,Makuyu
+ocd-division/country:ke/county:ke-21/ed:maragwa/ward:nginda,Nginda
+ocd-division/country:ke/county:ke-21/ed:mathioya,Mathioya
+ocd-division/country:ke/county:ke-21/ed:mathioya/ward:gitugi,Gitugi
+ocd-division/country:ke/county:ke-21/ed:mathioya/ward:kamacharia,Kamacharia
+ocd-division/country:ke/county:ke-21/ed:mathioya/ward:kiru,Kiru
+ocd-division/country:ke/county:ke-22,Kiambu
+ocd-division/country:ke/county:ke-22/ed:gatundu_north,Gatundu North
+ocd-division/country:ke/county:ke-22/ed:gatundu_north/ward:chania,Chania
+ocd-division/country:ke/county:ke-22/ed:gatundu_north/ward:githobokoni,Githobokoni
+ocd-division/country:ke/county:ke-22/ed:gatundu_north/ward:gituamba,Gituamba
+ocd-division/country:ke/county:ke-22/ed:gatundu_north/ward:mangu,Mang’u
+ocd-division/country:ke/county:ke-22/ed:gatundu_south,Gatundu South
+ocd-division/country:ke/county:ke-22/ed:gatundu_south/ward:kiamwangi,Kiamwangi
+ocd-division/country:ke/county:ke-22/ed:gatundu_south/ward:kiganjo,Kiganjo
+ocd-division/country:ke/county:ke-22/ed:gatundu_south/ward:ndarugu,Ndarugu
+ocd-division/country:ke/county:ke-22/ed:gatundu_south/ward:ngenda,Ngenda
+ocd-division/country:ke/county:ke-22/ed:githunguri,Githunguri
+ocd-division/country:ke/county:ke-22/ed:githunguri/ward:githiga,Githiga
+ocd-division/country:ke/county:ke-22/ed:githunguri/ward:githunguri,Githunguri
+ocd-division/country:ke/county:ke-22/ed:githunguri/ward:ikinu,Ikinu
+ocd-division/country:ke/county:ke-22/ed:githunguri/ward:komothai,Komothai
+ocd-division/country:ke/county:ke-22/ed:githunguri/ward:ngewa,Ngewa
+ocd-division/country:ke/county:ke-22/ed:juja,Juja
+ocd-division/country:ke/county:ke-22/ed:juja/ward:juja,Juja
+ocd-division/country:ke/county:ke-22/ed:juja/ward:kalimoni,Kalimoni
+ocd-division/country:ke/county:ke-22/ed:juja/ward:murera,Murera
+ocd-division/country:ke/county:ke-22/ed:juja/ward:theta,Theta
+ocd-division/country:ke/county:ke-22/ed:juja/ward:witeithie,Witeithie
+ocd-division/country:ke/county:ke-22/ed:kabete,Kabete
+ocd-division/country:ke/county:ke-22/ed:kabete/ward:gitaru,Gitaru
+ocd-division/country:ke/county:ke-22/ed:kabete/ward:kabete,Kabete
+ocd-division/country:ke/county:ke-22/ed:kabete/ward:muguga,Muguga
+ocd-division/country:ke/county:ke-22/ed:kabete/ward:nyadhuna,Nyadhuna
+ocd-division/country:ke/county:ke-22/ed:kabete/ward:uthiru,Uthiru
+ocd-division/country:ke/county:ke-22/ed:kiambaa,Kiambaa
+ocd-division/country:ke/county:ke-22/ed:kiambaa/ward:cianda,Cianda
+ocd-division/country:ke/county:ke-22/ed:kiambaa/ward:karuri,Karuri
+ocd-division/country:ke/county:ke-22/ed:kiambaa/ward:kihara,Kihara
+ocd-division/country:ke/county:ke-22/ed:kiambaa/ward:muchatha,Muchatha
+ocd-division/country:ke/county:ke-22/ed:kiambaa/ward:ndenderu,Ndenderu
+ocd-division/country:ke/county:ke-22/ed:kiambu,Kiambu
+ocd-division/country:ke/county:ke-22/ed:kiambu/ward:ndumberi,Ndumberi
+ocd-division/country:ke/county:ke-22/ed:kiambu/ward:riabai,Riabai
+ocd-division/country:ke/county:ke-22/ed:kiambu/ward:tinganga,Ting’ang’a
+ocd-division/country:ke/county:ke-22/ed:kiambu/ward:township,Township
+ocd-division/country:ke/county:ke-22/ed:kikuyu,Kikuyu
+ocd-division/country:ke/county:ke-22/ed:kikuyu/ward:karai,Karai
+ocd-division/country:ke/county:ke-22/ed:kikuyu/ward:kikuyu,Kikuyu
+ocd-division/country:ke/county:ke-22/ed:kikuyu/ward:kinoo,Kinoo
+ocd-division/country:ke/county:ke-22/ed:kikuyu/ward:nachu,Nachu
+ocd-division/country:ke/county:ke-22/ed:kikuyu/ward:sigona,Sigona
+ocd-division/country:ke/county:ke-22/ed:lari,Lari
+ocd-division/country:ke/county:ke-22/ed:lari/ward:kamburu,Kamburu
+ocd-division/country:ke/county:ke-22/ed:lari/ward:kijabe,Kijabe
+ocd-division/country:ke/county:ke-22/ed:lari/ward:kinale,Kinale
+ocd-division/country:ke/county:ke-22/ed:lari/ward:lari_kirenga,Lari-Kirenga
+ocd-division/country:ke/county:ke-22/ed:lari/ward:nyanduma,Nyanduma
+ocd-division/country:ke/county:ke-22/ed:limuru,Limuru
+ocd-division/country:ke/county:ke-22/ed:limuru/ward:bibirioni,Bibirioni
+ocd-division/country:ke/county:ke-22/ed:limuru/ward:limuru_central,Limuru Central
+ocd-division/country:ke/county:ke-22/ed:limuru/ward:limuru_east,Limuru East
+ocd-division/country:ke/county:ke-22/ed:limuru/ward:ndeiya,Ndeiya
+ocd-division/country:ke/county:ke-22/ed:limuru/ward:ngecha_tigoni,Ngecha Tigoni
+ocd-division/country:ke/county:ke-22/ed:ruiru,Ruiru
+ocd-division/country:ke/county:ke-22/ed:ruiru/ward:biashara,Biashara
+ocd-division/country:ke/county:ke-22/ed:ruiru/ward:gatongora,Gatongora
+ocd-division/country:ke/county:ke-22/ed:ruiru/ward:gitothua,Gitothua
+ocd-division/country:ke/county:ke-22/ed:ruiru/ward:kahawa_sukari,Kahawa Sukari
+ocd-division/country:ke/county:ke-22/ed:ruiru/ward:kahawa_wendani,Kahawa Wendani
+ocd-division/country:ke/county:ke-22/ed:ruiru/ward:kiuu,Kiuu
+ocd-division/country:ke/county:ke-22/ed:ruiru/ward:mwihoko,Mwihoko
+ocd-division/country:ke/county:ke-22/ed:ruiru/ward:mwiki,Mwiki
+ocd-division/country:ke/county:ke-22/ed:thika_town,Thika Town
+ocd-division/country:ke/county:ke-22/ed:thika_town/ward:gatuanyaga,Gatuanyaga
+ocd-division/country:ke/county:ke-22/ed:thika_town/ward:hospital,Hospital
+ocd-division/country:ke/county:ke-22/ed:thika_town/ward:kamenu,Kamenu
+ocd-division/country:ke/county:ke-22/ed:thika_town/ward:ngoliba,Ngoliba
+ocd-division/country:ke/county:ke-22/ed:thika_town/ward:township,Township
+ocd-division/country:ke/county:ke-23,Turkana
+ocd-division/country:ke/county:ke-23/ed:loima,Loima
+ocd-division/country:ke/county:ke-23/ed:loima/ward:kotaruk_lobei,Kotaruk-Lobei
+ocd-division/country:ke/county:ke-23/ed:loima/ward:loima,Loima
+ocd-division/country:ke/county:ke-23/ed:loima/ward:lokiriama_lorengippi,Lokiriama-Lorengippi
+ocd-division/country:ke/county:ke-23/ed:loima/ward:turkwel,Turkwel
+ocd-division/country:ke/county:ke-23/ed:turkana_central,Turkana Central
+ocd-division/country:ke/county:ke-23/ed:turkana_central/ward:kalokol,Kalokol
+ocd-division/country:ke/county:ke-23/ed:turkana_central/ward:kanamkemer,Kanamkemer
+ocd-division/country:ke/county:ke-23/ed:turkana_central/ward:kangatotha,Kangatotha
+ocd-division/country:ke/county:ke-23/ed:turkana_central/ward:kerio_delta,Kerio Delta
+ocd-division/country:ke/county:ke-23/ed:turkana_central/ward:lodwar_township,Lodwar Township
+ocd-division/country:ke/county:ke-23/ed:turkana_east,Turkana East
+ocd-division/country:ke/county:ke-23/ed:turkana_east/ward:kapedo_napeitom,Kapedo-Napeitom
+ocd-division/country:ke/county:ke-23/ed:turkana_east/ward:katilia,Katilia
+ocd-division/country:ke/county:ke-23/ed:turkana_east/ward:lokori_kochodin,Lokori-Kochodin
+ocd-division/country:ke/county:ke-23/ed:turkana_north,Turkana North
+ocd-division/country:ke/county:ke-23/ed:turkana_north/ward:kaaleng_kaikor,Kaaleng-Kaikor
+ocd-division/country:ke/county:ke-23/ed:turkana_north/ward:kaeris,Kaeris
+ocd-division/country:ke/county:ke-23/ed:turkana_north/ward:kibish,Kibish
+ocd-division/country:ke/county:ke-23/ed:turkana_north/ward:lake_zone,Lake Zone
+ocd-division/country:ke/county:ke-23/ed:turkana_north/ward:lapur,Lapur
+ocd-division/country:ke/county:ke-23/ed:turkana_north/ward:nakalale,Nakalale
+ocd-division/country:ke/county:ke-23/ed:turkana_south,Turkana South
+ocd-division/country:ke/county:ke-23/ed:turkana_south/ward:kalapata,Kalapata
+ocd-division/country:ke/county:ke-23/ed:turkana_south/ward:kaputir,Kaputir
+ocd-division/country:ke/county:ke-23/ed:turkana_south/ward:katilu,Katilu
+ocd-division/country:ke/county:ke-23/ed:turkana_south/ward:lobokat,Lobokat
+ocd-division/country:ke/county:ke-23/ed:turkana_south/ward:lokichar,Lokichar
+ocd-division/country:ke/county:ke-23/ed:turkana_west,Turkana West
+ocd-division/country:ke/county:ke-23/ed:turkana_west/ward:kakuma,Kakuma
+ocd-division/country:ke/county:ke-23/ed:turkana_west/ward:kalobeyei,Kalobeyei
+ocd-division/country:ke/county:ke-23/ed:turkana_west/ward:letea,Letea
+ocd-division/country:ke/county:ke-23/ed:turkana_west/ward:lokichoggio,Lokichoggio
+ocd-division/country:ke/county:ke-23/ed:turkana_west/ward:lopur,Lopur
+ocd-division/country:ke/county:ke-23/ed:turkana_west/ward:nanaam,Nanaam
+ocd-division/country:ke/county:ke-23/ed:turkana_west/ward:songot,Songot
+ocd-division/country:ke/county:ke-24,West Pokot
+ocd-division/country:ke/county:ke-24/ed:kacheliba,Kacheliba
+ocd-division/country:ke/county:ke-24/ed:kacheliba/ward:alale,Alale
+ocd-division/country:ke/county:ke-24/ed:kacheliba/ward:kapchok,Kapchok
+ocd-division/country:ke/county:ke-24/ed:kacheliba/ward:kasei,Kasei
+ocd-division/country:ke/county:ke-24/ed:kacheliba/ward:kiwawa,Kiwawa
+ocd-division/country:ke/county:ke-24/ed:kacheliba/ward:kodich,Kodich
+ocd-division/country:ke/county:ke-24/ed:kacheliba/ward:suam,Suam
+ocd-division/country:ke/county:ke-24/ed:kapenguria,Kapenguria
+ocd-division/country:ke/county:ke-24/ed:kapenguria/ward:endugh,Endugh
+ocd-division/country:ke/county:ke-24/ed:kapenguria/ward:kapenguria,Kapenguria
+ocd-division/country:ke/county:ke-24/ed:kapenguria/ward:mnagei,Mnagei
+ocd-division/country:ke/county:ke-24/ed:kapenguria/ward:riwo,Riwo
+ocd-division/country:ke/county:ke-24/ed:kapenguria/ward:siyoi,Siyoi
+ocd-division/country:ke/county:ke-24/ed:kapenguria/ward:sook,Sook
+ocd-division/country:ke/county:ke-24/ed:pokot_south,Pokot South
+ocd-division/country:ke/county:ke-24/ed:pokot_south/ward:batei,Batei
+ocd-division/country:ke/county:ke-24/ed:pokot_south/ward:chepareria,Chepareria
+ocd-division/country:ke/county:ke-24/ed:pokot_south/ward:lelan,Lelan
+ocd-division/country:ke/county:ke-24/ed:pokot_south/ward:tapach,Tapach
+ocd-division/country:ke/county:ke-24/ed:sigor,Sigor
+ocd-division/country:ke/county:ke-24/ed:sigor/ward:lomut,Lomut
+ocd-division/country:ke/county:ke-24/ed:sigor/ward:masool,Masool
+ocd-division/country:ke/county:ke-24/ed:sigor/ward:sekerr,Sekerr
+ocd-division/country:ke/county:ke-24/ed:sigor/ward:weiwei,Weiwei
+ocd-division/country:ke/county:ke-25,Samburu
+ocd-division/country:ke/county:ke-25/ed:samburu_east,Samburu East
+ocd-division/country:ke/county:ke-25/ed:samburu_east/ward:wamba_east,Wamba East
+ocd-division/country:ke/county:ke-25/ed:samburu_east/ward:wamba_north,Wamba North
+ocd-division/country:ke/county:ke-25/ed:samburu_east/ward:wamba_west,Wamba West
+ocd-division/country:ke/county:ke-25/ed:samburu_east/ward:waso,Waso
+ocd-division/country:ke/county:ke-25/ed:samburu_north,Samburu North
+ocd-division/country:ke/county:ke-25/ed:samburu_north/ward:angata_nanyokie,Angata Nanyokie
+ocd-division/country:ke/county:ke-25/ed:samburu_north/ward:baawa,Baawa
+ocd-division/country:ke/county:ke-25/ed:samburu_north/ward:el_barta,El-Barta
+ocd-division/country:ke/county:ke-25/ed:samburu_north/ward:nachola,Nachola
+ocd-division/country:ke/county:ke-25/ed:samburu_north/ward:ndoto,Ndoto
+ocd-division/country:ke/county:ke-25/ed:samburu_north/ward:nyiro,Nyiro
+ocd-division/country:ke/county:ke-25/ed:samburu_west,Samburu West
+ocd-division/country:ke/county:ke-25/ed:samburu_west/ward:lodokejek,Lodokejek
+ocd-division/country:ke/county:ke-25/ed:samburu_west/ward:loosuk,Loosuk
+ocd-division/country:ke/county:ke-25/ed:samburu_west/ward:maralal,Maralal
+ocd-division/country:ke/county:ke-25/ed:samburu_west/ward:poro,Poro
+ocd-division/country:ke/county:ke-25/ed:samburu_west/ward:suguta_marmar,Suguta Marmar
+ocd-division/country:ke/county:ke-26,Trans Nzoia
+ocd-division/country:ke/county:ke-26/ed:cherangany,Cherangany
+ocd-division/country:ke/county:ke-26/ed:cherangany/ward:chepsiro_kiptoror,Chepsiro-Kiptoror
+ocd-division/country:ke/county:ke-26/ed:cherangany/ward:cherangany_suwerwa,Cherangany-Suwerwa
+ocd-division/country:ke/county:ke-26/ed:cherangany/ward:kaplamai,Kaplamai
+ocd-division/country:ke/county:ke-26/ed:cherangany/ward:makutano,Makutano
+ocd-division/country:ke/county:ke-26/ed:cherangany/ward:motosiet,Motosiet
+ocd-division/country:ke/county:ke-26/ed:cherangany/ward:sinyerere,Sinyerere
+ocd-division/country:ke/county:ke-26/ed:cherangany/ward:sitatunga,Sitatunga
+ocd-division/country:ke/county:ke-26/ed:endebess,Endebess
+ocd-division/country:ke/county:ke-26/ed:endebess/ward:chepchoina,Chepchoina
+ocd-division/country:ke/county:ke-26/ed:endebess/ward:endebess,Endebess
+ocd-division/country:ke/county:ke-26/ed:endebess/ward:matumbei,Matumbei
+ocd-division/country:ke/county:ke-26/ed:kiminini,Kiminini
+ocd-division/country:ke/county:ke-26/ed:kiminini/ward:hospital,Hospital
+ocd-division/country:ke/county:ke-26/ed:kiminini/ward:kiminini,Kiminini
+ocd-division/country:ke/county:ke-26/ed:kiminini/ward:nabiswa,Nabiswa
+ocd-division/country:ke/county:ke-26/ed:kiminini/ward:sikhendu,Sikhendu
+ocd-division/country:ke/county:ke-26/ed:kiminini/ward:sirende,Sirende
+ocd-division/country:ke/county:ke-26/ed:kiminini/ward:waitaluk,Waitaluk
+ocd-division/country:ke/county:ke-26/ed:kwanza,Kwanza
+ocd-division/country:ke/county:ke-26/ed:kwanza/ward:bidii,Bidii
+ocd-division/country:ke/county:ke-26/ed:kwanza/ward:kapomboi,Kapomboi
+ocd-division/country:ke/county:ke-26/ed:kwanza/ward:keiyo,Keiyo
+ocd-division/country:ke/county:ke-26/ed:kwanza/ward:kwanza,Kwanza
+ocd-division/country:ke/county:ke-26/ed:saboti,Saboti
+ocd-division/country:ke/county:ke-26/ed:saboti/ward:kinyoro,Kinyoro
+ocd-division/country:ke/county:ke-26/ed:saboti/ward:machewa,Machewa
+ocd-division/country:ke/county:ke-26/ed:saboti/ward:matisi,Matisi
+ocd-division/country:ke/county:ke-26/ed:saboti/ward:saboti,Saboti
+ocd-division/country:ke/county:ke-26/ed:saboti/ward:tuwani,Tuwani
+ocd-division/country:ke/county:ke-27,Uasin Gishu
+ocd-division/country:ke/county:ke-27/ed:ainabkoi,Ainabkoi
+ocd-division/country:ke/county:ke-27/ed:ainabkoi/ward:ainabkoi_olare,Ainabkoi-Olare
+ocd-division/country:ke/county:ke-27/ed:ainabkoi/ward:kapsoya,Kapsoya
+ocd-division/country:ke/county:ke-27/ed:ainabkoi/ward:kaptagat,Kaptagat
+ocd-division/country:ke/county:ke-27/ed:kapseret,Kapseret
+ocd-division/country:ke/county:ke-27/ed:kapseret/ward:kipkenyo,Kipkenyo
+ocd-division/country:ke/county:ke-27/ed:kapseret/ward:langas,Langas
+ocd-division/country:ke/county:ke-27/ed:kapseret/ward:megun,Megun
+ocd-division/country:ke/county:ke-27/ed:kapseret/ward:ngeria,Ngeria
+ocd-division/country:ke/county:ke-27/ed:kapseret/ward:simat_kapseret,Simat-Kapseret
+ocd-division/country:ke/county:ke-27/ed:kesses,Kesses
+ocd-division/country:ke/county:ke-27/ed:kesses/ward:cheptiret_kipchamo,Cheptiret-Kipchamo
+ocd-division/country:ke/county:ke-27/ed:kesses/ward:racecourse,Racecourse
+ocd-division/country:ke/county:ke-27/ed:kesses/ward:tarakwa,Tarakwa
+ocd-division/country:ke/county:ke-27/ed:kesses/ward:tulwet_chuiyat,Tulwet-Chuiyat
+ocd-division/country:ke/county:ke-27/ed:moiben,Moiben
+ocd-division/country:ke/county:ke-27/ed:moiben/ward:karuna_meibeki,Karuna-Meibeki
+ocd-division/country:ke/county:ke-27/ed:moiben/ward:kimumu,Kimumu
+ocd-division/country:ke/county:ke-27/ed:moiben/ward:moiben,Moiben
+ocd-division/country:ke/county:ke-27/ed:moiben/ward:sergoit,Sergoit
+ocd-division/country:ke/county:ke-27/ed:moiben/ward:tembelio,Tembelio
+ocd-division/country:ke/county:ke-27/ed:soy,Soy
+ocd-division/country:ke/county:ke-27/ed:soy/ward:kapkures,Kapkures
+ocd-division/country:ke/county:ke-27/ed:soy/ward:kipsomba,Kipsomba
+ocd-division/country:ke/county:ke-27/ed:soy/ward:kuinet_kapsuswa,Kuinet-Kapsuswa
+ocd-division/country:ke/county:ke-27/ed:soy/ward:mois_bridge,Moi’s Bridge
+ocd-division/country:ke/county:ke-27/ed:soy/ward:segero_barsombe,Segero-Barsombe
+ocd-division/country:ke/county:ke-27/ed:soy/ward:soy,Soy
+ocd-division/country:ke/county:ke-27/ed:soy/ward:ziwa,Ziwa
+ocd-division/country:ke/county:ke-27/ed:turbo,Turbo
+ocd-division/country:ke/county:ke-27/ed:turbo/ward:huruma,Huruma
+ocd-division/country:ke/county:ke-27/ed:turbo/ward:kamagut,Kamagut
+ocd-division/country:ke/county:ke-27/ed:turbo/ward:kapsaos,Kapsaos
+ocd-division/country:ke/county:ke-27/ed:turbo/ward:kiplombe,Kiplombe
+ocd-division/country:ke/county:ke-27/ed:turbo/ward:ngenyilel,Ngenyilel
+ocd-division/country:ke/county:ke-27/ed:turbo/ward:tapsagoi,Tapsagoi
+ocd-division/country:ke/county:ke-28,Elgeyo Marakwet
+ocd-division/country:ke/county:ke-28/ed:keiyo_north,Keiyo North
+ocd-division/country:ke/county:ke-28/ed:keiyo_north/ward:emsoo,Emsoo
+ocd-division/country:ke/county:ke-28/ed:keiyo_north/ward:kamariny,Kamariny
+ocd-division/country:ke/county:ke-28/ed:keiyo_north/ward:kapchemutwa,Kapchemutwa
+ocd-division/country:ke/county:ke-28/ed:keiyo_north/ward:tambach,Tambach
+ocd-division/country:ke/county:ke-28/ed:keiyo_south,Keiyo South
+ocd-division/country:ke/county:ke-28/ed:keiyo_south/ward:chepkorio,Chepkorio
+ocd-division/country:ke/county:ke-28/ed:keiyo_south/ward:kabiemit,Kabiemit
+ocd-division/country:ke/county:ke-28/ed:keiyo_south/ward:kaptarakwa,Kaptarakwa
+ocd-division/country:ke/county:ke-28/ed:keiyo_south/ward:metkei,Metkei
+ocd-division/country:ke/county:ke-28/ed:keiyo_south/ward:soy_north,Soy North
+ocd-division/country:ke/county:ke-28/ed:keiyo_south/ward:soy_south,Soy South
+ocd-division/country:ke/county:ke-28/ed:marakwet_east,Marakwet East
+ocd-division/country:ke/county:ke-28/ed:marakwet_east/ward:embobut_embulot,Embobut - Embulot
+ocd-division/country:ke/county:ke-28/ed:marakwet_east/ward:endo,Endo
+ocd-division/country:ke/county:ke-28/ed:marakwet_east/ward:kapyego,Kapyego
+ocd-division/country:ke/county:ke-28/ed:marakwet_east/ward:sambirir,Sambirir
+ocd-division/country:ke/county:ke-28/ed:marakwet_west,Marakwet West
+ocd-division/country:ke/county:ke-28/ed:marakwet_west/ward:arror,Arror
+ocd-division/country:ke/county:ke-28/ed:marakwet_west/ward:cherangany_chebororwa,Cherang’any-Chebororwa
+ocd-division/country:ke/county:ke-28/ed:marakwet_west/ward:kapsowar,Kapsowar
+ocd-division/country:ke/county:ke-28/ed:marakwet_west/ward:lelan,Lelan
+ocd-division/country:ke/county:ke-28/ed:marakwet_west/ward:moiben_kuserwo,Moiben-Kuserwo
+ocd-division/country:ke/county:ke-28/ed:marakwet_west/ward:sengwer,Sengwer
+ocd-division/country:ke/county:ke-29,Nandi
+ocd-division/country:ke/county:ke-29/ed:aldai,Aldai
+ocd-division/country:ke/county:ke-29/ed:aldai/ward:kabwareng,Kabwareng
+ocd-division/country:ke/county:ke-29/ed:aldai/ward:kaptumo_kaboi,Kaptumo-Kaboi
+ocd-division/country:ke/county:ke-29/ed:aldai/ward:kemeloi_maraba,Kemeloi-Maraba
+ocd-division/country:ke/county:ke-29/ed:aldai/ward:kobujoi,Kobujoi
+ocd-division/country:ke/county:ke-29/ed:aldai/ward:koyo_ndurio,Koyo-Ndurio
+ocd-division/country:ke/county:ke-29/ed:aldai/ward:terik,Terik
+ocd-division/country:ke/county:ke-29/ed:chesumei,Chesumei
+ocd-division/country:ke/county:ke-29/ed:chesumei/ward:chemundu_kapngetuny,Chemundu-Kapng’etuny
+ocd-division/country:ke/county:ke-29/ed:chesumei/ward:kaptel_kamoiywo,Kaptel-Kamoiywo
+ocd-division/country:ke/county:ke-29/ed:chesumei/ward:kiptuya,Kiptuya
+ocd-division/country:ke/county:ke-29/ed:chesumei/ward:kosirai,Kosirai
+ocd-division/country:ke/county:ke-29/ed:chesumei/ward:lelmokwo_ngechek,Lelmokwo-Ngechek
+ocd-division/country:ke/county:ke-29/ed:emgwen,Emgwen
+ocd-division/country:ke/county:ke-29/ed:emgwen/ward:chepkumia,Chepkumia
+ocd-division/country:ke/county:ke-29/ed:emgwen/ward:kapkangani,Kapkangani
+ocd-division/country:ke/county:ke-29/ed:emgwen/ward:kapsabet,Kapsabet
+ocd-division/country:ke/county:ke-29/ed:emgwen/ward:kilibwoni,Kilibwoni
+ocd-division/country:ke/county:ke-29/ed:mosop,Mosop
+ocd-division/country:ke/county:ke-29/ed:mosop/ward:chepterwai,Chepterwai
+ocd-division/country:ke/county:ke-29/ed:mosop/ward:kabisaga,Kabisaga
+ocd-division/country:ke/county:ke-29/ed:mosop/ward:kabiyet,Kabiyet
+ocd-division/country:ke/county:ke-29/ed:mosop/ward:kipkaren,Kipkaren
+ocd-division/country:ke/county:ke-29/ed:mosop/ward:kurgung_surungai,Kurgung-Surungai
+ocd-division/country:ke/county:ke-29/ed:mosop/ward:ndalat,Ndalat
+ocd-division/country:ke/county:ke-29/ed:mosop/ward:sangalo_kebulonik,Sangalo-Kebulonik
+ocd-division/country:ke/county:ke-29/ed:nandi_hills,Nandi Hills
+ocd-division/country:ke/county:ke-29/ed:nandi_hills/ward:chepkunyuk,Chepkunyuk
+ocd-division/country:ke/county:ke-29/ed:nandi_hills/ward:kapchorua,Kapchorua
+ocd-division/country:ke/county:ke-29/ed:nandi_hills/ward:nandi_hills,Nandi Hills
+ocd-division/country:ke/county:ke-29/ed:nandi_hills/ward:ollessos,Ol’lessos
+ocd-division/country:ke/county:ke-29/ed:tinderet,Tinderet
+ocd-division/country:ke/county:ke-29/ed:tinderet/ward:chemelil_chemase,Chemelil-Chemase
+ocd-division/country:ke/county:ke-29/ed:tinderet/ward:kapsimotwo,Kapsimotwo
+ocd-division/country:ke/county:ke-29/ed:tinderet/ward:songhor_soba,Songhor-Soba
+ocd-division/country:ke/county:ke-29/ed:tinderet/ward:tindiret,Tindiret
+ocd-division/country:ke/county:ke-30,Baringo
+ocd-division/country:ke/county:ke-30/ed:baringo_central,Baringo Central
+ocd-division/country:ke/county:ke-30/ed:baringo_central/ward:ewalel_chapchap,Ewalel-Chapchap
+ocd-division/country:ke/county:ke-30/ed:baringo_central/ward:kabarnet,Kabarnet
+ocd-division/country:ke/county:ke-30/ed:baringo_central/ward:kapropita,Kapropita
+ocd-division/country:ke/county:ke-30/ed:baringo_central/ward:sacho,Sacho
+ocd-division/country:ke/county:ke-30/ed:baringo_central/ward:tenges,Tenges
+ocd-division/country:ke/county:ke-30/ed:baringo_north,Baringo North
+ocd-division/country:ke/county:ke-30/ed:baringo_north/ward:bartabwa,Bartabwa
+ocd-division/country:ke/county:ke-30/ed:baringo_north/ward:barwessa,Barwessa
+ocd-division/country:ke/county:ke-30/ed:baringo_north/ward:kabartonjo,Kabartonjo
+ocd-division/country:ke/county:ke-30/ed:baringo_north/ward:saimo_kipsaraman,Saimo-Kipsaraman
+ocd-division/country:ke/county:ke-30/ed:baringo_north/ward:saimo_soi,Saimo-Soi
+ocd-division/country:ke/county:ke-30/ed:baringo_south,Baringo South
+ocd-division/country:ke/county:ke-30/ed:baringo_south/ward:ilchamus,Ilchamus
+ocd-division/country:ke/county:ke-30/ed:baringo_south/ward:marigat,Marigat
+ocd-division/country:ke/county:ke-30/ed:baringo_south/ward:mochongoi,Mochongoi
+ocd-division/country:ke/county:ke-30/ed:baringo_south/ward:mukutani,Mukutani
+ocd-division/country:ke/county:ke-30/ed:eldama_ravine,Eldama Ravine
+ocd-division/country:ke/county:ke-30/ed:eldama_ravine/ward:koibatek,Koibatek
+ocd-division/country:ke/county:ke-30/ed:eldama_ravine/ward:lembus,Lembus
+ocd-division/country:ke/county:ke-30/ed:eldama_ravine/ward:lembus_kwen,Lembus Kwen
+ocd-division/country:ke/county:ke-30/ed:eldama_ravine/ward:lembus_perkerra,Lembus-Perkerra
+ocd-division/country:ke/county:ke-30/ed:eldama_ravine/ward:mumberes_maji_mazuri,Mumberes-Maji Mazuri
+ocd-division/country:ke/county:ke-30/ed:eldama_ravine/ward:ravine,Ravine
+ocd-division/country:ke/county:ke-30/ed:mogotio,Mogotio
+ocd-division/country:ke/county:ke-30/ed:mogotio/ward:emining,Emining
+ocd-division/country:ke/county:ke-30/ed:mogotio/ward:kisanana,Kisanana
+ocd-division/country:ke/county:ke-30/ed:mogotio/ward:mogotio,Mogotio
+ocd-division/country:ke/county:ke-30/ed:tiaty,Tiaty
+ocd-division/country:ke/county:ke-30/ed:tiaty/ward:churo_amaya,Churo-Amaya
+ocd-division/country:ke/county:ke-30/ed:tiaty/ward:kolowa,Kolowa
+ocd-division/country:ke/county:ke-30/ed:tiaty/ward:loiyamorock,Loiyamorock
+ocd-division/country:ke/county:ke-30/ed:tiaty/ward:ribkwo,Ribkwo
+ocd-division/country:ke/county:ke-30/ed:tiaty/ward:silale,Silale
+ocd-division/country:ke/county:ke-30/ed:tiaty/ward:tangulbei_korossi,Tangulbei-Korossi
+ocd-division/country:ke/county:ke-30/ed:tiaty/ward:tirioko,Tirioko
+ocd-division/country:ke/county:ke-31,Laikipia
+ocd-division/country:ke/county:ke-31/ed:laikipia_east,Laikipia East
+ocd-division/country:ke/county:ke-31/ed:laikipia_east/ward:nanyuki,Nanyuki
+ocd-division/country:ke/county:ke-31/ed:laikipia_east/ward:ngobit,Ngobit
+ocd-division/country:ke/county:ke-31/ed:laikipia_east/ward:thingithu,Thingithu
+ocd-division/country:ke/county:ke-31/ed:laikipia_east/ward:tigithi,Tigithi
+ocd-division/country:ke/county:ke-31/ed:laikipia_east/ward:umande,Umande
+ocd-division/country:ke/county:ke-31/ed:laikipia_north,Laikipia North
+ocd-division/country:ke/county:ke-31/ed:laikipia_north/ward:mugogodo_east,Mugogodo East
+ocd-division/country:ke/county:ke-31/ed:laikipia_north/ward:mugogodo_west,Mugogodo West
+ocd-division/country:ke/county:ke-31/ed:laikipia_north/ward:segera,Segera
+ocd-division/country:ke/county:ke-31/ed:laikipia_north/ward:sosian,Sosian
+ocd-division/country:ke/county:ke-31/ed:laikipia_west,Laikipia West
+ocd-division/country:ke/county:ke-31/ed:laikipia_west/ward:githiga,Githiga
+ocd-division/country:ke/county:ke-31/ed:laikipia_west/ward:igwamiti,Igwamiti
+ocd-division/country:ke/county:ke-31/ed:laikipia_west/ward:marmanet,Marmanet
+ocd-division/country:ke/county:ke-31/ed:laikipia_west/ward:ol_moran,Ol-Moran
+ocd-division/country:ke/county:ke-31/ed:laikipia_west/ward:rumuruti_township,Rumuruti Township
+ocd-division/country:ke/county:ke-31/ed:laikipia_west/ward:salama,Salama
+ocd-division/country:ke/county:ke-32,Nakuru
+ocd-division/country:ke/county:ke-32/ed:bahati,Bahati
+ocd-division/country:ke/county:ke-32/ed:bahati/ward:bahati,Bahati
+ocd-division/country:ke/county:ke-32/ed:bahati/ward:dundori,Dundori
+ocd-division/country:ke/county:ke-32/ed:bahati/ward:kabatini,Kabatini
+ocd-division/country:ke/county:ke-32/ed:bahati/ward:kiamaina,Kiamaina
+ocd-division/country:ke/county:ke-32/ed:bahati/ward:lanet_umoja,Lanet-Umoja
+ocd-division/country:ke/county:ke-32/ed:gilgil,Gilgil
+ocd-division/country:ke/county:ke-32/ed:gilgil/ward:elementaita,Elementaita
+ocd-division/country:ke/county:ke-32/ed:gilgil/ward:gilgil,Gilgil
+ocd-division/country:ke/county:ke-32/ed:gilgil/ward:malewa_west,Malewa West
+ocd-division/country:ke/county:ke-32/ed:gilgil/ward:mbaruk_eburu,Mbaruk-Eburu
+ocd-division/country:ke/county:ke-32/ed:gilgil/ward:murindati,Murindati
+ocd-division/country:ke/county:ke-32/ed:kuresoi_north,Kuresoi North
+ocd-division/country:ke/county:ke-32/ed:kuresoi_north/ward:kamara,Kamara
+ocd-division/country:ke/county:ke-32/ed:kuresoi_north/ward:kiptororo,Kiptororo
+ocd-division/country:ke/county:ke-32/ed:kuresoi_north/ward:nyota,Nyota
+ocd-division/country:ke/county:ke-32/ed:kuresoi_north/ward:sirikwa,Sirikwa
+ocd-division/country:ke/county:ke-32/ed:kuresoi_south,Kuresoi South
+ocd-division/country:ke/county:ke-32/ed:kuresoi_south/ward:amalo,Amalo
+ocd-division/country:ke/county:ke-32/ed:kuresoi_south/ward:keringet,Keringet
+ocd-division/country:ke/county:ke-32/ed:kuresoi_south/ward:kiptagich,Kiptagich
+ocd-division/country:ke/county:ke-32/ed:kuresoi_south/ward:tinet,Tinet
+ocd-division/country:ke/county:ke-32/ed:molo,Molo
+ocd-division/country:ke/county:ke-32/ed:molo/ward:elburgon,Elburgon
+ocd-division/country:ke/county:ke-32/ed:molo/ward:mariashoni,Mariashoni
+ocd-division/country:ke/county:ke-32/ed:molo/ward:molo,Molo
+ocd-division/country:ke/county:ke-32/ed:molo/ward:turi,Turi
+ocd-division/country:ke/county:ke-32/ed:naivasha,Naivasha
+ocd-division/country:ke/county:ke-32/ed:naivasha/ward:biashara,Biashara
+ocd-division/country:ke/county:ke-32/ed:naivasha/ward:hells_gate,Hells Gate
+ocd-division/country:ke/county:ke-32/ed:naivasha/ward:lake_view,Lake View
+ocd-division/country:ke/county:ke-32/ed:naivasha/ward:mai_mahiu,Mai Mahiu
+ocd-division/country:ke/county:ke-32/ed:naivasha/ward:maiella,Maiella
+ocd-division/country:ke/county:ke-32/ed:naivasha/ward:naivasha_east,Naivasha East
+ocd-division/country:ke/county:ke-32/ed:naivasha/ward:olkaria,Olkaria
+ocd-division/country:ke/county:ke-32/ed:naivasha/ward:viwandani,Viwandani
+ocd-division/country:ke/county:ke-32/ed:nakuru_town_east,Nakuru Town East
+ocd-division/country:ke/county:ke-32/ed:nakuru_town_east/ward:biashara,Biashara
+ocd-division/country:ke/county:ke-32/ed:nakuru_town_east/ward:flamingo,Flamingo
+ocd-division/country:ke/county:ke-32/ed:nakuru_town_east/ward:kivumbini,Kivumbini
+ocd-division/country:ke/county:ke-32/ed:nakuru_town_east/ward:menengai,Menengai
+ocd-division/country:ke/county:ke-32/ed:nakuru_town_east/ward:nakuru_east,Nakuru East
+ocd-division/country:ke/county:ke-32/ed:nakuru_town_west,Nakuru Town West
+ocd-division/country:ke/county:ke-32/ed:nakuru_town_west/ward:barut,Barut
+ocd-division/country:ke/county:ke-32/ed:nakuru_town_west/ward:kapkures,Kapkures
+ocd-division/country:ke/county:ke-32/ed:nakuru_town_west/ward:kaptembwo,Kaptembwo
+ocd-division/country:ke/county:ke-32/ed:nakuru_town_west/ward:london,London
+ocd-division/country:ke/county:ke-32/ed:nakuru_town_west/ward:rhoda,Rhoda
+ocd-division/country:ke/county:ke-32/ed:nakuru_town_west/ward:shaabab,Shaabab
+ocd-division/country:ke/county:ke-32/ed:njoro,Njoro
+ocd-division/country:ke/county:ke-32/ed:njoro/ward:kihingo,Kihingo
+ocd-division/country:ke/county:ke-32/ed:njoro/ward:lare,Lare
+ocd-division/country:ke/county:ke-32/ed:njoro/ward:mau_narok,Mau Narok
+ocd-division/country:ke/county:ke-32/ed:njoro/ward:mauche,Mauche
+ocd-division/country:ke/county:ke-32/ed:njoro/ward:nessuit,Nessuit
+ocd-division/country:ke/county:ke-32/ed:njoro/ward:njoro,Njoro
+ocd-division/country:ke/county:ke-32/ed:rongai,Rongai
+ocd-division/country:ke/county:ke-32/ed:rongai/ward:menengai_west,Menengai West
+ocd-division/country:ke/county:ke-32/ed:rongai/ward:mosop,Mosop
+ocd-division/country:ke/county:ke-32/ed:rongai/ward:soin,Soin
+ocd-division/country:ke/county:ke-32/ed:rongai/ward:solai,Solai
+ocd-division/country:ke/county:ke-32/ed:rongai/ward:visoi,Visoi
+ocd-division/country:ke/county:ke-32/ed:subukia,Subukia
+ocd-division/country:ke/county:ke-32/ed:subukia/ward:kabazi,Kabazi
+ocd-division/country:ke/county:ke-32/ed:subukia/ward:subukia,Subukia
+ocd-division/country:ke/county:ke-32/ed:subukia/ward:waseges,Waseges
+ocd-division/country:ke/county:ke-33,Narok
+ocd-division/country:ke/county:ke-33/ed:emurua_dikirr,Emurua Dikirr
+ocd-division/country:ke/county:ke-33/ed:emurua_dikirr/ward:ilkerin,Ilkerin
+ocd-division/country:ke/county:ke-33/ed:emurua_dikirr/ward:kapsasian,Kapsasian
+ocd-division/country:ke/county:ke-33/ed:emurua_dikirr/ward:mogondo,Mogondo
+ocd-division/country:ke/county:ke-33/ed:emurua_dikirr/ward:ololmasani,Ololmasani
+ocd-division/country:ke/county:ke-33/ed:kilgoris,Kilgoris
+ocd-division/country:ke/county:ke-33/ed:kilgoris/ward:angata_barikoi,Angata Barikoi
+ocd-division/country:ke/county:ke-33/ed:kilgoris/ward:keyian,Keyian
+ocd-division/country:ke/county:ke-33/ed:kilgoris/ward:kilgoris_central,Kilgoris Central
+ocd-division/country:ke/county:ke-33/ed:kilgoris/ward:kimintet,Kimintet
+ocd-division/country:ke/county:ke-33/ed:kilgoris/ward:lolgorian,Lolgorian
+ocd-division/country:ke/county:ke-33/ed:kilgoris/ward:shankoe,Shankoe
+ocd-division/country:ke/county:ke-33/ed:narok_east,Narok East
+ocd-division/country:ke/county:ke-33/ed:narok_east/ward:ildamat,Ildamat
+ocd-division/country:ke/county:ke-33/ed:narok_east/ward:keekonyokie,Keekonyokie
+ocd-division/country:ke/county:ke-33/ed:narok_east/ward:mosiro,Mosiro
+ocd-division/country:ke/county:ke-33/ed:narok_east/ward:suswa,Suswa
+ocd-division/country:ke/county:ke-33/ed:narok_north,Narok North
+ocd-division/country:ke/county:ke-33/ed:narok_north/ward:melili,Melili
+ocd-division/country:ke/county:ke-33/ed:narok_north/ward:narok_town,Narok Town
+ocd-division/country:ke/county:ke-33/ed:narok_north/ward:nkareta,Nkareta
+ocd-division/country:ke/county:ke-33/ed:narok_north/ward:olokurto,Olokurto
+ocd-division/country:ke/county:ke-33/ed:narok_north/ward:olorropil,Olorropil
+ocd-division/country:ke/county:ke-33/ed:narok_north/ward:olpusimoru,Olpusimoru
+ocd-division/country:ke/county:ke-33/ed:narok_south,Narok South
+ocd-division/country:ke/county:ke-33/ed:narok_south/ward:loita,Loita
+ocd-division/country:ke/county:ke-33/ed:narok_south/ward:majimoto_naroosura,Majimoto-Naroosura
+ocd-division/country:ke/county:ke-33/ed:narok_south/ward:melelo,Melelo
+ocd-division/country:ke/county:ke-33/ed:narok_south/ward:ololulunga,Ololulung’a
+ocd-division/country:ke/county:ke-33/ed:narok_south/ward:sagamian,Sagamian
+ocd-division/country:ke/county:ke-33/ed:narok_south/ward:sogoo,Sogoo
+ocd-division/country:ke/county:ke-33/ed:narok_west,Narok West
+ocd-division/country:ke/county:ke-33/ed:narok_west/ward:ilmotiok,Ilmotiok
+ocd-division/country:ke/county:ke-33/ed:narok_west/ward:mara,Mara
+ocd-division/country:ke/county:ke-33/ed:narok_west/ward:naikarra,Naikarra
+ocd-division/country:ke/county:ke-33/ed:narok_west/ward:siana,Siana
+ocd-division/country:ke/county:ke-34,Kajiado
+ocd-division/country:ke/county:ke-34/ed:kajiado_central,Kajiado Central
+ocd-division/country:ke/county:ke-34/ed:kajiado_central/ward:dalalekutuk,Dalalekutuk
+ocd-division/country:ke/county:ke-34/ed:kajiado_central/ward:ildamat,Ildamat
+ocd-division/country:ke/county:ke-34/ed:kajiado_central/ward:matapato_north,Matapato North
+ocd-division/country:ke/county:ke-34/ed:kajiado_central/ward:matapato_south,Matapato South
+ocd-division/country:ke/county:ke-34/ed:kajiado_central/ward:purko,Purko
+ocd-division/country:ke/county:ke-34/ed:kajiado_east,Kajiado East
+ocd-division/country:ke/county:ke-34/ed:kajiado_east/ward:imaroro,Imaroro
+ocd-division/country:ke/county:ke-34/ed:kajiado_east/ward:kaputiei_north,Kaputiei North
+ocd-division/country:ke/county:ke-34/ed:kajiado_east/ward:kenyawa_poka,Kenyawa-Poka
+ocd-division/country:ke/county:ke-34/ed:kajiado_east/ward:kitengela,Kitengela
+ocd-division/country:ke/county:ke-34/ed:kajiado_east/ward:oloosirkon_sholinke,Oloosirkon-Sholinke
+ocd-division/country:ke/county:ke-34/ed:kajiado_north,Kajiado North
+ocd-division/country:ke/county:ke-34/ed:kajiado_north/ward:ngong,Ngong
+ocd-division/country:ke/county:ke-34/ed:kajiado_north/ward:nkaimurunya,Nkaimurunya
+ocd-division/country:ke/county:ke-34/ed:kajiado_north/ward:olkeri,Olkeri
+ocd-division/country:ke/county:ke-34/ed:kajiado_north/ward:oloolua,Oloolua
+ocd-division/country:ke/county:ke-34/ed:kajiado_north/ward:ongata_rongai,Ongata Rongai
+ocd-division/country:ke/county:ke-34/ed:kajiado_south,Kajiado South
+ocd-division/country:ke/county:ke-34/ed:kajiado_south/ward:entonet_lenkisim,Entonet-Lenkisim
+ocd-division/country:ke/county:ke-34/ed:kajiado_south/ward:kimana,Kimana
+ocd-division/country:ke/county:ke-34/ed:kajiado_south/ward:kuku,Kuku
+ocd-division/country:ke/county:ke-34/ed:kajiado_south/ward:mbirikani_eselenkei,Mbirikani-Eselenkei
+ocd-division/country:ke/county:ke-34/ed:kajiado_south/ward:rombo,Rombo
+ocd-division/country:ke/county:ke-34/ed:kajiado_west,Kajiado West
+ocd-division/country:ke/county:ke-34/ed:kajiado_west/ward:ewuaso_oonkidongi,Ewuaso Oonkidong’i
+ocd-division/country:ke/county:ke-34/ed:kajiado_west/ward:iloodokilani,Iloodokilani
+ocd-division/country:ke/county:ke-34/ed:kajiado_west/ward:keekonyokie,Keekonyokie
+ocd-division/country:ke/county:ke-34/ed:kajiado_west/ward:magadi,Magadi
+ocd-division/country:ke/county:ke-34/ed:kajiado_west/ward:mosiro,Mosiro
+ocd-division/country:ke/county:ke-35,Kericho
+ocd-division/country:ke/county:ke-35/ed:ainamoi,Ainamoi
+ocd-division/country:ke/county:ke-35/ed:ainamoi/ward:ainamoi,Ainamoi
+ocd-division/country:ke/county:ke-35/ed:ainamoi/ward:kapkugerwet,Kapkugerwet
+ocd-division/country:ke/county:ke-35/ed:ainamoi/ward:kapsaos,Kapsaos
+ocd-division/country:ke/county:ke-35/ed:ainamoi/ward:kapsoit,Kapsoit
+ocd-division/country:ke/county:ke-35/ed:ainamoi/ward:kipchebor,Kipchebor
+ocd-division/country:ke/county:ke-35/ed:ainamoi/ward:kipchimchim,Kipchimchim
+ocd-division/country:ke/county:ke-35/ed:belgut,Belgut
+ocd-division/country:ke/county:ke-35/ed:belgut/ward:chaik,Chaik
+ocd-division/country:ke/county:ke-35/ed:belgut/ward:cheptororiet_seretut,Cheptororiet-Seretut
+ocd-division/country:ke/county:ke-35/ed:belgut/ward:kabianga,Kabianga
+ocd-division/country:ke/county:ke-35/ed:belgut/ward:kapsuser,Kapsuser
+ocd-division/country:ke/county:ke-35/ed:belgut/ward:waldai,Waldai
+ocd-division/country:ke/county:ke-35/ed:bureti,Bureti
+ocd-division/country:ke/county:ke-35/ed:bureti/ward:cheboin,Cheboin
+ocd-division/country:ke/county:ke-35/ed:bureti/ward:chemosot,Chemosot
+ocd-division/country:ke/county:ke-35/ed:bureti/ward:cheplanget,Cheplanget
+ocd-division/country:ke/county:ke-35/ed:bureti/ward:kapkatet,Kapkatet
+ocd-division/country:ke/county:ke-35/ed:bureti/ward:kisiara,Kisiara
+ocd-division/country:ke/county:ke-35/ed:bureti/ward:litein,Litein
+ocd-division/country:ke/county:ke-35/ed:bureti/ward:tebesonik,Tebesonik
+ocd-division/country:ke/county:ke-35/ed:kipkelion_east,Kipkelion East
+ocd-division/country:ke/county:ke-35/ed:kipkelion_east/ward:chepseon,Chepseon
+ocd-division/country:ke/county:ke-35/ed:kipkelion_east/ward:kedowa_kimugul,Kedowa-Kimugul
+ocd-division/country:ke/county:ke-35/ed:kipkelion_east/ward:londiani,Londiani
+ocd-division/country:ke/county:ke-35/ed:kipkelion_east/ward:tendeno_sorget,Tendeno-Sorget
+ocd-division/country:ke/county:ke-35/ed:kipkelion_west,Kipkelion West
+ocd-division/country:ke/county:ke-35/ed:kipkelion_west/ward:chilchila,Chilchila
+ocd-division/country:ke/county:ke-35/ed:kipkelion_west/ward:kamasian,Kamasian
+ocd-division/country:ke/county:ke-35/ed:kipkelion_west/ward:kipkelion,Kipkelion
+ocd-division/country:ke/county:ke-35/ed:kipkelion_west/ward:kunyak,Kunyak
+ocd-division/country:ke/county:ke-35/ed:sigowet_soin,Sigowet Soin
+ocd-division/country:ke/county:ke-35/ed:sigowet_soin/ward:kaplelartet,Kaplelartet
+ocd-division/country:ke/county:ke-35/ed:sigowet_soin/ward:sigowet,Sigowet
+ocd-division/country:ke/county:ke-35/ed:sigowet_soin/ward:soin,Soin
+ocd-division/country:ke/county:ke-35/ed:sigowet_soin/ward:soliat,Soliat
+ocd-division/country:ke/county:ke-36,Bomet
+ocd-division/country:ke/county:ke-36/ed:bomet_central,Bomet Central
+ocd-division/country:ke/county:ke-36/ed:bomet_central/ward:chesoen,Chesoen
+ocd-division/country:ke/county:ke-36/ed:bomet_central/ward:mutarakwa,Mutarakwa
+ocd-division/country:ke/county:ke-36/ed:bomet_central/ward:ndaraweta,Ndaraweta
+ocd-division/country:ke/county:ke-36/ed:bomet_central/ward:silibwet_township,Silibwet Township
+ocd-division/country:ke/county:ke-36/ed:bomet_central/ward:singorwet,Singorwet
+ocd-division/country:ke/county:ke-36/ed:bomet_east,Bomet East
+ocd-division/country:ke/county:ke-36/ed:bomet_east/ward:chemaner,Chemaner
+ocd-division/country:ke/county:ke-36/ed:bomet_east/ward:kembu,Kembu
+ocd-division/country:ke/county:ke-36/ed:bomet_east/ward:kipreres,Kipreres
+ocd-division/country:ke/county:ke-36/ed:bomet_east/ward:longisa,Longisa
+ocd-division/country:ke/county:ke-36/ed:bomet_east/ward:merigi,Merigi
+ocd-division/country:ke/county:ke-36/ed:chepalungu,Chepalungu
+ocd-division/country:ke/county:ke-36/ed:chepalungu/ward:chebunyo,Chebunyo
+ocd-division/country:ke/county:ke-36/ed:chepalungu/ward:kongasis,Kong’asis
+ocd-division/country:ke/county:ke-36/ed:chepalungu/ward:nyangores,Nyangores
+ocd-division/country:ke/county:ke-36/ed:chepalungu/ward:sigor,Sigor
+ocd-division/country:ke/county:ke-36/ed:chepalungu/ward:siongiroi,Siongiroi
+ocd-division/country:ke/county:ke-36/ed:konoin,Konoin
+ocd-division/country:ke/county:ke-36/ed:konoin/ward:boito,Boito
+ocd-division/country:ke/county:ke-36/ed:konoin/ward:chepchabas,Chepchabas
+ocd-division/country:ke/county:ke-36/ed:konoin/ward:embomos,Embomos
+ocd-division/country:ke/county:ke-36/ed:konoin/ward:kimulot,Kimulot
+ocd-division/country:ke/county:ke-36/ed:konoin/ward:mogogosiek,Mogogosiek
+ocd-division/country:ke/county:ke-36/ed:sotik,Sotik
+ocd-division/country:ke/county:ke-36/ed:sotik/ward:chemagel,Chemagel
+ocd-division/country:ke/county:ke-36/ed:sotik/ward:kapletundo,Kapletundo
+ocd-division/country:ke/county:ke-36/ed:sotik/ward:kipsonoi,Kipsonoi
+ocd-division/country:ke/county:ke-36/ed:sotik/ward:ndanai_abosi,Ndanai-Abosi
+ocd-division/country:ke/county:ke-36/ed:sotik/ward:rongena_manaret,Rongena-Manaret
+ocd-division/country:ke/county:ke-37,Kakamega
+ocd-division/country:ke/county:ke-37/ed:butere,Butere
+ocd-division/country:ke/county:ke-37/ed:butere/ward:marama_central,Marama Central
+ocd-division/country:ke/county:ke-37/ed:butere/ward:marama_north,Marama North
+ocd-division/country:ke/county:ke-37/ed:butere/ward:marama_south,Marama South
+ocd-division/country:ke/county:ke-37/ed:butere/ward:marama_west,Marama West
+ocd-division/country:ke/county:ke-37/ed:butere/ward:marenyo_shianda,Marenyo - Shianda
+ocd-division/country:ke/county:ke-37/ed:ikolomani,Ikolomani
+ocd-division/country:ke/county:ke-37/ed:ikolomani/ward:idakho_central,Idakho Central
+ocd-division/country:ke/county:ke-37/ed:ikolomani/ward:idakho_east,Idakho East
+ocd-division/country:ke/county:ke-37/ed:ikolomani/ward:idakho_north,Idakho North
+ocd-division/country:ke/county:ke-37/ed:ikolomani/ward:idakho_south,Idakho South
+ocd-division/country:ke/county:ke-37/ed:khwisero,Khwisero
+ocd-division/country:ke/county:ke-37/ed:khwisero/ward:kisa_central,Kisa Central
+ocd-division/country:ke/county:ke-37/ed:khwisero/ward:kisa_east,Kisa East
+ocd-division/country:ke/county:ke-37/ed:khwisero/ward:kisa_north,Kisa North
+ocd-division/country:ke/county:ke-37/ed:khwisero/ward:kisa_west,Kisa West
+ocd-division/country:ke/county:ke-37/ed:likuyani,Likuyani
+ocd-division/country:ke/county:ke-37/ed:likuyani/ward:kongoni,Kongoni
+ocd-division/country:ke/county:ke-37/ed:likuyani/ward:likuyani,Likuyani
+ocd-division/country:ke/county:ke-37/ed:likuyani/ward:nzoia,Nzoia
+ocd-division/country:ke/county:ke-37/ed:likuyani/ward:sango,Sango
+ocd-division/country:ke/county:ke-37/ed:likuyani/ward:sinoko,Sinoko
+ocd-division/country:ke/county:ke-37/ed:lugari,Lugari
+ocd-division/country:ke/county:ke-37/ed:lugari/ward:chekalini,Chekalini
+ocd-division/country:ke/county:ke-37/ed:lugari/ward:chevaywa,Chevaywa
+ocd-division/country:ke/county:ke-37/ed:lugari/ward:lugari,Lugari
+ocd-division/country:ke/county:ke-37/ed:lugari/ward:lumakanda,Lumakanda
+ocd-division/country:ke/county:ke-37/ed:lugari/ward:lwandeti,Lwandeti
+ocd-division/country:ke/county:ke-37/ed:lugari/ward:mautuma,Mautuma
+ocd-division/country:ke/county:ke-37/ed:lurambi,Lurambi
+ocd-division/country:ke/county:ke-37/ed:lurambi/ward:butsotso_central,Butsotso Central
+ocd-division/country:ke/county:ke-37/ed:lurambi/ward:butsotso_east,Butsotso East
+ocd-division/country:ke/county:ke-37/ed:lurambi/ward:butsotso_south,Butsotso South
+ocd-division/country:ke/county:ke-37/ed:lurambi/ward:mahiakalo,Mahiakalo
+ocd-division/country:ke/county:ke-37/ed:lurambi/ward:sheywe,Sheywe
+ocd-division/country:ke/county:ke-37/ed:lurambi/ward:shirere,Shirere
+ocd-division/country:ke/county:ke-37/ed:malava,Malava
+ocd-division/country:ke/county:ke-37/ed:malava/ward:butali_chegulo,Butali-Chegulo
+ocd-division/country:ke/county:ke-37/ed:malava/ward:chemuche,Chemuche
+ocd-division/country:ke/county:ke-37/ed:malava/ward:east_kabras,East Kabras
+ocd-division/country:ke/county:ke-37/ed:malava/ward:manda_shivanga,Manda-Shivanga
+ocd-division/country:ke/county:ke-37/ed:malava/ward:shirugu_mugai,Shirugu-Mugai
+ocd-division/country:ke/county:ke-37/ed:malava/ward:south_kabras,South Kabras
+ocd-division/country:ke/county:ke-37/ed:malava/ward:west_kabras,West Kabras
+ocd-division/country:ke/county:ke-37/ed:matungu,Matungu
+ocd-division/country:ke/county:ke-37/ed:matungu/ward:khalaba,Khalaba
+ocd-division/country:ke/county:ke-37/ed:matungu/ward:kholera,Kholera
+ocd-division/country:ke/county:ke-37/ed:matungu/ward:koyonzo,Koyonzo
+ocd-division/country:ke/county:ke-37/ed:matungu/ward:mayoni,Mayoni
+ocd-division/country:ke/county:ke-37/ed:matungu/ward:namamali,Namamali
+ocd-division/country:ke/county:ke-37/ed:mumias_east,Mumias East
+ocd-division/country:ke/county:ke-37/ed:mumias_east/ward:east_wanga,East Wanga
+ocd-division/country:ke/county:ke-37/ed:mumias_east/ward:lusheya_lubinu,Lusheya-Lubinu
+ocd-division/country:ke/county:ke-37/ed:mumias_east/ward:malaha_isongo_makunga,Malaha-Isongo-Makunga
+ocd-division/country:ke/county:ke-37/ed:mumias_west,Mumias West
+ocd-division/country:ke/county:ke-37/ed:mumias_west/ward:etenje,Etenje
+ocd-division/country:ke/county:ke-37/ed:mumias_west/ward:mumias_central,Mumias Central
+ocd-division/country:ke/county:ke-37/ed:mumias_west/ward:mumias_north,Mumias North
+ocd-division/country:ke/county:ke-37/ed:mumias_west/ward:musanda,Musanda
+ocd-division/country:ke/county:ke-37/ed:navakholo,Navakholo
+ocd-division/country:ke/county:ke-37/ed:navakholo/ward:bunyala_central,Bunyala Central
+ocd-division/country:ke/county:ke-37/ed:navakholo/ward:bunyala_east,Bunyala East
+ocd-division/country:ke/county:ke-37/ed:navakholo/ward:bunyala_west,Bunyala West
+ocd-division/country:ke/county:ke-37/ed:navakholo/ward:ingostse_mathia,Ingostse-Mathia
+ocd-division/country:ke/county:ke-37/ed:navakholo/ward:shinoyi_shikomari_esumeyia,Shinoyi-Shikomari-Esumeyia
+ocd-division/country:ke/county:ke-37/ed:shinyalu,Shinyalu
+ocd-division/country:ke/county:ke-37/ed:shinyalu/ward:isukha_central,Isukha Central
+ocd-division/country:ke/county:ke-37/ed:shinyalu/ward:isukha_east,Isukha East
+ocd-division/country:ke/county:ke-37/ed:shinyalu/ward:isukha_north,Isukha North
+ocd-division/country:ke/county:ke-37/ed:shinyalu/ward:isukha_south,Isukha South
+ocd-division/country:ke/county:ke-37/ed:shinyalu/ward:isukha_west,Isukha West
+ocd-division/country:ke/county:ke-37/ed:shinyalu/ward:murhanda,Murhanda
+ocd-division/country:ke/county:ke-38,Vihiga
+ocd-division/country:ke/county:ke-38/ed:emuhaya,Emuhaya
+ocd-division/country:ke/county:ke-38/ed:emuhaya/ward:central_bunyore,Central Bunyore
+ocd-division/country:ke/county:ke-38/ed:emuhaya/ward:north_east_bunyore,North East Bunyore
+ocd-division/country:ke/county:ke-38/ed:emuhaya/ward:west_bunyore,West Bunyore
+ocd-division/country:ke/county:ke-38/ed:hamisi,Hamisi
+ocd-division/country:ke/county:ke-38/ed:hamisi/ward:banja,Banja
+ocd-division/country:ke/county:ke-38/ed:hamisi/ward:gisambai,Gisambai
+ocd-division/country:ke/county:ke-38/ed:hamisi/ward:jepkoyai,Jepkoyai
+ocd-division/country:ke/county:ke-38/ed:hamisi/ward:muhudu,Muhudu
+ocd-division/country:ke/county:ke-38/ed:hamisi/ward:shamakhokho,Shamakhokho
+ocd-division/country:ke/county:ke-38/ed:hamisi/ward:shiru,Shiru
+ocd-division/country:ke/county:ke-38/ed:hamisi/ward:tambua,Tambua
+ocd-division/country:ke/county:ke-38/ed:luanda,Luanda
+ocd-division/country:ke/county:ke-38/ed:luanda/ward:emabungo,Emabungo
+ocd-division/country:ke/county:ke-38/ed:luanda/ward:luanda_south,Luanda South
+ocd-division/country:ke/county:ke-38/ed:luanda/ward:luanda_township,Luanda Township
+ocd-division/country:ke/county:ke-38/ed:luanda/ward:mwibona,Mwibona
+ocd-division/country:ke/county:ke-38/ed:luanda/ward:wemilabi,Wemilabi
+ocd-division/country:ke/county:ke-38/ed:sabatia,Sabatia
+ocd-division/country:ke/county:ke-38/ed:sabatia/ward:busali,Busali
+ocd-division/country:ke/county:ke-38/ed:sabatia/ward:chavakali,Chavakali
+ocd-division/country:ke/county:ke-38/ed:sabatia/ward:lyaduywa_izava,Lyaduywa-Izava
+ocd-division/country:ke/county:ke-38/ed:sabatia/ward:north_maragoli,North Maragoli
+ocd-division/country:ke/county:ke-38/ed:sabatia/ward:west_sabatia,West Sabatia
+ocd-division/country:ke/county:ke-38/ed:sabatia/ward:wodanga,Wodanga
+ocd-division/country:ke/county:ke-38/ed:vihiga,Vihiga
+ocd-division/country:ke/county:ke-38/ed:vihiga/ward:central_maragoli,Central Maragoli
+ocd-division/country:ke/county:ke-38/ed:vihiga/ward:lugaga_wamuluma,Lugaga-Wamuluma
+ocd-division/country:ke/county:ke-38/ed:vihiga/ward:mungoma,Mungoma
+ocd-division/country:ke/county:ke-38/ed:vihiga/ward:south_maragoli,South Maragoli
+ocd-division/country:ke/county:ke-39,Bungoma
+ocd-division/country:ke/county:ke-39/ed:bumula,Bumula
+ocd-division/country:ke/county:ke-39/ed:bumula/ward:bumula,Bumula
+ocd-division/country:ke/county:ke-39/ed:bumula/ward:kabula,Kabula
+ocd-division/country:ke/county:ke-39/ed:bumula/ward:khasoko,Khasoko
+ocd-division/country:ke/county:ke-39/ed:bumula/ward:kimaeti,Kimaeti
+ocd-division/country:ke/county:ke-39/ed:bumula/ward:siboti,Siboti
+ocd-division/country:ke/county:ke-39/ed:bumula/ward:south_bukusu,South Bukusu
+ocd-division/country:ke/county:ke-39/ed:bumula/ward:west_bukusu,West Bukusu
+ocd-division/country:ke/county:ke-39/ed:kabuchai,Kabuchai
+ocd-division/country:ke/county:ke-39/ed:kabuchai/ward:bwake_luuya,Bwake-Luuya
+ocd-division/country:ke/county:ke-39/ed:kabuchai/ward:kabuchai_chwele,Kabuchai-Chwele
+ocd-division/country:ke/county:ke-39/ed:kabuchai/ward:mukuyuni,Mukuyuni
+ocd-division/country:ke/county:ke-39/ed:kabuchai/ward:west_nalondo,West Nalondo
+ocd-division/country:ke/county:ke-39/ed:kanduyi,Kanduyi
+ocd-division/country:ke/county:ke-39/ed:kanduyi/ward:bukembe_east,Bukembe East
+ocd-division/country:ke/county:ke-39/ed:kanduyi/ward:bukembe_west,Bukembe West
+ocd-division/country:ke/county:ke-39/ed:kanduyi/ward:east_sangalo,East Sang’alo
+ocd-division/country:ke/county:ke-39/ed:kanduyi/ward:khalaba,Khalaba
+ocd-division/country:ke/county:ke-39/ed:kanduyi/ward:marakaru_tuuti,Marakaru-Tuuti
+ocd-division/country:ke/county:ke-39/ed:kanduyi/ward:musikoma,Musikoma
+ocd-division/country:ke/county:ke-39/ed:kanduyi/ward:township,Township
+ocd-division/country:ke/county:ke-39/ed:kanduyi/ward:west_sangalo,West Sang’alo
+ocd-division/country:ke/county:ke-39/ed:kimilili,Kimilili
+ocd-division/country:ke/county:ke-39/ed:kimilili/ward:kamukuywa,Kamukuywa
+ocd-division/country:ke/county:ke-39/ed:kimilili/ward:kibingei,Kibingei
+ocd-division/country:ke/county:ke-39/ed:kimilili/ward:kimilili,Kimilili
+ocd-division/country:ke/county:ke-39/ed:kimilili/ward:maeni,Maeni
+ocd-division/country:ke/county:ke-39/ed:mt._elgon,Mt. Elgon
+ocd-division/country:ke/county:ke-39/ed:mt._elgon/ward:cheptais,Cheptais
+ocd-division/country:ke/county:ke-39/ed:mt._elgon/ward:chepyuk,Chepyuk
+ocd-division/country:ke/county:ke-39/ed:mt._elgon/ward:chesikaki,Chesikaki
+ocd-division/country:ke/county:ke-39/ed:mt._elgon/ward:elgon,Elgon
+ocd-division/country:ke/county:ke-39/ed:mt._elgon/ward:kapkateny,Kapkateny
+ocd-division/country:ke/county:ke-39/ed:mt._elgon/ward:kaptama,Kaptama
+ocd-division/country:ke/county:ke-39/ed:sirisia,Sirisia
+ocd-division/country:ke/county:ke-39/ed:sirisia/ward:lwandanyi,Lwandanyi
+ocd-division/country:ke/county:ke-39/ed:sirisia/ward:malakisi_south_kulisiru,Malakisi-South Kulisiru
+ocd-division/country:ke/county:ke-39/ed:sirisia/ward:namwela,Namwela
+ocd-division/country:ke/county:ke-39/ed:tongaren,Tongaren
+ocd-division/country:ke/county:ke-39/ed:tongaren/ward:mbakalo,Mbakalo
+ocd-division/country:ke/county:ke-39/ed:tongaren/ward:milima,Milima
+ocd-division/country:ke/county:ke-39/ed:tongaren/ward:naitiri_kabuyefwe,Naitiri-Kabuyefwe
+ocd-division/country:ke/county:ke-39/ed:tongaren/ward:ndalu_tabani,Ndalu- Tabani
+ocd-division/country:ke/county:ke-39/ed:tongaren/ward:soysambu_mitua,Soysambu- Mitua
+ocd-division/country:ke/county:ke-39/ed:tongaren/ward:tongaren,Tongaren
+ocd-division/country:ke/county:ke-39/ed:webuye_east,Webuye East
+ocd-division/country:ke/county:ke-39/ed:webuye_east/ward:maraka,Maraka
+ocd-division/country:ke/county:ke-39/ed:webuye_east/ward:mihuu,Mihuu
+ocd-division/country:ke/county:ke-39/ed:webuye_east/ward:ndivisi,Ndivisi
+ocd-division/country:ke/county:ke-39/ed:webuye_west,Webuye West
+ocd-division/country:ke/county:ke-39/ed:webuye_west/ward:bokoli,Bokoli
+ocd-division/country:ke/county:ke-39/ed:webuye_west/ward:matulo,Matulo
+ocd-division/country:ke/county:ke-39/ed:webuye_west/ward:misikhu,Misikhu
+ocd-division/country:ke/county:ke-39/ed:webuye_west/ward:sitikho,Sitikho
+ocd-division/country:ke/county:ke-40,Busia
+ocd-division/country:ke/county:ke-40/ed:budalangi,Budalangi
+ocd-division/country:ke/county:ke-40/ed:budalangi/ward:bunyala_central,Bunyala Central
+ocd-division/country:ke/county:ke-40/ed:budalangi/ward:bunyala_north,Bunyala North
+ocd-division/country:ke/county:ke-40/ed:budalangi/ward:bunyala_south,Bunyala South
+ocd-division/country:ke/county:ke-40/ed:budalangi/ward:bunyala_west,Bunyala West
+ocd-division/country:ke/county:ke-40/ed:butula,Butula
+ocd-division/country:ke/county:ke-40/ed:butula/ward:elugulu,Elugulu
+ocd-division/country:ke/county:ke-40/ed:butula/ward:kingandole,Kingandole
+ocd-division/country:ke/county:ke-40/ed:butula/ward:marachi_central,Marachi Central
+ocd-division/country:ke/county:ke-40/ed:butula/ward:marachi_east,Marachi East
+ocd-division/country:ke/county:ke-40/ed:butula/ward:marachi_north,Marachi North
+ocd-division/country:ke/county:ke-40/ed:butula/ward:marachi_west,Marachi West
+ocd-division/country:ke/county:ke-40/ed:funyula,Funyula
+ocd-division/country:ke/county:ke-40/ed:funyula/ward:agenga_nanguba,Ageng’a Nanguba
+ocd-division/country:ke/county:ke-40/ed:funyula/ward:bwiri,Bwiri
+ocd-division/country:ke/county:ke-40/ed:funyula/ward:namboboto_nambuku,Namboboto Nambuku
+ocd-division/country:ke/county:ke-40/ed:funyula/ward:nangina,Nangina
+ocd-division/country:ke/county:ke-40/ed:matayos,Matayos
+ocd-division/country:ke/county:ke-40/ed:matayos/ward:bukhayo_west,Bukhayo West
+ocd-division/country:ke/county:ke-40/ed:matayos/ward:burumba,Burumba
+ocd-division/country:ke/county:ke-40/ed:matayos/ward:busibwabo,Busibwabo
+ocd-division/country:ke/county:ke-40/ed:matayos/ward:matayos_south,Matayos South
+ocd-division/country:ke/county:ke-40/ed:matayos/ward:mayenje,Mayenje
+ocd-division/country:ke/county:ke-40/ed:nambale,Nambale
+ocd-division/country:ke/county:ke-40/ed:nambale/ward:bukhayo_central,Bukhayo Central
+ocd-division/country:ke/county:ke-40/ed:nambale/ward:bukhayo_east,Bukhayo East
+ocd-division/country:ke/county:ke-40/ed:nambale/ward:bukhayo_north_waltsi,Bukhayo North-Waltsi
+ocd-division/country:ke/county:ke-40/ed:nambale/ward:nambale_township,Nambale Township
+ocd-division/country:ke/county:ke-40/ed:teso_north,Teso North
+ocd-division/country:ke/county:ke-40/ed:teso_north/ward:angurai_east,Ang’urai East
+ocd-division/country:ke/county:ke-40/ed:teso_north/ward:angurai_north,Ang’urai North
+ocd-division/country:ke/county:ke-40/ed:teso_north/ward:angurai_south,Ang’urai South
+ocd-division/country:ke/county:ke-40/ed:teso_north/ward:malaba_central,Malaba Central
+ocd-division/country:ke/county:ke-40/ed:teso_north/ward:malaba_north,Malaba North
+ocd-division/country:ke/county:ke-40/ed:teso_north/ward:malaba_south,Malaba South
+ocd-division/country:ke/county:ke-40/ed:teso_south,Teso South
+ocd-division/country:ke/county:ke-40/ed:teso_south/ward:amukura_central,Amukura Central
+ocd-division/country:ke/county:ke-40/ed:teso_south/ward:amukura_east,Amukura East
+ocd-division/country:ke/county:ke-40/ed:teso_south/ward:amukura_west,Amukura West
+ocd-division/country:ke/county:ke-40/ed:teso_south/ward:angorom,Ang’orom
+ocd-division/country:ke/county:ke-40/ed:teso_south/ward:chakol_north,Chakol North
+ocd-division/country:ke/county:ke-40/ed:teso_south/ward:chakol_south,Chakol South
+ocd-division/country:ke/county:ke-41,Siaya
+ocd-division/country:ke/county:ke-41/ed:alego_usonga,Alego Usonga
+ocd-division/country:ke/county:ke-41/ed:alego_usonga/ward:central_alego,Central Alego
+ocd-division/country:ke/county:ke-41/ed:alego_usonga/ward:north_alego,North Alego
+ocd-division/country:ke/county:ke-41/ed:alego_usonga/ward:siaya_township,Siaya Township
+ocd-division/country:ke/county:ke-41/ed:alego_usonga/ward:south_east_alego,South East Alego
+ocd-division/country:ke/county:ke-41/ed:alego_usonga/ward:usonga,Usonga
+ocd-division/country:ke/county:ke-41/ed:alego_usonga/ward:west_alego,West Alego
+ocd-division/country:ke/county:ke-41/ed:bondo,Bondo
+ocd-division/country:ke/county:ke-41/ed:bondo/ward:central_sakwa,Central Sakwa
+ocd-division/country:ke/county:ke-41/ed:bondo/ward:north_sakwa,North Sakwa
+ocd-division/country:ke/county:ke-41/ed:bondo/ward:south_sakwa,South Sakwa
+ocd-division/country:ke/county:ke-41/ed:bondo/ward:west_sakwa,West Sakwa
+ocd-division/country:ke/county:ke-41/ed:bondo/ward:west_yimbo,West Yimbo
+ocd-division/country:ke/county:ke-41/ed:bondo/ward:yimbo_east,Yimbo East
+ocd-division/country:ke/county:ke-41/ed:gem,Gem
+ocd-division/country:ke/county:ke-41/ed:gem/ward:central_gem,Central Gem
+ocd-division/country:ke/county:ke-41/ed:gem/ward:east_gem,East Gem
+ocd-division/country:ke/county:ke-41/ed:gem/ward:north_gem,North Gem
+ocd-division/country:ke/county:ke-41/ed:gem/ward:south_gem,South Gem
+ocd-division/country:ke/county:ke-41/ed:gem/ward:west_gem,West Gem
+ocd-division/country:ke/county:ke-41/ed:gem/ward:yala_township,Yala Township
+ocd-division/country:ke/county:ke-41/ed:rarieda,Rarieda
+ocd-division/country:ke/county:ke-41/ed:rarieda/ward:east_asembo,East Asembo
+ocd-division/country:ke/county:ke-41/ed:rarieda/ward:north_uyoma,North Uyoma
+ocd-division/country:ke/county:ke-41/ed:rarieda/ward:south_uyoma,South Uyoma
+ocd-division/country:ke/county:ke-41/ed:rarieda/ward:west_asembo,West Asembo
+ocd-division/country:ke/county:ke-41/ed:rarieda/ward:west_uyoma,West Uyoma
+ocd-division/country:ke/county:ke-41/ed:ugenya,Ugenya
+ocd-division/country:ke/county:ke-41/ed:ugenya/ward:east_ugenya,East Ugenya
+ocd-division/country:ke/county:ke-41/ed:ugenya/ward:north_ugenya,North Ugenya
+ocd-division/country:ke/county:ke-41/ed:ugenya/ward:ukwala,Ukwala
+ocd-division/country:ke/county:ke-41/ed:ugenya/ward:west_ugenya,West Ugenya
+ocd-division/country:ke/county:ke-41/ed:ugunja,Ugunja
+ocd-division/country:ke/county:ke-41/ed:ugunja/ward:sidindi,Sidindi
+ocd-division/country:ke/county:ke-41/ed:ugunja/ward:sigomere,Sigomere
+ocd-division/country:ke/county:ke-41/ed:ugunja/ward:ugunja,Ugunja
+ocd-division/country:ke/county:ke-42,Kisumu
+ocd-division/country:ke/county:ke-42/ed:kisumu_central,Kisumu Central
+ocd-division/country:ke/county:ke-42/ed:kisumu_central/ward:kondele,Kondele
+ocd-division/country:ke/county:ke-42/ed:kisumu_central/ward:market_milimani,Market Milimani
+ocd-division/country:ke/county:ke-42/ed:kisumu_central/ward:migosi,Migosi
+ocd-division/country:ke/county:ke-42/ed:kisumu_central/ward:nyalenda_b,Nyalenda B
+ocd-division/country:ke/county:ke-42/ed:kisumu_central/ward:railways,Railways
+ocd-division/country:ke/county:ke-42/ed:kisumu_central/ward:shaurimoyo_kaloleni,Shaurimoyo Kaloleni
+ocd-division/country:ke/county:ke-42/ed:kisumu_east,Kisumu East
+ocd-division/country:ke/county:ke-42/ed:kisumu_east/ward:kajulu,Kajulu
+ocd-division/country:ke/county:ke-42/ed:kisumu_east/ward:kolwa_central,Kolwa Central
+ocd-division/country:ke/county:ke-42/ed:kisumu_east/ward:kolwa_east,Kolwa East
+ocd-division/country:ke/county:ke-42/ed:kisumu_east/ward:manyatta,Manyatta
+ocd-division/country:ke/county:ke-42/ed:kisumu_east/ward:nyalenda,Nyalenda
+ocd-division/country:ke/county:ke-42/ed:kisumu_west,Kisumu West
+ocd-division/country:ke/county:ke-42/ed:kisumu_west/ward:central_kisumu,Central Kisumu
+ocd-division/country:ke/county:ke-42/ed:kisumu_west/ward:kisumu_north,Kisumu North
+ocd-division/country:ke/county:ke-42/ed:kisumu_west/ward:north_west_kisumu,North West Kisumu
+ocd-division/country:ke/county:ke-42/ed:kisumu_west/ward:south_west_kisumu,South West Kisumu
+ocd-division/country:ke/county:ke-42/ed:kisumu_west/ward:west_kisumu,West Kisumu
+ocd-division/country:ke/county:ke-42/ed:muhoroni,Muhoroni
+ocd-division/country:ke/county:ke-42/ed:muhoroni/ward:chemelil,Chemelil
+ocd-division/country:ke/county:ke-42/ed:muhoroni/ward:masogo_nyangoma,Masogo-Nyangoma
+ocd-division/country:ke/county:ke-42/ed:muhoroni/ward:miwani,Miwani
+ocd-division/country:ke/county:ke-42/ed:muhoroni/ward:muhoroni_koru,Muhoroni-Koru
+ocd-division/country:ke/county:ke-42/ed:muhoroni/ward:ombeyi,Ombeyi
+ocd-division/country:ke/county:ke-42/ed:nyakach,Nyakach
+ocd-division/country:ke/county:ke-42/ed:nyakach/ward:central_nyakach,Central Nyakach
+ocd-division/country:ke/county:ke-42/ed:nyakach/ward:north_nyakach,North Nyakach
+ocd-division/country:ke/county:ke-42/ed:nyakach/ward:south_east_nyakach,South East Nyakach
+ocd-division/country:ke/county:ke-42/ed:nyakach/ward:south_west_nyakach,South West Nyakach
+ocd-division/country:ke/county:ke-42/ed:nyakach/ward:west_nyakach,West Nyakach
+ocd-division/country:ke/county:ke-42/ed:nyando,Nyando
+ocd-division/country:ke/county:ke-42/ed:nyando/ward:ahero,Ahero
+ocd-division/country:ke/county:ke-42/ed:nyando/ward:awasi_onjiko,Awasi-Onjiko
+ocd-division/country:ke/county:ke-42/ed:nyando/ward:east_kano_wawidhi,East Kano-Wawidhi
+ocd-division/country:ke/county:ke-42/ed:nyando/ward:kabonyo_kanyagwal,Kabonyo-Kanyagwal
+ocd-division/country:ke/county:ke-42/ed:nyando/ward:kobura,Kobura
+ocd-division/country:ke/county:ke-42/ed:seme,Seme
+ocd-division/country:ke/county:ke-42/ed:seme/ward:central_seme,Central Seme
+ocd-division/country:ke/county:ke-42/ed:seme/ward:east_seme,East Seme
+ocd-division/country:ke/county:ke-42/ed:seme/ward:north_seme,North Seme
+ocd-division/country:ke/county:ke-42/ed:seme/ward:west_seme,West Seme
+ocd-division/country:ke/county:ke-43,Homa Bay
+ocd-division/country:ke/county:ke-43/ed:homa_bay_town,Homa Bay Town
+ocd-division/country:ke/county:ke-43/ed:homa_bay_town/ward:homa_bay_arujo,Homa Bay Arujo
+ocd-division/country:ke/county:ke-43/ed:homa_bay_town/ward:homa_bay_central,Homa Bay Central
+ocd-division/country:ke/county:ke-43/ed:homa_bay_town/ward:homa_bay_east,Homa Bay East
+ocd-division/country:ke/county:ke-43/ed:homa_bay_town/ward:homa_bay_west,Homa Bay West
+ocd-division/country:ke/county:ke-43/ed:kabondo_kasipul,Kabondo Kasipul
+ocd-division/country:ke/county:ke-43/ed:kabondo_kasipul/ward:kabondo_east,Kabondo East
+ocd-division/country:ke/county:ke-43/ed:kabondo_kasipul/ward:kabondo_west,Kabondo West
+ocd-division/country:ke/county:ke-43/ed:kabondo_kasipul/ward:kojwach,Kojwach
+ocd-division/country:ke/county:ke-43/ed:kabondo_kasipul/ward:kokwanyo_kakelo,Kokwanyo-Kakelo
+ocd-division/country:ke/county:ke-43/ed:karachuonyo,Karachuonyo
+ocd-division/country:ke/county:ke-43/ed:karachuonyo/ward:central,Central
+ocd-division/country:ke/county:ke-43/ed:karachuonyo/ward:kanyaluo,Kanyaluo
+ocd-division/country:ke/county:ke-43/ed:karachuonyo/ward:kendu_bay_town,Kendu Bay Town
+ocd-division/country:ke/county:ke-43/ed:karachuonyo/ward:kibiri,Kibiri
+ocd-division/country:ke/county:ke-43/ed:karachuonyo/ward:north_karachuonyo,North Karachuonyo
+ocd-division/country:ke/county:ke-43/ed:karachuonyo/ward:wangchieng,Wangchieng
+ocd-division/country:ke/county:ke-43/ed:karachuonyo/ward:west_karachuonyo,West Karachuonyo
+ocd-division/country:ke/county:ke-43/ed:kasipul,Kasipul
+ocd-division/country:ke/county:ke-43/ed:kasipul/ward:central_kasipul,Central Kasipul
+ocd-division/country:ke/county:ke-43/ed:kasipul/ward:east_kamagak,East Kamagak
+ocd-division/country:ke/county:ke-43/ed:kasipul/ward:south_kasipul,South Kasipul
+ocd-division/country:ke/county:ke-43/ed:kasipul/ward:west_kamagak,West Kamagak
+ocd-division/country:ke/county:ke-43/ed:kasipul/ward:west_kasipul,West Kasipul
+ocd-division/country:ke/county:ke-43/ed:ndhiwa,Ndhiwa
+ocd-division/country:ke/county:ke-43/ed:ndhiwa/ward:kabuoch_north,Kabuoch North
+ocd-division/country:ke/county:ke-43/ed:ndhiwa/ward:kabuoch_south_pala,Kabuoch South-Pala
+ocd-division/country:ke/county:ke-43/ed:ndhiwa/ward:kanyadoto,Kanyadoto
+ocd-division/country:ke/county:ke-43/ed:ndhiwa/ward:kanyamwa_kologi,Kanyamwa Kologi
+ocd-division/country:ke/county:ke-43/ed:ndhiwa/ward:kanyamwa_kosewe,Kanyamwa Kosewe
+ocd-division/country:ke/county:ke-43/ed:ndhiwa/ward:kanyikela,Kanyikela
+ocd-division/country:ke/county:ke-43/ed:ndhiwa/ward:kwabwai,Kwabwai
+ocd-division/country:ke/county:ke-43/ed:rangwe,Rangwe
+ocd-division/country:ke/county:ke-43/ed:rangwe/ward:east_gem,East Gem
+ocd-division/country:ke/county:ke-43/ed:rangwe/ward:kagan,Kagan
+ocd-division/country:ke/county:ke-43/ed:rangwe/ward:kochia,Kochia
+ocd-division/country:ke/county:ke-43/ed:rangwe/ward:west_gem,West Gem
+ocd-division/country:ke/county:ke-43/ed:suba_north,Suba North
+ocd-division/country:ke/county:ke-43/ed:suba_north/ward:gembe,Gembe
+ocd-division/country:ke/county:ke-43/ed:suba_north/ward:kasgunga,Kasgunga
+ocd-division/country:ke/county:ke-43/ed:suba_north/ward:lambwe,Lambwe
+ocd-division/country:ke/county:ke-43/ed:suba_north/ward:mfangano_island,Mfangano Island
+ocd-division/country:ke/county:ke-43/ed:suba_north/ward:rusinga_island,Rusinga Island
+ocd-division/country:ke/county:ke-43/ed:suba_south,Suba South
+ocd-division/country:ke/county:ke-43/ed:suba_south/ward:gwassi_north,Gwassi North
+ocd-division/country:ke/county:ke-43/ed:suba_south/ward:gwassi_south,Gwassi South
+ocd-division/country:ke/county:ke-43/ed:suba_south/ward:kaksingri_west,Kaksingri West
+ocd-division/country:ke/county:ke-43/ed:suba_south/ward:ruma_kaksingri,Ruma-Kaksingri
+ocd-division/country:ke/county:ke-44,Migori
+ocd-division/country:ke/county:ke-44/ed:awendo,Awendo
+ocd-division/country:ke/county:ke-44/ed:awendo/ward:central_sakwa,Central Sakwa
+ocd-division/country:ke/county:ke-44/ed:awendo/ward:north_sakwa,North Sakwa
+ocd-division/country:ke/county:ke-44/ed:awendo/ward:south_sakwa,South Sakwa
+ocd-division/country:ke/county:ke-44/ed:awendo/ward:west_sakwa,West Sakwa
+ocd-division/country:ke/county:ke-44/ed:kuria_east,Kuria East
+ocd-division/country:ke/county:ke-44/ed:kuria_east/ward:gokeharaka_getambwega,Gokeharaka-Getambwega
+ocd-division/country:ke/county:ke-44/ed:kuria_east/ward:ntimaru_east,Ntimaru East
+ocd-division/country:ke/county:ke-44/ed:kuria_east/ward:ntimaru_west,Ntimaru West
+ocd-division/country:ke/county:ke-44/ed:kuria_east/ward:nyabasi_east,Nyabasi East
+ocd-division/country:ke/county:ke-44/ed:kuria_east/ward:nyabasi_west,Nyabasi West
+ocd-division/country:ke/county:ke-44/ed:kuria_west,Kuria West
+ocd-division/country:ke/county:ke-44/ed:kuria_west/ward:bukira_centrl_ikerege,Bukira Centrl-Ikerege
+ocd-division/country:ke/county:ke-44/ed:kuria_west/ward:bukira_east,Bukira East
+ocd-division/country:ke/county:ke-44/ed:kuria_west/ward:isibania,Isibania
+ocd-division/country:ke/county:ke-44/ed:kuria_west/ward:makerero,Makerero
+ocd-division/country:ke/county:ke-44/ed:kuria_west/ward:masaba,Masaba
+ocd-division/country:ke/county:ke-44/ed:kuria_west/ward:nyamosense_komosoko,Nyamosense-Komosoko
+ocd-division/country:ke/county:ke-44/ed:kuria_west/ward:tagare,Tagare
+ocd-division/country:ke/county:ke-44/ed:nyatike,Nyatike
+ocd-division/country:ke/county:ke-44/ed:nyatike/ward:got_kachola,Got Kachola
+ocd-division/country:ke/county:ke-44/ed:nyatike/ward:kachieng,Kachieng
+ocd-division/country:ke/county:ke-44/ed:nyatike/ward:kaler,Kaler
+ocd-division/country:ke/county:ke-44/ed:nyatike/ward:kanyasa,Kanyasa
+ocd-division/country:ke/county:ke-44/ed:nyatike/ward:macalder_kanyarwanda,Macalder-Kanyarwanda
+ocd-division/country:ke/county:ke-44/ed:nyatike/ward:muhuru,Muhuru
+ocd-division/country:ke/county:ke-44/ed:nyatike/ward:north_kadem,North Kadem
+ocd-division/country:ke/county:ke-44/ed:rongo,Rongo
+ocd-division/country:ke/county:ke-44/ed:rongo/ward:central_kamagambo,Central Kamagambo
+ocd-division/country:ke/county:ke-44/ed:rongo/ward:east_kamagambo,East Kamagambo
+ocd-division/country:ke/county:ke-44/ed:rongo/ward:north_kamagambo,North Kamagambo
+ocd-division/country:ke/county:ke-44/ed:rongo/ward:south_kamagambo,South Kamagambo
+ocd-division/country:ke/county:ke-44/ed:suna_east,Suna East
+ocd-division/country:ke/county:ke-44/ed:suna_east/ward:god_jope,God Jope
+ocd-division/country:ke/county:ke-44/ed:suna_east/ward:kakrao,Kakrao
+ocd-division/country:ke/county:ke-44/ed:suna_east/ward:kwa,Kwa
+ocd-division/country:ke/county:ke-44/ed:suna_east/ward:suna_central,Suna Central
+ocd-division/country:ke/county:ke-44/ed:suna_west,Suna West
+ocd-division/country:ke/county:ke-44/ed:suna_west/ward:ragana_oruba,Ragana-Oruba
+ocd-division/country:ke/county:ke-44/ed:suna_west/ward:wasimbete,Wasimbete
+ocd-division/country:ke/county:ke-44/ed:suna_west/ward:wasweta_ii,Wasweta II
+ocd-division/country:ke/county:ke-44/ed:suna_west/ward:wiga,Wiga
+ocd-division/country:ke/county:ke-44/ed:uriri,Uriri
+ocd-division/country:ke/county:ke-44/ed:uriri/ward:central_kanyamkago,Central Kanyamkago
+ocd-division/country:ke/county:ke-44/ed:uriri/ward:east_kanyamkago,East Kanyamkago
+ocd-division/country:ke/county:ke-44/ed:uriri/ward:north_kanyamkago,North Kanyamkago
+ocd-division/country:ke/county:ke-44/ed:uriri/ward:south_kanyamkago,South Kanyamkago
+ocd-division/country:ke/county:ke-44/ed:uriri/ward:west_kanyamkago,West Kanyamkago
+ocd-division/country:ke/county:ke-45,Kisii
+ocd-division/country:ke/county:ke-45/ed:bobasi,Bobasi
+ocd-division/country:ke/county:ke-45/ed:bobasi/ward:basi_bogetaorio,Basi Bogetaorio
+ocd-division/country:ke/county:ke-45/ed:bobasi/ward:basi_central,Basi Central
+ocd-division/country:ke/county:ke-45/ed:bobasi/ward:bobasi_boitangare,Bobasi Boitangare
+ocd-division/country:ke/county:ke-45/ed:bobasi/ward:bobasi_chache,Bobasi Chache
+ocd-division/country:ke/county:ke-45/ed:bobasi/ward:masige_east,Masige East
+ocd-division/country:ke/county:ke-45/ed:bobasi/ward:masige_west,Masige West
+ocd-division/country:ke/county:ke-45/ed:bobasi/ward:nyacheki,Nyacheki
+ocd-division/country:ke/county:ke-45/ed:bobasi/ward:sameta_mokwerero,Sameta-Mokwerero
+ocd-division/country:ke/county:ke-45/ed:bomachoge_borabu,Bomachoge Borabu
+ocd-division/country:ke/county:ke-45/ed:bomachoge_borabu/ward:bokimonge,Bokimonge
+ocd-division/country:ke/county:ke-45/ed:bomachoge_borabu/ward:bombaba_borabu,Bombaba Borabu
+ocd-division/country:ke/county:ke-45/ed:bomachoge_borabu/ward:boochi_borabu,Boochi Borabu
+ocd-division/country:ke/county:ke-45/ed:bomachoge_borabu/ward:magenche,Magenche
+ocd-division/country:ke/county:ke-45/ed:bomachoge_chache,Bomachoge Chache
+ocd-division/country:ke/county:ke-45/ed:bomachoge_chache/ward:boochi_tendere,Boochi-Tendere
+ocd-division/country:ke/county:ke-45/ed:bomachoge_chache/ward:bosoti_sengera,Bosoti-Sengera
+ocd-division/country:ke/county:ke-45/ed:bomachoge_chache/ward:majoge_basi,Majoge Basi
+ocd-division/country:ke/county:ke-45/ed:bonchari,Bonchari
+ocd-division/country:ke/county:ke-45/ed:bonchari/ward:bogiakumu,Bogiakumu
+ocd-division/country:ke/county:ke-45/ed:bonchari/ward:bomariba,Bomariba
+ocd-division/country:ke/county:ke-45/ed:bonchari/ward:bomorenda,Bomorenda
+ocd-division/country:ke/county:ke-45/ed:bonchari/ward:riana,Riana
+ocd-division/country:ke/county:ke-45/ed:kitutu_chache_north,Kitutu Chache North
+ocd-division/country:ke/county:ke-45/ed:kitutu_chache_north/ward:kegogi,Kegogi
+ocd-division/country:ke/county:ke-45/ed:kitutu_chache_north/ward:marani,Marani
+ocd-division/country:ke/county:ke-45/ed:kitutu_chache_north/ward:monyerero,Monyerero
+ocd-division/country:ke/county:ke-45/ed:kitutu_chache_north/ward:sensi,Sensi
+ocd-division/country:ke/county:ke-45/ed:kitutu_chache_south,Kitutu Chache South
+ocd-division/country:ke/county:ke-45/ed:kitutu_chache_south/ward:bogeka,Bogeka
+ocd-division/country:ke/county:ke-45/ed:kitutu_chache_south/ward:bogusero,Bogusero
+ocd-division/country:ke/county:ke-45/ed:kitutu_chache_south/ward:kitutu_central,Kitutu Central
+ocd-division/country:ke/county:ke-45/ed:kitutu_chache_south/ward:nyakoe,Nyakoe
+ocd-division/country:ke/county:ke-45/ed:kitutu_chache_south/ward:nyatieko,Nyatieko
+ocd-division/country:ke/county:ke-45/ed:nyaribari_chache,Nyaribari Chache
+ocd-division/country:ke/county:ke-45/ed:nyaribari_chache/ward:birongo,Birongo
+ocd-division/country:ke/county:ke-45/ed:nyaribari_chache/ward:bobaracho,Bobaracho
+ocd-division/country:ke/county:ke-45/ed:nyaribari_chache/ward:ibeno,Ibeno
+ocd-division/country:ke/county:ke-45/ed:nyaribari_chache/ward:keumbu,Keumbu
+ocd-division/country:ke/county:ke-45/ed:nyaribari_chache/ward:kiogoro,Kiogoro
+ocd-division/country:ke/county:ke-45/ed:nyaribari_chache/ward:kisii_central,Kisii Central
+ocd-division/country:ke/county:ke-45/ed:nyaribari_masaba,Nyaribari Masaba
+ocd-division/country:ke/county:ke-45/ed:nyaribari_masaba/ward:gesusu,Gesusu
+ocd-division/country:ke/county:ke-45/ed:nyaribari_masaba/ward:ichuni,Ichuni
+ocd-division/country:ke/county:ke-45/ed:nyaribari_masaba/ward:kiamokama,Kiamokama
+ocd-division/country:ke/county:ke-45/ed:nyaribari_masaba/ward:masimba,Masimba
+ocd-division/country:ke/county:ke-45/ed:nyaribari_masaba/ward:nyamasibi,Nyamasibi
+ocd-division/country:ke/county:ke-45/ed:south_mugirango,South Mugirango
+ocd-division/country:ke/county:ke-45/ed:south_mugirango/ward:bogetenga,Bogetenga
+ocd-division/country:ke/county:ke-45/ed:south_mugirango/ward:boikanga,Boikanga
+ocd-division/country:ke/county:ke-45/ed:south_mugirango/ward:borabu_chitago,Borabu - Chitago
+ocd-division/country:ke/county:ke-45/ed:south_mugirango/ward:getenga,Getenga
+ocd-division/country:ke/county:ke-45/ed:south_mugirango/ward:moticho,Moticho
+ocd-division/country:ke/county:ke-45/ed:south_mugirango/ward:tabaka,Tabaka
+ocd-division/country:ke/county:ke-46,Nyamira
+ocd-division/country:ke/county:ke-46/ed:borabu,Borabu
+ocd-division/country:ke/county:ke-46/ed:borabu/ward:esise,Esise
+ocd-division/country:ke/county:ke-46/ed:borabu/ward:kiabonyoru,Kiabonyoru
+ocd-division/country:ke/county:ke-46/ed:borabu/ward:mekenene,Mekenene
+ocd-division/country:ke/county:ke-46/ed:borabu/ward:nyansiongo,Nyansiongo
+ocd-division/country:ke/county:ke-46/ed:kitutu_masaba,Kitutu Masaba
+ocd-division/country:ke/county:ke-46/ed:kitutu_masaba/ward:gachuba,Gachuba
+ocd-division/country:ke/county:ke-46/ed:kitutu_masaba/ward:gesima,Gesima
+ocd-division/country:ke/county:ke-46/ed:kitutu_masaba/ward:kemera,Kemera
+ocd-division/country:ke/county:ke-46/ed:kitutu_masaba/ward:magombo,Magombo
+ocd-division/country:ke/county:ke-46/ed:kitutu_masaba/ward:manga,Manga
+ocd-division/country:ke/county:ke-46/ed:kitutu_masaba/ward:rigoma,Rigoma
+ocd-division/country:ke/county:ke-46/ed:north_mugirango,North Mugirango
+ocd-division/country:ke/county:ke-46/ed:north_mugirango/ward:bokeira,Bokeira
+ocd-division/country:ke/county:ke-46/ed:north_mugirango/ward:bomwagamo,Bomwagamo
+ocd-division/country:ke/county:ke-46/ed:north_mugirango/ward:ekerenyo,Ekerenyo
+ocd-division/country:ke/county:ke-46/ed:north_mugirango/ward:itibo,Itibo
+ocd-division/country:ke/county:ke-46/ed:north_mugirango/ward:magwagwa,Magwagwa
+ocd-division/country:ke/county:ke-46/ed:west_mugirango,West Mugirango
+ocd-division/country:ke/county:ke-46/ed:west_mugirango/ward:bogichora,Bogichora
+ocd-division/country:ke/county:ke-46/ed:west_mugirango/ward:bonyamatuta,Bonyamatuta
+ocd-division/country:ke/county:ke-46/ed:west_mugirango/ward:bosamaro,Bosamaro
+ocd-division/country:ke/county:ke-46/ed:west_mugirango/ward:nyamaiya,Nyamaiya
+ocd-division/country:ke/county:ke-46/ed:west_mugirango/ward:township,Township
+ocd-division/country:ke/county:ke-47,Nairobi City
+ocd-division/country:ke/county:ke-47/ed:dagoretti_north,Dagoretti North
+ocd-division/country:ke/county:ke-47/ed:dagoretti_north/ward:gatina,Gatina
+ocd-division/country:ke/county:ke-47/ed:dagoretti_north/ward:kabiro,Kabiro
+ocd-division/country:ke/county:ke-47/ed:dagoretti_north/ward:kawangware,Kawangware
+ocd-division/country:ke/county:ke-47/ed:dagoretti_north/ward:kileleshwa,Kileleshwa
+ocd-division/country:ke/county:ke-47/ed:dagoretti_north/ward:kilimani,Kilimani
+ocd-division/country:ke/county:ke-47/ed:dagoretti_south,Dagoretti South
+ocd-division/country:ke/county:ke-47/ed:dagoretti_south/ward:mutu_ini,Mutu-ini
+ocd-division/country:ke/county:ke-47/ed:dagoretti_south/ward:ngando,Ngando
+ocd-division/country:ke/county:ke-47/ed:dagoretti_south/ward:riruta,Riruta
+ocd-division/country:ke/county:ke-47/ed:dagoretti_south/ward:uthiru_ruthimitu,Uthiru-Ruthimitu
+ocd-division/country:ke/county:ke-47/ed:dagoretti_south/ward:waithaka,Waithaka
+ocd-division/country:ke/county:ke-47/ed:embakasi_central,Embakasi Central
+ocd-division/country:ke/county:ke-47/ed:embakasi_central/ward:kayole_central,Kayole Central
+ocd-division/country:ke/county:ke-47/ed:embakasi_central/ward:kayole_north,Kayole North
+ocd-division/country:ke/county:ke-47/ed:embakasi_central/ward:kayole_south,Kayole South
+ocd-division/country:ke/county:ke-47/ed:embakasi_central/ward:komarock,Komarock
+ocd-division/country:ke/county:ke-47/ed:embakasi_central/ward:matopeni_spring_valley,Matopeni-Spring Valley
+ocd-division/country:ke/county:ke-47/ed:embakasi_east,Embakasi East
+ocd-division/country:ke/county:ke-47/ed:embakasi_east/ward:embakasi,Embakasi
+ocd-division/country:ke/county:ke-47/ed:embakasi_east/ward:lower_savannah,Lower Savannah
+ocd-division/country:ke/county:ke-47/ed:embakasi_east/ward:mihango,Mihango
+ocd-division/country:ke/county:ke-47/ed:embakasi_east/ward:upper_savannah,Upper Savannah
+ocd-division/country:ke/county:ke-47/ed:embakasi_east/ward:utawala,Utawala
+ocd-division/country:ke/county:ke-47/ed:embakasi_north,Embakasi North
+ocd-division/country:ke/county:ke-47/ed:embakasi_north/ward:dandora_area_i,Dandora Area I
+ocd-division/country:ke/county:ke-47/ed:embakasi_north/ward:dandora_area_ii,Dandora Area II
+ocd-division/country:ke/county:ke-47/ed:embakasi_north/ward:dandora_area_iii,Dandora Area III
+ocd-division/country:ke/county:ke-47/ed:embakasi_north/ward:dandora_area_iv,Dandora Area IV
+ocd-division/country:ke/county:ke-47/ed:embakasi_north/ward:kariobangi_north,Kariobangi North
+ocd-division/country:ke/county:ke-47/ed:embakasi_south,Embakasi South
+ocd-division/country:ke/county:ke-47/ed:embakasi_south/ward:imara_daima,Imara Daima
+ocd-division/country:ke/county:ke-47/ed:embakasi_south/ward:kwa_njenga,Kwa Njenga
+ocd-division/country:ke/county:ke-47/ed:embakasi_south/ward:kwa_reuben,Kwa Reuben
+ocd-division/country:ke/county:ke-47/ed:embakasi_south/ward:kware,Kware
+ocd-division/country:ke/county:ke-47/ed:embakasi_south/ward:pipeline,Pipeline
+ocd-division/country:ke/county:ke-47/ed:embakasi_west,Embakasi West
+ocd-division/country:ke/county:ke-47/ed:embakasi_west/ward:kariobangi_south,Kariobangi South
+ocd-division/country:ke/county:ke-47/ed:embakasi_west/ward:mowlem,Mowlem
+ocd-division/country:ke/county:ke-47/ed:embakasi_west/ward:umoja_i,Umoja I
+ocd-division/country:ke/county:ke-47/ed:embakasi_west/ward:umoja_ii,Umoja II
+ocd-division/country:ke/county:ke-47/ed:kamukunji,Kamukunji
+ocd-division/country:ke/county:ke-47/ed:kamukunji/ward:airbase,Airbase
+ocd-division/country:ke/county:ke-47/ed:kamukunji/ward:california,California
+ocd-division/country:ke/county:ke-47/ed:kamukunji/ward:eastleigh_north,Eastleigh North
+ocd-division/country:ke/county:ke-47/ed:kamukunji/ward:eastleigh_south,Eastleigh South
+ocd-division/country:ke/county:ke-47/ed:kamukunji/ward:pumwani,Pumwani
+ocd-division/country:ke/county:ke-47/ed:kasarani,Kasarani
+ocd-division/country:ke/county:ke-47/ed:kasarani/ward:clay_city,Clay City
+ocd-division/country:ke/county:ke-47/ed:kasarani/ward:kasarani,Kasarani
+ocd-division/country:ke/county:ke-47/ed:kasarani/ward:mwiki,Mwiki
+ocd-division/country:ke/county:ke-47/ed:kasarani/ward:njiru,Njiru
+ocd-division/country:ke/county:ke-47/ed:kasarani/ward:ruai,Ruai
+ocd-division/country:ke/county:ke-47/ed:kibra,Kibra
+ocd-division/country:ke/county:ke-47/ed:kibra/ward:laini_saba,Laini Saba
+ocd-division/country:ke/county:ke-47/ed:kibra/ward:lindi,Lindi
+ocd-division/country:ke/county:ke-47/ed:kibra/ward:makina,Makina
+ocd-division/country:ke/county:ke-47/ed:kibra/ward:sarangombe,Sarangombe
+ocd-division/country:ke/county:ke-47/ed:kibra/ward:woodley_kenyatta_golf_course,Woodley-Kenyatta Golf Course
+ocd-division/country:ke/county:ke-47/ed:langata,Langata
+ocd-division/country:ke/county:ke-47/ed:langata/ward:karen,Karen
+ocd-division/country:ke/county:ke-47/ed:langata/ward:mugumu_ini,Mugumu-ini
+ocd-division/country:ke/county:ke-47/ed:langata/ward:nairobi_west,Nairobi West
+ocd-division/country:ke/county:ke-47/ed:langata/ward:nyayo_highrise,Nyayo Highrise
+ocd-division/country:ke/county:ke-47/ed:langata/ward:south_c,South C
+ocd-division/country:ke/county:ke-47/ed:makadara,Makadara
+ocd-division/country:ke/county:ke-47/ed:makadara/ward:harambee,Harambee
+ocd-division/country:ke/county:ke-47/ed:makadara/ward:makongeni,Makongeni
+ocd-division/country:ke/county:ke-47/ed:makadara/ward:maringo_hamza,Maringo-Hamza
+ocd-division/country:ke/county:ke-47/ed:makadara/ward:viwandani,Viwandani
+ocd-division/country:ke/county:ke-47/ed:mathare,Mathare
+ocd-division/country:ke/county:ke-47/ed:mathare/ward:hospital,Hospital
+ocd-division/country:ke/county:ke-47/ed:mathare/ward:huruma,Huruma
+ocd-division/country:ke/county:ke-47/ed:mathare/ward:kiamaiko,Kiamaiko
+ocd-division/country:ke/county:ke-47/ed:mathare/ward:mabatini,Mabatini
+ocd-division/country:ke/county:ke-47/ed:mathare/ward:mlango_kubwa,Mlango Kubwa
+ocd-division/country:ke/county:ke-47/ed:mathare/ward:ngei,Ngei
+ocd-division/country:ke/county:ke-47/ed:roysambu,Roysambu
+ocd-division/country:ke/county:ke-47/ed:roysambu/ward:githurai,Githurai
+ocd-division/country:ke/county:ke-47/ed:roysambu/ward:kahawa,Kahawa
+ocd-division/country:ke/county:ke-47/ed:roysambu/ward:kahawa_west,Kahawa West
+ocd-division/country:ke/county:ke-47/ed:roysambu/ward:roysambu,Roysambu
+ocd-division/country:ke/county:ke-47/ed:roysambu/ward:zimmerman,Zimmerman
+ocd-division/country:ke/county:ke-47/ed:ruaraka,Ruaraka
+ocd-division/country:ke/county:ke-47/ed:ruaraka/ward:baba_dogo,Baba Dogo
+ocd-division/country:ke/county:ke-47/ed:ruaraka/ward:korogocho,Korogocho
+ocd-division/country:ke/county:ke-47/ed:ruaraka/ward:lucky_summer,Lucky Summer
+ocd-division/country:ke/county:ke-47/ed:ruaraka/ward:mathare_north,Mathare North
+ocd-division/country:ke/county:ke-47/ed:ruaraka/ward:utalii,Utalii
+ocd-division/country:ke/county:ke-47/ed:starehe,Starehe
+ocd-division/country:ke/county:ke-47/ed:starehe/ward:landimawe,Landimawe
+ocd-division/country:ke/county:ke-47/ed:starehe/ward:nairobi_central,Nairobi Central
+ocd-division/country:ke/county:ke-47/ed:starehe/ward:nairobi_south,Nairobi South
+ocd-division/country:ke/county:ke-47/ed:starehe/ward:ngara,Ngara
+ocd-division/country:ke/county:ke-47/ed:starehe/ward:pangani,Pangani
+ocd-division/country:ke/county:ke-47/ed:starehe/ward:ziwani_kariokor,Ziwani-Kariokor
+ocd-division/country:ke/county:ke-47/ed:westlands,Westlands
+ocd-division/country:ke/county:ke-47/ed:westlands/ward:kangemi,Kangemi
+ocd-division/country:ke/county:ke-47/ed:westlands/ward:karura,Karura
+ocd-division/country:ke/county:ke-47/ed:westlands/ward:kitisuru,Kitisuru
+ocd-division/country:ke/county:ke-47/ed:westlands/ward:mountain_view,Mountain View
+ocd-division/country:ke/county:ke-47/ed:westlands/ward:parklands_highridge,Parklands-Highridge

--- a/identifiers/country-ke/README.MD
+++ b/identifiers/country-ke/README.MD
@@ -1,0 +1,14 @@
+OCD Division Identifier
+---
+
+This folder `country-ke` lists the following administrative divisions of Kenya:
+
+* counties: contains Contains 47 counties of Kenya
+* national_assembly: Contains 290 constituencies in Kenya for Kenyan National Assembly
+* county_assembly: Contains 1450 wards in Kenya for the 47 County Assemblies. 
+
+
+Counties represented  based on the ISO 3166-2 Used sources [ISO 3166-2:KE](https://en.wikipedia.org/wiki/ISO_3166-2:KE)
+
+
+Constituencies & Wards  are represented as _ed_, and _ward_  respectively , sourced from [IEBC](https://www.iebc.or.ke/uploads/resources/AHxYKqSUn0.pdf)

--- a/identifiers/country-ke/counties.csv
+++ b/identifiers/country-ke/counties.csv
@@ -1,0 +1,48 @@
+id,name
+ocd-division/country:ke/county:ke-01,Mombasa
+ocd-division/country:ke/county:ke-02,Kwale
+ocd-division/country:ke/county:ke-03,Kilifi
+ocd-division/country:ke/county:ke-04,Tana River
+ocd-division/country:ke/county:ke-05,Lamu
+ocd-division/country:ke/county:ke-06,Taita Taveta
+ocd-division/country:ke/county:ke-07,Garissa
+ocd-division/country:ke/county:ke-08,Wajir
+ocd-division/country:ke/county:ke-09,Mandera
+ocd-division/country:ke/county:ke-10,Marsabit
+ocd-division/country:ke/county:ke-11,Isiolo
+ocd-division/country:ke/county:ke-12,Meru
+ocd-division/country:ke/county:ke-13,Tharaka - Nithi
+ocd-division/country:ke/county:ke-14,Embu
+ocd-division/country:ke/county:ke-15,Kitui
+ocd-division/country:ke/county:ke-16,Machakos
+ocd-division/country:ke/county:ke-17,Makueni
+ocd-division/country:ke/county:ke-18,Nyandarua
+ocd-division/country:ke/county:ke-19,Nyeri
+ocd-division/country:ke/county:ke-20,Kirinyaga
+ocd-division/country:ke/county:ke-21,Murang'a
+ocd-division/country:ke/county:ke-22,Kiambu
+ocd-division/country:ke/county:ke-23,Turkana
+ocd-division/country:ke/county:ke-24,West Pokot
+ocd-division/country:ke/county:ke-25,Samburu
+ocd-division/country:ke/county:ke-26,Trans Nzoia
+ocd-division/country:ke/county:ke-27,Uasin Gishu
+ocd-division/country:ke/county:ke-28,Elgeyo Marakwet
+ocd-division/country:ke/county:ke-29,Nandi
+ocd-division/country:ke/county:ke-30,Baringo
+ocd-division/country:ke/county:ke-31,Laikipia
+ocd-division/country:ke/county:ke-32,Nakuru
+ocd-division/country:ke/county:ke-33,Narok
+ocd-division/country:ke/county:ke-34,Kajiado
+ocd-division/country:ke/county:ke-35,Kericho
+ocd-division/country:ke/county:ke-36,Bomet
+ocd-division/country:ke/county:ke-37,Kakamega
+ocd-division/country:ke/county:ke-38,Vihiga
+ocd-division/country:ke/county:ke-39,Bungoma
+ocd-division/country:ke/county:ke-40,Busia
+ocd-division/country:ke/county:ke-41,Siaya
+ocd-division/country:ke/county:ke-42,Kisumu
+ocd-division/country:ke/county:ke-43,Homa Bay
+ocd-division/country:ke/county:ke-44,Migori
+ocd-division/country:ke/county:ke-45,Kisii
+ocd-division/country:ke/county:ke-46,Nyamira
+ocd-division/country:ke/county:ke-47,Nairobi City

--- a/identifiers/country-ke/county_assembly.csv
+++ b/identifiers/country-ke/county_assembly.csv
@@ -1,0 +1,1451 @@
+id,name
+ocd-division/country:ke/county:ke-01/ed:changamwe/ward:port_reitz,Port Reitz
+ocd-division/country:ke/county:ke-01/ed:changamwe/ward:kipevu,Kipevu
+ocd-division/country:ke/county:ke-01/ed:changamwe/ward:airport,Airport
+ocd-division/country:ke/county:ke-01/ed:changamwe/ward:changamwe,Changamwe
+ocd-division/country:ke/county:ke-01/ed:changamwe/ward:chaani,Chaani
+ocd-division/country:ke/county:ke-01/ed:jomvu/ward:jomvu_kuu,Jomvu Kuu
+ocd-division/country:ke/county:ke-01/ed:jomvu/ward:miritini,Miritini
+ocd-division/country:ke/county:ke-01/ed:jomvu/ward:mikindani,Mikindani
+ocd-division/country:ke/county:ke-01/ed:kisauni/ward:mjambere,Mjambere
+ocd-division/country:ke/county:ke-01/ed:kisauni/ward:junda,Junda
+ocd-division/country:ke/county:ke-01/ed:kisauni/ward:bamburi,Bamburi
+ocd-division/country:ke/county:ke-01/ed:kisauni/ward:mwakirunge,Mwakirunge
+ocd-division/country:ke/county:ke-01/ed:kisauni/ward:mtopanga,Mtopanga
+ocd-division/country:ke/county:ke-01/ed:kisauni/ward:magogoni,Magogoni
+ocd-division/country:ke/county:ke-01/ed:kisauni/ward:shanzu,Shanzu
+ocd-division/country:ke/county:ke-01/ed:nyali/ward:frere_town,Frere Town
+ocd-division/country:ke/county:ke-01/ed:nyali/ward:ziwa_la_ngombe,Ziwa La Ng’ombe
+ocd-division/country:ke/county:ke-01/ed:nyali/ward:mkomani,Mkomani
+ocd-division/country:ke/county:ke-01/ed:nyali/ward:kongowea,Kongowea
+ocd-division/country:ke/county:ke-01/ed:nyali/ward:kadzandani,Kadzandani
+ocd-division/country:ke/county:ke-01/ed:likoni/ward:mtongwe,Mtongwe
+ocd-division/country:ke/county:ke-01/ed:likoni/ward:shika_adabu,Shika Adabu
+ocd-division/country:ke/county:ke-01/ed:likoni/ward:bofu,Bofu
+ocd-division/country:ke/county:ke-01/ed:likoni/ward:likoni,Likoni
+ocd-division/country:ke/county:ke-01/ed:likoni/ward:timbwani,Timbwani
+ocd-division/country:ke/county:ke-01/ed:mvita/ward:mji_wa_kale_makadara,Mji Wa Kale-Makadara
+ocd-division/country:ke/county:ke-01/ed:mvita/ward:tudor,Tudor
+ocd-division/country:ke/county:ke-01/ed:mvita/ward:tononoka,Tononoka
+ocd-division/country:ke/county:ke-01/ed:mvita/ward:shimanzi_ganjoni,Shimanzi-Ganjoni
+ocd-division/country:ke/county:ke-01/ed:mvita/ward:majengo,Majengo
+ocd-division/country:ke/county:ke-02/ed:msambweni/ward:gombato_bongwe,Gombato Bongwe
+ocd-division/country:ke/county:ke-02/ed:msambweni/ward:ukunda,Ukunda
+ocd-division/country:ke/county:ke-02/ed:msambweni/ward:kinondo,Kinondo
+ocd-division/country:ke/county:ke-02/ed:msambweni/ward:ramisi,Ramisi
+ocd-division/country:ke/county:ke-02/ed:lungalunga/ward:pongwe_kikoneni,Pongwe-Kikoneni
+ocd-division/country:ke/county:ke-02/ed:lungalunga/ward:dzombo,Dzombo
+ocd-division/country:ke/county:ke-02/ed:lungalunga/ward:mwereni,Mwereni
+ocd-division/country:ke/county:ke-02/ed:lungalunga/ward:vanga,Vanga
+ocd-division/country:ke/county:ke-02/ed:matuga/ward:tsimba_golini,Tsimba Golini
+ocd-division/country:ke/county:ke-02/ed:matuga/ward:waa,Waa
+ocd-division/country:ke/county:ke-02/ed:matuga/ward:tiwi,Tiwi
+ocd-division/country:ke/county:ke-02/ed:matuga/ward:kubo_south,Kubo South
+ocd-division/country:ke/county:ke-02/ed:matuga/ward:mkongani,Mkongani
+ocd-division/country:ke/county:ke-02/ed:kinango/ward:ndavaya,Ndavaya
+ocd-division/country:ke/county:ke-02/ed:kinango/ward:puma,Puma
+ocd-division/country:ke/county:ke-02/ed:kinango/ward:kinango,Kinango
+ocd-division/country:ke/county:ke-02/ed:kinango/ward:mackinnon_road,Mackinnon Road
+ocd-division/country:ke/county:ke-02/ed:kinango/ward:chengoni_samburu,Chengoni-Samburu
+ocd-division/country:ke/county:ke-02/ed:kinango/ward:mwavumbo,Mwavumbo
+ocd-division/country:ke/county:ke-02/ed:kinango/ward:kasemeni,Kasemeni
+ocd-division/country:ke/county:ke-03/ed:kilifi_north/ward:tezo,Tezo
+ocd-division/country:ke/county:ke-03/ed:kilifi_north/ward:sokoni,Sokoni
+ocd-division/country:ke/county:ke-03/ed:kilifi_north/ward:kibarani,Kibarani
+ocd-division/country:ke/county:ke-03/ed:kilifi_north/ward:dabaso,Dabaso
+ocd-division/country:ke/county:ke-03/ed:kilifi_north/ward:matsangoni,Matsangoni
+ocd-division/country:ke/county:ke-03/ed:kilifi_north/ward:watamu,Watamu
+ocd-division/country:ke/county:ke-03/ed:kilifi_north/ward:mnarani,Mnarani
+ocd-division/country:ke/county:ke-03/ed:kilifi_south/ward:junju,Junju
+ocd-division/country:ke/county:ke-03/ed:kilifi_south/ward:mwarakaya,Mwarakaya
+ocd-division/country:ke/county:ke-03/ed:kilifi_south/ward:shimo_la_tewa,Shimo La Tewa
+ocd-division/country:ke/county:ke-03/ed:kilifi_south/ward:chasimba,Chasimba
+ocd-division/country:ke/county:ke-03/ed:kilifi_south/ward:mtepeni,Mtepeni
+ocd-division/country:ke/county:ke-03/ed:kaloleni/ward:mariakani,Mariakani
+ocd-division/country:ke/county:ke-03/ed:kaloleni/ward:kayafungo,Kayafungo
+ocd-division/country:ke/county:ke-03/ed:kaloleni/ward:kaloleni,Kaloleni
+ocd-division/country:ke/county:ke-03/ed:kaloleni/ward:mwanamwinga,Mwanamwinga
+ocd-division/country:ke/county:ke-03/ed:rabai/ward:mwawesa,Mwawesa
+ocd-division/country:ke/county:ke-03/ed:rabai/ward:ruruma,Ruruma
+ocd-division/country:ke/county:ke-03/ed:rabai/ward:kambe_ribe,Kambe-Ribe
+ocd-division/country:ke/county:ke-03/ed:rabai/ward:rabai_kisurutini,Rabai-Kisurutini
+ocd-division/country:ke/county:ke-03/ed:ganze/ward:ganze,Ganze
+ocd-division/country:ke/county:ke-03/ed:ganze/ward:bamba,Bamba
+ocd-division/country:ke/county:ke-03/ed:ganze/ward:jaribuni,Jaribuni
+ocd-division/country:ke/county:ke-03/ed:ganze/ward:sokoke,Sokoke
+ocd-division/country:ke/county:ke-03/ed:malindi/ward:jilore,Jilore
+ocd-division/country:ke/county:ke-03/ed:malindi/ward:kakuyuni,Kakuyuni
+ocd-division/country:ke/county:ke-03/ed:malindi/ward:ganda,Ganda
+ocd-division/country:ke/county:ke-03/ed:malindi/ward:malindi_town,Malindi Town
+ocd-division/country:ke/county:ke-03/ed:malindi/ward:shella,Shella
+ocd-division/country:ke/county:ke-03/ed:magarini/ward:marafa,Marafa
+ocd-division/country:ke/county:ke-03/ed:magarini/ward:magarini,Magarini
+ocd-division/country:ke/county:ke-03/ed:magarini/ward:gongoni,Gongoni
+ocd-division/country:ke/county:ke-03/ed:magarini/ward:adu,Adu
+ocd-division/country:ke/county:ke-03/ed:magarini/ward:garashi,Garashi
+ocd-division/country:ke/county:ke-03/ed:magarini/ward:sabaki,Sabaki
+ocd-division/country:ke/county:ke-04/ed:garsen/ward:kipini_east,Kipini East
+ocd-division/country:ke/county:ke-04/ed:garsen/ward:garsen_south,Garsen South
+ocd-division/country:ke/county:ke-04/ed:garsen/ward:kipini_west,Kipini West
+ocd-division/country:ke/county:ke-04/ed:garsen/ward:garsen_central,Garsen Central
+ocd-division/country:ke/county:ke-04/ed:garsen/ward:garsen_west,Garsen West
+ocd-division/country:ke/county:ke-04/ed:garsen/ward:garsen_north,Garsen North
+ocd-division/country:ke/county:ke-04/ed:galole/ward:kinakomba,Kinakomba
+ocd-division/country:ke/county:ke-04/ed:galole/ward:mikinduni,Mikinduni
+ocd-division/country:ke/county:ke-04/ed:galole/ward:chewani,Chewani
+ocd-division/country:ke/county:ke-04/ed:galole/ward:wayu,Wayu
+ocd-division/country:ke/county:ke-04/ed:bura/ward:chewele,Chewele
+ocd-division/country:ke/county:ke-04/ed:bura/ward:hirimani,Hirimani
+ocd-division/country:ke/county:ke-04/ed:bura/ward:bangale,Bangale
+ocd-division/country:ke/county:ke-04/ed:bura/ward:sala,Sala
+ocd-division/country:ke/county:ke-04/ed:bura/ward:madogo,Madogo
+ocd-division/country:ke/county:ke-05/ed:lamu_east/ward:faza,Faza
+ocd-division/country:ke/county:ke-05/ed:lamu_east/ward:kiunga,Kiunga
+ocd-division/country:ke/county:ke-05/ed:lamu_east/ward:basuba,Basuba
+ocd-division/country:ke/county:ke-05/ed:lamu_west/ward:shella,Shella
+ocd-division/country:ke/county:ke-05/ed:lamu_west/ward:mkomani,Mkomani
+ocd-division/country:ke/county:ke-05/ed:lamu_west/ward:hindi,Hindi
+ocd-division/country:ke/county:ke-05/ed:lamu_west/ward:mkunumbi,Mkunumbi
+ocd-division/country:ke/county:ke-05/ed:lamu_west/ward:hongwe,Hongwe
+ocd-division/country:ke/county:ke-05/ed:lamu_west/ward:witu,Witu
+ocd-division/country:ke/county:ke-05/ed:lamu_west/ward:bahari,Bahari
+ocd-division/country:ke/county:ke-06/ed:taveta/ward:chala,Chala
+ocd-division/country:ke/county:ke-06/ed:taveta/ward:mahoo,Mahoo
+ocd-division/country:ke/county:ke-06/ed:taveta/ward:bomani,Bomani
+ocd-division/country:ke/county:ke-06/ed:taveta/ward:mboghoni,Mboghoni
+ocd-division/country:ke/county:ke-06/ed:taveta/ward:mata,Mata
+ocd-division/country:ke/county:ke-06/ed:wundanyi/ward:wundanyi_mbale,Wundanyi-Mbale
+ocd-division/country:ke/county:ke-06/ed:wundanyi/ward:werugha,Werugha
+ocd-division/country:ke/county:ke-06/ed:wundanyi/ward:wumingu_kishushe,Wumingu-Kishushe
+ocd-division/country:ke/county:ke-06/ed:wundanyi/ward:mwanda_mgange,Mwanda-Mgange
+ocd-division/country:ke/county:ke-06/ed:mwatate/ward:ronge,Rong’e
+ocd-division/country:ke/county:ke-06/ed:mwatate/ward:mwatate,Mwatate
+ocd-division/country:ke/county:ke-06/ed:mwatate/ward:bura,Bura
+ocd-division/country:ke/county:ke-06/ed:mwatate/ward:chawia,Chawia
+ocd-division/country:ke/county:ke-06/ed:mwatate/ward:wusi_kishamba,Wusi-Kishamba
+ocd-division/country:ke/county:ke-06/ed:voi/ward:mbololo,Mbololo
+ocd-division/country:ke/county:ke-06/ed:voi/ward:sagalla,Sagalla
+ocd-division/country:ke/county:ke-06/ed:voi/ward:kaloleni,Kaloleni
+ocd-division/country:ke/county:ke-06/ed:voi/ward:marungu,Marungu
+ocd-division/country:ke/county:ke-06/ed:voi/ward:kasigau,Kasigau
+ocd-division/country:ke/county:ke-06/ed:voi/ward:ngolia,Ngolia
+ocd-division/country:ke/county:ke-07/ed:garissa_township/ward:waberi,Waberi
+ocd-division/country:ke/county:ke-07/ed:garissa_township/ward:galbet,Galbet
+ocd-division/country:ke/county:ke-07/ed:garissa_township/ward:township,Township
+ocd-division/country:ke/county:ke-07/ed:garissa_township/ward:iftin,Iftin
+ocd-division/country:ke/county:ke-07/ed:balambala/ward:balambala,Balambala
+ocd-division/country:ke/county:ke-07/ed:balambala/ward:danyere,Danyere
+ocd-division/country:ke/county:ke-07/ed:balambala/ward:jara_jara,Jara Jara
+ocd-division/country:ke/county:ke-07/ed:balambala/ward:saka,Saka
+ocd-division/country:ke/county:ke-07/ed:balambala/ward:sankuri,Sankuri
+ocd-division/country:ke/county:ke-07/ed:lagdera/ward:modogashe,Modogashe
+ocd-division/country:ke/county:ke-07/ed:lagdera/ward:benane,Benane
+ocd-division/country:ke/county:ke-07/ed:lagdera/ward:goreale,Goreale
+ocd-division/country:ke/county:ke-07/ed:lagdera/ward:maalimin,Maalimin
+ocd-division/country:ke/county:ke-07/ed:lagdera/ward:sabena,Sabena
+ocd-division/country:ke/county:ke-07/ed:lagdera/ward:baraki,Baraki
+ocd-division/country:ke/county:ke-07/ed:dadaab/ward:dertu,Dertu
+ocd-division/country:ke/county:ke-07/ed:dadaab/ward:dadaab,Dadaab
+ocd-division/country:ke/county:ke-07/ed:dadaab/ward:labasigale,Labasigale
+ocd-division/country:ke/county:ke-07/ed:dadaab/ward:damajale,Damajale
+ocd-division/country:ke/county:ke-07/ed:dadaab/ward:liboi,Liboi
+ocd-division/country:ke/county:ke-07/ed:dadaab/ward:abakaile,Abakaile
+ocd-division/country:ke/county:ke-07/ed:fafi/ward:bura,Bura
+ocd-division/country:ke/county:ke-07/ed:fafi/ward:dekaharia,Dekaharia
+ocd-division/country:ke/county:ke-07/ed:fafi/ward:jarajila,Jarajila
+ocd-division/country:ke/county:ke-07/ed:fafi/ward:fafi,Fafi
+ocd-division/country:ke/county:ke-07/ed:fafi/ward:nanighi,Nanighi
+ocd-division/country:ke/county:ke-07/ed:ijara/ward:hulugho,Hulugho
+ocd-division/country:ke/county:ke-07/ed:ijara/ward:sangailu,Sangailu
+ocd-division/country:ke/county:ke-07/ed:ijara/ward:ijara,Ijara
+ocd-division/country:ke/county:ke-07/ed:ijara/ward:masalani,Masalani
+ocd-division/country:ke/county:ke-08/ed:wajir_north/ward:gurar,Gurar
+ocd-division/country:ke/county:ke-08/ed:wajir_north/ward:bute,Bute
+ocd-division/country:ke/county:ke-08/ed:wajir_north/ward:korondile,Korondile
+ocd-division/country:ke/county:ke-08/ed:wajir_north/ward:malkagufu,Malkagufu
+ocd-division/country:ke/county:ke-08/ed:wajir_north/ward:batalu,Batalu
+ocd-division/country:ke/county:ke-08/ed:wajir_north/ward:danaba,Danaba
+ocd-division/country:ke/county:ke-08/ed:wajir_north/ward:godoma,Godoma
+ocd-division/country:ke/county:ke-08/ed:wajir_east/ward:wagberi,Wagberi
+ocd-division/country:ke/county:ke-08/ed:wajir_east/ward:township,Township
+ocd-division/country:ke/county:ke-08/ed:wajir_east/ward:barwago,Barwago
+ocd-division/country:ke/county:ke-08/ed:wajir_east/ward:khorof_harar,Khorof-Harar
+ocd-division/country:ke/county:ke-08/ed:tarbaj/ward:elben,Elben
+ocd-division/country:ke/county:ke-08/ed:tarbaj/ward:sarman,Sarman
+ocd-division/country:ke/county:ke-08/ed:tarbaj/ward:tarbaj,Tarbaj
+ocd-division/country:ke/county:ke-08/ed:tarbaj/ward:wargadud,Wargadud
+ocd-division/country:ke/county:ke-08/ed:wajir_west/ward:arbajahan,Arbajahan
+ocd-division/country:ke/county:ke-08/ed:wajir_west/ward:hadado_athibohol,Hadado-Athibohol
+ocd-division/country:ke/county:ke-08/ed:wajir_west/ward:adamasajide,Adamasajide
+ocd-division/country:ke/county:ke-08/ed:wajir_west/ward:ganyure_wagalla,Ganyure-Wagalla
+ocd-division/country:ke/county:ke-08/ed:eldas/ward:eldas,Eldas
+ocd-division/country:ke/county:ke-08/ed:eldas/ward:della,Della
+ocd-division/country:ke/county:ke-08/ed:eldas/ward:lakoley_south_basir,Lakoley South-Basir
+ocd-division/country:ke/county:ke-08/ed:eldas/ward:elnur_tula_tula,Elnur-Tula Tula
+ocd-division/country:ke/county:ke-08/ed:wajir_south/ward:benane,Benane
+ocd-division/country:ke/county:ke-08/ed:wajir_south/ward:burder,Burder
+ocd-division/country:ke/county:ke-08/ed:wajir_south/ward:dadaja_bulla,Dadaja Bulla
+ocd-division/country:ke/county:ke-08/ed:wajir_south/ward:habasswein,Habasswein
+ocd-division/country:ke/county:ke-08/ed:wajir_south/ward:lagboghol_south,Lagboghol South
+ocd-division/country:ke/county:ke-08/ed:wajir_south/ward:ibrahim_ure,Ibrahim Ure
+ocd-division/country:ke/county:ke-08/ed:wajir_south/ward:diif,Diif
+ocd-division/country:ke/county:ke-09/ed:mandera_west/ward:takaba_south,Takaba South
+ocd-division/country:ke/county:ke-09/ed:mandera_west/ward:takaba,Takaba
+ocd-division/country:ke/county:ke-09/ed:mandera_west/ward:lagsure,Lagsure
+ocd-division/country:ke/county:ke-09/ed:mandera_west/ward:dandu,Dandu
+ocd-division/country:ke/county:ke-09/ed:mandera_west/ward:gither,Gither
+ocd-division/country:ke/county:ke-09/ed:banissa/ward:banissa,Banissa
+ocd-division/country:ke/county:ke-09/ed:banissa/ward:derkhale,Derkhale
+ocd-division/country:ke/county:ke-09/ed:banissa/ward:guba,Guba
+ocd-division/country:ke/county:ke-09/ed:banissa/ward:malkamari,Malkamari
+ocd-division/country:ke/county:ke-09/ed:banissa/ward:kiliwehiri,Kiliwehiri
+ocd-division/country:ke/county:ke-09/ed:mandera_north/ward:ashabito,Ashabito
+ocd-division/country:ke/county:ke-09/ed:mandera_north/ward:guticha,Guticha
+ocd-division/country:ke/county:ke-09/ed:mandera_north/ward:morothile,Morothile
+ocd-division/country:ke/county:ke-09/ed:mandera_north/ward:rhamu,Rhamu
+ocd-division/country:ke/county:ke-09/ed:mandera_north/ward:rhamu_dimtu,Rhamu-Dimtu
+ocd-division/country:ke/county:ke-09/ed:mandera_south/ward:wargadud,Wargadud
+ocd-division/country:ke/county:ke-09/ed:mandera_south/ward:kutulo,Kutulo
+ocd-division/country:ke/county:ke-09/ed:mandera_south/ward:elwak_south,Elwak South
+ocd-division/country:ke/county:ke-09/ed:mandera_south/ward:elwak_north,Elwak North
+ocd-division/country:ke/county:ke-09/ed:mandera_south/ward:shimbir_fatuma,Shimbir Fatuma
+ocd-division/country:ke/county:ke-09/ed:mandera_east/ward:arabia,Arabia
+ocd-division/country:ke/county:ke-09/ed:mandera_east/ward:bulla_mpya,Bulla Mpya
+ocd-division/country:ke/county:ke-09/ed:mandera_east/ward:khalalio,Khalalio
+ocd-division/country:ke/county:ke-09/ed:mandera_east/ward:neboi,Neboi
+ocd-division/country:ke/county:ke-09/ed:mandera_east/ward:township,Township
+ocd-division/country:ke/county:ke-09/ed:lafey/ward:libehia,Libehia
+ocd-division/country:ke/county:ke-09/ed:lafey/ward:fino,Fino
+ocd-division/country:ke/county:ke-09/ed:lafey/ward:lafey,Lafey
+ocd-division/country:ke/county:ke-09/ed:lafey/ward:waranqara,Waranqara
+ocd-division/country:ke/county:ke-09/ed:lafey/ward:alango_gof,Alango Gof
+ocd-division/country:ke/county:ke-10/ed:moyale/ward:butiye,Butiye
+ocd-division/country:ke/county:ke-10/ed:moyale/ward:sololo,Sololo
+ocd-division/country:ke/county:ke-10/ed:moyale/ward:heillu_manyatta,Heillu-Manyatta
+ocd-division/country:ke/county:ke-10/ed:moyale/ward:golbo,Golbo
+ocd-division/country:ke/county:ke-10/ed:moyale/ward:moyale_township,Moyale Township
+ocd-division/country:ke/county:ke-10/ed:moyale/ward:uran,Uran
+ocd-division/country:ke/county:ke-10/ed:moyale/ward:obbu,Obbu
+ocd-division/country:ke/county:ke-10/ed:north_horr/ward:dukana,Dukana
+ocd-division/country:ke/county:ke-10/ed:north_horr/ward:maikona,Maikona
+ocd-division/country:ke/county:ke-10/ed:north_horr/ward:turbi,Turbi
+ocd-division/country:ke/county:ke-10/ed:north_horr/ward:north_horr,North Horr
+ocd-division/country:ke/county:ke-10/ed:north_horr/ward:illeret,Illeret
+ocd-division/country:ke/county:ke-10/ed:saku/ward:sagante_jaldesa,Sagante-Jaldesa
+ocd-division/country:ke/county:ke-10/ed:saku/ward:karare,Karare
+ocd-division/country:ke/county:ke-10/ed:saku/ward:marsabit_central,Marsabit Central
+ocd-division/country:ke/county:ke-10/ed:laisamis/ward:loiyangalani,Loiyangalani
+ocd-division/country:ke/county:ke-10/ed:laisamis/ward:kargi_south_horr,Kargi-South Horr
+ocd-division/country:ke/county:ke-10/ed:laisamis/ward:korr_ngurunit,Korr-Ngurunit
+ocd-division/country:ke/county:ke-10/ed:laisamis/ward:logo_logo,Logo Logo
+ocd-division/country:ke/county:ke-10/ed:laisamis/ward:laisamis,Laisamis
+ocd-division/country:ke/county:ke-11/ed:isiolo_north/ward:wabera,Wabera
+ocd-division/country:ke/county:ke-11/ed:isiolo_north/ward:bulla_pesa,Bulla Pesa
+ocd-division/country:ke/county:ke-11/ed:isiolo_north/ward:chari,Chari
+ocd-division/country:ke/county:ke-11/ed:isiolo_north/ward:cherab,Cherab
+ocd-division/country:ke/county:ke-11/ed:isiolo_north/ward:ngare_mara,Ngare Mara
+ocd-division/country:ke/county:ke-11/ed:isiolo_north/ward:burat,Burat
+ocd-division/country:ke/county:ke-11/ed:isiolo_north/ward:oldo_nyiro,Oldo-Nyiro
+ocd-division/country:ke/county:ke-11/ed:isiolo_south/ward:garbatulla,Garbatulla
+ocd-division/country:ke/county:ke-11/ed:isiolo_south/ward:kinna,Kinna
+ocd-division/country:ke/county:ke-11/ed:isiolo_south/ward:sericho,Sericho
+ocd-division/country:ke/county:ke-12/ed:igembe_south/ward:maua,Maua
+ocd-division/country:ke/county:ke-12/ed:igembe_south/ward:kiegoi_antubochiu,Kiegoi-Antubochiu
+ocd-division/country:ke/county:ke-12/ed:igembe_south/ward:athiru_gaiti,Athiru Gaiti
+ocd-division/country:ke/county:ke-12/ed:igembe_south/ward:akachiu,Akachiu
+ocd-division/country:ke/county:ke-12/ed:igembe_south/ward:kanuni,Kanuni
+ocd-division/country:ke/county:ke-12/ed:igembe_central/ward:akirangondu,Akirang’ondu
+ocd-division/country:ke/county:ke-12/ed:igembe_central/ward:athiru_ruujine,Athiru Ruujine
+ocd-division/country:ke/county:ke-12/ed:igembe_central/ward:igembe_east,Igembe East
+ocd-division/country:ke/county:ke-12/ed:igembe_central/ward:njia,Njia
+ocd-division/country:ke/county:ke-12/ed:igembe_central/ward:kangeta,Kangeta
+ocd-division/country:ke/county:ke-12/ed:igembe_north/ward:antuambui,Antuambui
+ocd-division/country:ke/county:ke-12/ed:igembe_north/ward:ntunene,Ntunene
+ocd-division/country:ke/county:ke-12/ed:igembe_north/ward:antubetwe_kiongo,Antubetwe Kiongo
+ocd-division/country:ke/county:ke-12/ed:igembe_north/ward:naathu,Naathu
+ocd-division/country:ke/county:ke-12/ed:igembe_north/ward:amwathi,Amwathi
+ocd-division/country:ke/county:ke-12/ed:tigania_west/ward:athwana,Athwana
+ocd-division/country:ke/county:ke-12/ed:tigania_west/ward:akithii,Akithii
+ocd-division/country:ke/county:ke-12/ed:tigania_west/ward:kianjai,Kianjai
+ocd-division/country:ke/county:ke-12/ed:tigania_west/ward:nkomo,Nkomo
+ocd-division/country:ke/county:ke-12/ed:tigania_west/ward:mbeu,Mbeu
+ocd-division/country:ke/county:ke-12/ed:tigania_east/ward:thangatha,Thangatha
+ocd-division/country:ke/county:ke-12/ed:tigania_east/ward:mikinduri,Mikinduri
+ocd-division/country:ke/county:ke-12/ed:tigania_east/ward:kiguchwa,Kiguchwa
+ocd-division/country:ke/county:ke-12/ed:tigania_east/ward:muthara,Muthara
+ocd-division/country:ke/county:ke-12/ed:tigania_east/ward:karama,Karama
+ocd-division/country:ke/county:ke-12/ed:north_imenti/ward:municipality,Municipality
+ocd-division/country:ke/county:ke-12/ed:north_imenti/ward:ntima_east,Ntima East
+ocd-division/country:ke/county:ke-12/ed:north_imenti/ward:ntima_west,Ntima West
+ocd-division/country:ke/county:ke-12/ed:north_imenti/ward:nyaki_west,Nyaki West
+ocd-division/country:ke/county:ke-12/ed:north_imenti/ward:nyaki_east,Nyaki East
+ocd-division/country:ke/county:ke-12/ed:buuri/ward:timau,Timau
+ocd-division/country:ke/county:ke-12/ed:buuri/ward:kisima,Kisima
+ocd-division/country:ke/county:ke-12/ed:buuri/ward:kiirua_naari,Kiirua-Naari
+ocd-division/country:ke/county:ke-12/ed:buuri/ward:ruiri_rwarera,Ruiri-Rwarera
+ocd-division/country:ke/county:ke-12/ed:central_imenti/ward:mwanganthia,Mwanganthia
+ocd-division/country:ke/county:ke-12/ed:central_imenti/ward:abothuguchi_central,Abothuguchi Central
+ocd-division/country:ke/county:ke-12/ed:central_imenti/ward:abothuguchi_west,Abothuguchi West
+ocd-division/country:ke/county:ke-12/ed:central_imenti/ward:kiagu,Kiagu
+ocd-division/country:ke/county:ke-12/ed:buuri/ward:kibirichia,Kibirichia
+ocd-division/country:ke/county:ke-12/ed:south_imenti/ward:mitunguu,Mitunguu
+ocd-division/country:ke/county:ke-12/ed:south_imenti/ward:igoji_east,Igoji East
+ocd-division/country:ke/county:ke-12/ed:south_imenti/ward:igoji_west,Igoji West
+ocd-division/country:ke/county:ke-12/ed:south_imenti/ward:abogeta_east,Abogeta East
+ocd-division/country:ke/county:ke-12/ed:south_imenti/ward:abogeta_west,Abogeta West
+ocd-division/country:ke/county:ke-12/ed:south_imenti/ward:nkuene,Nkuene
+ocd-division/country:ke/county:ke-13/ed:maara/ward:mitheru,Mitheru
+ocd-division/country:ke/county:ke-13/ed:maara/ward:muthambi,Muthambi
+ocd-division/country:ke/county:ke-13/ed:maara/ward:mwimbi,Mwimbi
+ocd-division/country:ke/county:ke-13/ed:maara/ward:ganga,Ganga
+ocd-division/country:ke/county:ke-13/ed:maara/ward:chogoria,Chogoria
+ocd-division/country:ke/county:ke-13/ed:chuka_igambangombe/ward:mariani,Mariani
+ocd-division/country:ke/county:ke-13/ed:chuka_igambangombe/ward:karingani,Karingani
+ocd-division/country:ke/county:ke-13/ed:chuka_igambangombe/ward:magumoni,Magumoni
+ocd-division/country:ke/county:ke-13/ed:chuka_igambangombe/ward:mugwe,Mugwe
+ocd-division/country:ke/county:ke-13/ed:chuka_igambangombe/ward:igambangombe,Igambang’ombe
+ocd-division/country:ke/county:ke-13/ed:tharaka/ward:gatunga,Gatunga
+ocd-division/country:ke/county:ke-13/ed:tharaka/ward:mukothima,Mukothima
+ocd-division/country:ke/county:ke-13/ed:tharaka/ward:nkondi,Nkondi
+ocd-division/country:ke/county:ke-13/ed:tharaka/ward:chiakariga,Chiakariga
+ocd-division/country:ke/county:ke-13/ed:tharaka/ward:marimanti,Marimanti
+ocd-division/country:ke/county:ke-14/ed:manyatta/ward:ruguru_ngandori,Ruguru-Ngandori
+ocd-division/country:ke/county:ke-14/ed:manyatta/ward:kithimu,Kithimu
+ocd-division/country:ke/county:ke-14/ed:manyatta/ward:nginda,Nginda
+ocd-division/country:ke/county:ke-14/ed:manyatta/ward:mbeti_north,Mbeti North
+ocd-division/country:ke/county:ke-14/ed:manyatta/ward:kirimari,Kirimari
+ocd-division/country:ke/county:ke-14/ed:manyatta/ward:gaturi_south,Gaturi South
+ocd-division/country:ke/county:ke-14/ed:runyenjes/ward:gaturi_north,Gaturi North
+ocd-division/country:ke/county:ke-14/ed:runyenjes/ward:kagaari_south,Kagaari South
+ocd-division/country:ke/county:ke-14/ed:runyenjes/ward:central_ward,Central Ward
+ocd-division/country:ke/county:ke-14/ed:runyenjes/ward:kagaari_north,Kagaari North
+ocd-division/country:ke/county:ke-14/ed:runyenjes/ward:kyeni_north,Kyeni North
+ocd-division/country:ke/county:ke-14/ed:runyenjes/ward:kyeni_south,Kyeni South
+ocd-division/country:ke/county:ke-14/ed:mbeere_south/ward:mwea,Mwea
+ocd-division/country:ke/county:ke-14/ed:mbeere_south/ward:makima,Makima
+ocd-division/country:ke/county:ke-14/ed:mbeere_south/ward:mbeti_south,Mbeti South
+ocd-division/country:ke/county:ke-14/ed:mbeere_south/ward:mavuria,Mavuria
+ocd-division/country:ke/county:ke-14/ed:mbeere_south/ward:kiambere,Kiambere
+ocd-division/country:ke/county:ke-14/ed:mbeere_north/ward:nthawa,Nthawa
+ocd-division/country:ke/county:ke-14/ed:mbeere_north/ward:muminji,Muminji
+ocd-division/country:ke/county:ke-14/ed:mbeere_north/ward:evurore,Evurore
+ocd-division/country:ke/county:ke-15/ed:mwingi_north/ward:ngomeni,Ngomeni
+ocd-division/country:ke/county:ke-15/ed:mwingi_north/ward:kyuso,Kyuso
+ocd-division/country:ke/county:ke-15/ed:mwingi_north/ward:mumoni,Mumoni
+ocd-division/country:ke/county:ke-15/ed:mwingi_north/ward:tseikuru,Tseikuru
+ocd-division/country:ke/county:ke-15/ed:mwingi_north/ward:tharaka,Tharaka
+ocd-division/country:ke/county:ke-15/ed:mwingi_west/ward:kyome_thaana,Kyome-Thaana
+ocd-division/country:ke/county:ke-15/ed:mwingi_west/ward:nguutani,Nguutani
+ocd-division/country:ke/county:ke-15/ed:mwingi_west/ward:migwani,Migwani
+ocd-division/country:ke/county:ke-15/ed:mwingi_west/ward:kiomo_kyethani,Kiomo-Kyethani
+ocd-division/country:ke/county:ke-15/ed:mwingi_central/ward:central,Central
+ocd-division/country:ke/county:ke-15/ed:mwingi_central/ward:kivou,Kivou
+ocd-division/country:ke/county:ke-15/ed:mwingi_central/ward:nguni,Nguni
+ocd-division/country:ke/county:ke-15/ed:mwingi_central/ward:nuu,Nuu
+ocd-division/country:ke/county:ke-15/ed:mwingi_central/ward:mui,Mui
+ocd-division/country:ke/county:ke-15/ed:mwingi_central/ward:waita,Waita
+ocd-division/country:ke/county:ke-15/ed:kitui_west/ward:mutonguni,Mutonguni
+ocd-division/country:ke/county:ke-15/ed:kitui_west/ward:kauwi,Kauwi
+ocd-division/country:ke/county:ke-15/ed:kitui_west/ward:matinyani,Matinyani
+ocd-division/country:ke/county:ke-15/ed:kitui_west/ward:kwa_mutonga_kithumula,Kwa Mutonga-Kithumula
+ocd-division/country:ke/county:ke-15/ed:kitui_rural/ward:kisasi,Kisasi
+ocd-division/country:ke/county:ke-15/ed:kitui_rural/ward:mbitini,Mbitini
+ocd-division/country:ke/county:ke-15/ed:kitui_rural/ward:kwavonza_yatta,Kwavonza-Yatta
+ocd-division/country:ke/county:ke-15/ed:kitui_rural/ward:kanyangi,Kanyangi
+ocd-division/country:ke/county:ke-15/ed:kitui_central/ward:miambani,Miambani
+ocd-division/country:ke/county:ke-15/ed:kitui_central/ward:township,Township
+ocd-division/country:ke/county:ke-15/ed:kitui_central/ward:kyangwithya_west,Kyangwithya West
+ocd-division/country:ke/county:ke-15/ed:kitui_central/ward:mulango,Mulango
+ocd-division/country:ke/county:ke-15/ed:kitui_central/ward:kyangwithya_east,Kyangwithya East
+ocd-division/country:ke/county:ke-15/ed:kitui_east/ward:zombe_mwitika,Zombe-Mwitika
+ocd-division/country:ke/county:ke-15/ed:kitui_east/ward:nzambani,Nzambani
+ocd-division/country:ke/county:ke-15/ed:kitui_east/ward:chuluni,Chuluni
+ocd-division/country:ke/county:ke-15/ed:kitui_east/ward:voo_kyamatu,Voo-Kyamatu
+ocd-division/country:ke/county:ke-15/ed:kitui_east/ward:endau_malalani,Endau-Malalani
+ocd-division/country:ke/county:ke-15/ed:kitui_east/ward:mutito_kaliku,Mutito-Kaliku
+ocd-division/country:ke/county:ke-15/ed:kitui_south/ward:ikanga_kyatune,Ikanga-Kyatune
+ocd-division/country:ke/county:ke-15/ed:kitui_south/ward:mutomo,Mutomo
+ocd-division/country:ke/county:ke-15/ed:kitui_south/ward:mutha,Mutha
+ocd-division/country:ke/county:ke-15/ed:kitui_south/ward:ikutha,Ikutha
+ocd-division/country:ke/county:ke-15/ed:kitui_south/ward:kanziko,Kanziko
+ocd-division/country:ke/county:ke-15/ed:kitui_south/ward:athi,Athi
+ocd-division/country:ke/county:ke-16/ed:masinga/ward:kivaa,Kivaa
+ocd-division/country:ke/county:ke-16/ed:masinga/ward:masinga_central,Masinga Central
+ocd-division/country:ke/county:ke-16/ed:masinga/ward:ekalakala,Ekalakala
+ocd-division/country:ke/county:ke-16/ed:masinga/ward:muthesya,Muthesya
+ocd-division/country:ke/county:ke-16/ed:masinga/ward:ndithini,Ndithini
+ocd-division/country:ke/county:ke-16/ed:yatta/ward:ndalani,Ndalani
+ocd-division/country:ke/county:ke-16/ed:yatta/ward:matuu,Matuu
+ocd-division/country:ke/county:ke-16/ed:yatta/ward:kithimani,Kithimani
+ocd-division/country:ke/county:ke-16/ed:yatta/ward:ikombe,Ikombe
+ocd-division/country:ke/county:ke-16/ed:yatta/ward:katangi,Katangi
+ocd-division/country:ke/county:ke-16/ed:kangundo/ward:kangundo_north,Kangundo North
+ocd-division/country:ke/county:ke-16/ed:kangundo/ward:kangundo_central,Kangundo Central
+ocd-division/country:ke/county:ke-16/ed:kangundo/ward:kangundo_east,Kangundo East
+ocd-division/country:ke/county:ke-16/ed:kangundo/ward:kangundo_west,Kangundo West
+ocd-division/country:ke/county:ke-16/ed:matungulu/ward:tala,Tala
+ocd-division/country:ke/county:ke-16/ed:matungulu/ward:matungulu_north,Matungulu North
+ocd-division/country:ke/county:ke-16/ed:matungulu/ward:matungulu_east,Matungulu East
+ocd-division/country:ke/county:ke-16/ed:matungulu/ward:matungulu_west,Matungulu West
+ocd-division/country:ke/county:ke-16/ed:matungulu/ward:kyeleni,Kyeleni
+ocd-division/country:ke/county:ke-16/ed:kathiani/ward:mitaboni,Mitaboni
+ocd-division/country:ke/county:ke-16/ed:kathiani/ward:kathiani_central,Kathiani Central
+ocd-division/country:ke/county:ke-16/ed:kathiani/ward:upper_kaewa_iveti,Upper Kaewa-Iveti
+ocd-division/country:ke/county:ke-16/ed:kathiani/ward:lower_kaewa_kaani,Lower Kaewa-Kaani
+ocd-division/country:ke/county:ke-16/ed:mavoko/ward:athi_river,Athi River
+ocd-division/country:ke/county:ke-16/ed:mavoko/ward:kinanie,Kinanie
+ocd-division/country:ke/county:ke-16/ed:mavoko/ward:muthwani,Muthwani
+ocd-division/country:ke/county:ke-16/ed:mavoko/ward:syokimau_mulolongo,Syokimau-Mulolongo
+ocd-division/country:ke/county:ke-16/ed:machakos_town/ward:kalama,Kalama
+ocd-division/country:ke/county:ke-16/ed:machakos_town/ward:mua,Mua
+ocd-division/country:ke/county:ke-16/ed:machakos_town/ward:mutituni,Mutituni
+ocd-division/country:ke/county:ke-16/ed:machakos_town/ward:machakos_central,Machakos Central
+ocd-division/country:ke/county:ke-16/ed:machakos_town/ward:mumbuni_north,Mumbuni North
+ocd-division/country:ke/county:ke-16/ed:machakos_town/ward:muvuti_kiima_kimwe,Muvuti-Kiima-Kimwe
+ocd-division/country:ke/county:ke-16/ed:machakos_town/ward:kola,Kola
+ocd-division/country:ke/county:ke-16/ed:mwala/ward:mbiuni,Mbiuni
+ocd-division/country:ke/county:ke-16/ed:mwala/ward:makutano_mwala,Makutano- Mwala
+ocd-division/country:ke/county:ke-16/ed:mwala/ward:masii,Masii
+ocd-division/country:ke/county:ke-16/ed:mwala/ward:muthetheni,Muthetheni
+ocd-division/country:ke/county:ke-16/ed:mwala/ward:wamunyu,Wamunyu
+ocd-division/country:ke/county:ke-16/ed:mwala/ward:kibauni,Kibauni
+ocd-division/country:ke/county:ke-17/ed:mbooni/ward:tulimani,Tulimani
+ocd-division/country:ke/county:ke-17/ed:mbooni/ward:mbooni,Mbooni
+ocd-division/country:ke/county:ke-17/ed:mbooni/ward:kithungo_kitundu,Kithungo-Kitundu
+ocd-division/country:ke/county:ke-17/ed:mbooni/ward:kiteta_kisau,Kiteta-Kisau
+ocd-division/country:ke/county:ke-17/ed:mbooni/ward:waia_kako,Waia-Kako
+ocd-division/country:ke/county:ke-17/ed:mbooni/ward:kalawa,Kalawa
+ocd-division/country:ke/county:ke-17/ed:kilome/ward:kasikeu,Kasikeu
+ocd-division/country:ke/county:ke-17/ed:kilome/ward:mukaa,Mukaa
+ocd-division/country:ke/county:ke-17/ed:kilome/ward:kiima_kiu_kalanzoni,Kiima Kiu-Kalanzoni
+ocd-division/country:ke/county:ke-17/ed:kaiti/ward:ukia,Ukia
+ocd-division/country:ke/county:ke-17/ed:kaiti/ward:kee,Kee
+ocd-division/country:ke/county:ke-17/ed:kaiti/ward:kilungu,Kilungu
+ocd-division/country:ke/county:ke-17/ed:kaiti/ward:ilima,Ilima
+ocd-division/country:ke/county:ke-17/ed:makueni/ward:wote,Wote
+ocd-division/country:ke/county:ke-17/ed:makueni/ward:muvau_kikuumini,Muvau-Kikuumini
+ocd-division/country:ke/county:ke-17/ed:makueni/ward:mavindini,Mavindini
+ocd-division/country:ke/county:ke-17/ed:makueni/ward:kitise_kithuki,Kitise-Kithuki
+ocd-division/country:ke/county:ke-17/ed:makueni/ward:kathonzweni,Kathonzweni
+ocd-division/country:ke/county:ke-17/ed:makueni/ward:nzaui_kilili_kalamba,Nzaui-Kilili-Kalamba
+ocd-division/country:ke/county:ke-17/ed:makueni/ward:mbitini,Mbitini
+ocd-division/country:ke/county:ke-17/ed:kibwezi_west/ward:makindu,Makindu
+ocd-division/country:ke/county:ke-17/ed:kibwezi_west/ward:nguumo,Nguumo
+ocd-division/country:ke/county:ke-17/ed:kibwezi_west/ward:kikumbulyu_north,Kikumbulyu North
+ocd-division/country:ke/county:ke-17/ed:kibwezi_west/ward:kikumbulyu_south,Kikumbulyu South
+ocd-division/country:ke/county:ke-17/ed:kibwezi_west/ward:nguu_masumba,Nguu-Masumba
+ocd-division/country:ke/county:ke-17/ed:kibwezi_west/ward:emali_mulala,Emali-Mulala
+ocd-division/country:ke/county:ke-17/ed:kibwezi_east/ward:masongaleni,Masongaleni
+ocd-division/country:ke/county:ke-17/ed:kibwezi_east/ward:mtito_andei,Mtito Andei
+ocd-division/country:ke/county:ke-17/ed:kibwezi_east/ward:thange,Thange
+ocd-division/country:ke/county:ke-17/ed:kibwezi_east/ward:ivingoni_nzambani,Ivingoni-Nzambani
+ocd-division/country:ke/county:ke-18/ed:kinangop/ward:engineer,Engineer
+ocd-division/country:ke/county:ke-18/ed:kinangop/ward:gathara,Gathara
+ocd-division/country:ke/county:ke-18/ed:kinangop/ward:north_kinangop,North Kinangop
+ocd-division/country:ke/county:ke-18/ed:kinangop/ward:murungaru,Murungaru
+ocd-division/country:ke/county:ke-18/ed:kinangop/ward:njabini_kiburu,Njabini\Kiburu
+ocd-division/country:ke/county:ke-18/ed:kinangop/ward:nyakio,Nyakio
+ocd-division/country:ke/county:ke-18/ed:kinangop/ward:githabai,Githabai
+ocd-division/country:ke/county:ke-18/ed:kinangop/ward:magumu,Magumu
+ocd-division/country:ke/county:ke-18/ed:kipipiri/ward:wanjohi,Wanjohi
+ocd-division/country:ke/county:ke-18/ed:kipipiri/ward:kipipiri,Kipipiri
+ocd-division/country:ke/county:ke-18/ed:kipipiri/ward:geta,Geta
+ocd-division/country:ke/county:ke-18/ed:kipipiri/ward:githioro,Githioro
+ocd-division/country:ke/county:ke-18/ed:ol_kalou/ward:karau,Karau
+ocd-division/country:ke/county:ke-18/ed:ol_kalou/ward:kanjuiri_range,Kanjuiri Range
+ocd-division/country:ke/county:ke-18/ed:ol_kalou/ward:mirangine,Mirangine
+ocd-division/country:ke/county:ke-18/ed:ol_kalou/ward:kaimbaga,Kaimbaga
+ocd-division/country:ke/county:ke-18/ed:ol_kalou/ward:rurii,Rurii
+ocd-division/country:ke/county:ke-18/ed:ol_jorok/ward:gathanji,Gathanji
+ocd-division/country:ke/county:ke-18/ed:ol_jorok/ward:gatimu,Gatimu
+ocd-division/country:ke/county:ke-18/ed:ol_jorok/ward:weru,Weru
+ocd-division/country:ke/county:ke-18/ed:ol_jorok/ward:charagita,Charagita
+ocd-division/country:ke/county:ke-18/ed:ndaragwa/ward:leshau_pondo,Leshau-Pondo
+ocd-division/country:ke/county:ke-18/ed:ndaragwa/ward:kiriita,Kiriita
+ocd-division/country:ke/county:ke-18/ed:ndaragwa/ward:central,Central
+ocd-division/country:ke/county:ke-18/ed:ndaragwa/ward:shamata,Shamata
+ocd-division/country:ke/county:ke-19/ed:tetu/ward:dedan_kimanthi,Dedan Kimanthi
+ocd-division/country:ke/county:ke-19/ed:tetu/ward:wamagana,Wamagana
+ocd-division/country:ke/county:ke-19/ed:tetu/ward:aguthi_gaaki,Aguthi-Gaaki
+ocd-division/country:ke/county:ke-19/ed:kieni/ward:mweiga,Mweiga
+ocd-division/country:ke/county:ke-19/ed:kieni/ward:naromoru_kiamathaga,Naromoru Kiamathaga
+ocd-division/country:ke/county:ke-19/ed:kieni/ward:mwiyogo_endarasha,Mwiyogo-Endarasha
+ocd-division/country:ke/county:ke-19/ed:kieni/ward:mugunda,Mugunda
+ocd-division/country:ke/county:ke-19/ed:kieni/ward:gatarakwa,Gatarakwa
+ocd-division/country:ke/county:ke-19/ed:kieni/ward:thegu_river,Thegu River
+ocd-division/country:ke/county:ke-19/ed:kieni/ward:kabaru,Kabaru
+ocd-division/country:ke/county:ke-19/ed:kieni/ward:gakawa,Gakawa
+ocd-division/country:ke/county:ke-19/ed:mathira/ward:ruguru,Ruguru
+ocd-division/country:ke/county:ke-19/ed:mathira/ward:magutu,Magutu
+ocd-division/country:ke/county:ke-19/ed:mathira/ward:iriaini,Iriaini
+ocd-division/country:ke/county:ke-19/ed:mathira/ward:konyu,Konyu
+ocd-division/country:ke/county:ke-19/ed:mathira/ward:kirimukuyu,Kirimukuyu
+ocd-division/country:ke/county:ke-19/ed:mathira/ward:karatina_town,Karatina Town
+ocd-division/country:ke/county:ke-19/ed:othaya/ward:mahiga,Mahiga
+ocd-division/country:ke/county:ke-19/ed:othaya/ward:iria_ini,Iria-Ini
+ocd-division/country:ke/county:ke-19/ed:othaya/ward:chinga,Chinga
+ocd-division/country:ke/county:ke-19/ed:othaya/ward:karima,Karima
+ocd-division/country:ke/county:ke-19/ed:mukurweini/ward:gikondi,Gikondi
+ocd-division/country:ke/county:ke-19/ed:mukurweini/ward:rugi,Rugi
+ocd-division/country:ke/county:ke-19/ed:mukurweini/ward:mukurwe_ini_west,Mukurwe-Ini West
+ocd-division/country:ke/county:ke-19/ed:mukurweini/ward:mukurwe_ini_central,Mukurwe-Ini Central
+ocd-division/country:ke/county:ke-19/ed:nyeri_town/ward:kiganjo_mathari,Kiganjo-Mathari
+ocd-division/country:ke/county:ke-19/ed:nyeri_town/ward:rware,Rware
+ocd-division/country:ke/county:ke-19/ed:nyeri_town/ward:gatitu_muruguru,Gatitu-Muruguru
+ocd-division/country:ke/county:ke-19/ed:nyeri_town/ward:ruingu,Ruing’u
+ocd-division/country:ke/county:ke-19/ed:nyeri_town/ward:kamakwa_mukaro,Kamakwa-Mukaro
+ocd-division/country:ke/county:ke-20/ed:mwea/ward:mutithi,Mutithi
+ocd-division/country:ke/county:ke-20/ed:mwea/ward:kangai,Kangai
+ocd-division/country:ke/county:ke-20/ed:mwea/ward:thiba,Thiba
+ocd-division/country:ke/county:ke-20/ed:mwea/ward:wamumu,Wamumu
+ocd-division/country:ke/county:ke-20/ed:mwea/ward:nyangati,Nyangati
+ocd-division/country:ke/county:ke-20/ed:mwea/ward:murinduko,Murinduko
+ocd-division/country:ke/county:ke-20/ed:mwea/ward:gathigiriri,Gathigiriri
+ocd-division/country:ke/county:ke-20/ed:mwea/ward:tebere,Tebere
+ocd-division/country:ke/county:ke-20/ed:gichugu/ward:kabare,Kabare
+ocd-division/country:ke/county:ke-20/ed:gichugu/ward:baragwi,Baragwi
+ocd-division/country:ke/county:ke-20/ed:gichugu/ward:njukiini,Njukiini
+ocd-division/country:ke/county:ke-20/ed:gichugu/ward:ngariama,Ngariama
+ocd-division/country:ke/county:ke-20/ed:gichugu/ward:karumandi,Karumandi
+ocd-division/country:ke/county:ke-20/ed:ndia/ward:mukure,Mukure
+ocd-division/country:ke/county:ke-20/ed:ndia/ward:kiine,Kiine
+ocd-division/country:ke/county:ke-20/ed:ndia/ward:kariti,Kariti
+ocd-division/country:ke/county:ke-20/ed:kirinyaga_central/ward:mutira,Mutira
+ocd-division/country:ke/county:ke-20/ed:kirinyaga_central/ward:kanyekini,Kanyekini
+ocd-division/country:ke/county:ke-20/ed:kirinyaga_central/ward:kerugoya,Kerugoya
+ocd-division/country:ke/county:ke-20/ed:kirinyaga_central/ward:inoi,Inoi
+ocd-division/country:ke/county:ke-21/ed:kangema/ward:kanyenya_ini,Kanyenya-Ini
+ocd-division/country:ke/county:ke-21/ed:kangema/ward:muguru,Muguru
+ocd-division/country:ke/county:ke-21/ed:kangema/ward:rwathia,Rwathia
+ocd-division/country:ke/county:ke-21/ed:mathioya/ward:gitugi,Gitugi
+ocd-division/country:ke/county:ke-21/ed:mathioya/ward:kiru,Kiru
+ocd-division/country:ke/county:ke-21/ed:mathioya/ward:kamacharia,Kamacharia
+ocd-division/country:ke/county:ke-21/ed:kiharu/ward:wangu,Wangu
+ocd-division/country:ke/county:ke-21/ed:kiharu/ward:mugoiri,Mugoiri
+ocd-division/country:ke/county:ke-21/ed:kiharu/ward:mbiri,Mbiri
+ocd-division/country:ke/county:ke-21/ed:kiharu/ward:township,Township
+ocd-division/country:ke/county:ke-21/ed:kiharu/ward:murarandia,Murarandia
+ocd-division/country:ke/county:ke-21/ed:kiharu/ward:gaturi,Gaturi
+ocd-division/country:ke/county:ke-21/ed:kigumo/ward:kahumbu,Kahumbu
+ocd-division/country:ke/county:ke-21/ed:kigumo/ward:muthithi,Muthithi
+ocd-division/country:ke/county:ke-21/ed:kigumo/ward:kigumo,Kigumo
+ocd-division/country:ke/county:ke-21/ed:kigumo/ward:kangari,Kangari
+ocd-division/country:ke/county:ke-21/ed:kigumo/ward:kinyona,Kinyona
+ocd-division/country:ke/county:ke-21/ed:maragwa/ward:kimorori_wempa,Kimorori-Wempa
+ocd-division/country:ke/county:ke-21/ed:maragwa/ward:makuyu,Makuyu
+ocd-division/country:ke/county:ke-21/ed:maragwa/ward:kambiti,Kambiti
+ocd-division/country:ke/county:ke-21/ed:maragwa/ward:kamahuha,Kamahuha
+ocd-division/country:ke/county:ke-21/ed:maragwa/ward:ichagaki,Ichagaki
+ocd-division/country:ke/county:ke-21/ed:maragwa/ward:nginda,Nginda
+ocd-division/country:ke/county:ke-21/ed:kandara/ward:ngararia,Ng’araria
+ocd-division/country:ke/county:ke-21/ed:kandara/ward:muruka,Muruka
+ocd-division/country:ke/county:ke-21/ed:kandara/ward:kagundu_ini,Kagundu-Ini
+ocd-division/country:ke/county:ke-21/ed:kandara/ward:gaichanjiru,Gaichanjiru
+ocd-division/country:ke/county:ke-21/ed:kandara/ward:ithiru,Ithiru
+ocd-division/country:ke/county:ke-21/ed:kandara/ward:ruchu,Ruchu
+ocd-division/country:ke/county:ke-21/ed:gatanga/ward:ithanga,Ithanga
+ocd-division/country:ke/county:ke-21/ed:gatanga/ward:kakuzi_mitubiri,Kakuzi-Mitubiri
+ocd-division/country:ke/county:ke-21/ed:gatanga/ward:mugumo_ini,Mugumo-Ini
+ocd-division/country:ke/county:ke-21/ed:gatanga/ward:kihumbu_ini,Kihumbu-Ini
+ocd-division/country:ke/county:ke-21/ed:gatanga/ward:gatanga,Gatanga
+ocd-division/country:ke/county:ke-21/ed:gatanga/ward:kariara,Kariara
+ocd-division/country:ke/county:ke-22/ed:gatundu_south/ward:kiamwangi,Kiamwangi
+ocd-division/country:ke/county:ke-22/ed:gatundu_south/ward:kiganjo,Kiganjo
+ocd-division/country:ke/county:ke-22/ed:gatundu_south/ward:ndarugu,Ndarugu
+ocd-division/country:ke/county:ke-22/ed:gatundu_south/ward:ngenda,Ngenda
+ocd-division/country:ke/county:ke-22/ed:gatundu_north/ward:gituamba,Gituamba
+ocd-division/country:ke/county:ke-22/ed:gatundu_north/ward:githobokoni,Githobokoni
+ocd-division/country:ke/county:ke-22/ed:gatundu_north/ward:chania,Chania
+ocd-division/country:ke/county:ke-22/ed:gatundu_north/ward:mangu,Mang’u
+ocd-division/country:ke/county:ke-22/ed:juja/ward:murera,Murera
+ocd-division/country:ke/county:ke-22/ed:juja/ward:theta,Theta
+ocd-division/country:ke/county:ke-22/ed:juja/ward:juja,Juja
+ocd-division/country:ke/county:ke-22/ed:juja/ward:witeithie,Witeithie
+ocd-division/country:ke/county:ke-22/ed:juja/ward:kalimoni,Kalimoni
+ocd-division/country:ke/county:ke-22/ed:thika_town/ward:township,Township
+ocd-division/country:ke/county:ke-22/ed:thika_town/ward:kamenu,Kamenu
+ocd-division/country:ke/county:ke-22/ed:thika_town/ward:hospital,Hospital
+ocd-division/country:ke/county:ke-22/ed:thika_town/ward:gatuanyaga,Gatuanyaga
+ocd-division/country:ke/county:ke-22/ed:thika_town/ward:ngoliba,Ngoliba
+ocd-division/country:ke/county:ke-22/ed:ruiru/ward:gitothua,Gitothua
+ocd-division/country:ke/county:ke-22/ed:ruiru/ward:biashara,Biashara
+ocd-division/country:ke/county:ke-22/ed:ruiru/ward:gatongora,Gatongora
+ocd-division/country:ke/county:ke-22/ed:ruiru/ward:kahawa_sukari,Kahawa Sukari
+ocd-division/country:ke/county:ke-22/ed:ruiru/ward:kahawa_wendani,Kahawa Wendani
+ocd-division/country:ke/county:ke-22/ed:ruiru/ward:kiuu,Kiuu
+ocd-division/country:ke/county:ke-22/ed:ruiru/ward:mwiki,Mwiki
+ocd-division/country:ke/county:ke-22/ed:ruiru/ward:mwihoko,Mwihoko
+ocd-division/country:ke/county:ke-22/ed:githunguri/ward:githunguri,Githunguri
+ocd-division/country:ke/county:ke-22/ed:githunguri/ward:githiga,Githiga
+ocd-division/country:ke/county:ke-22/ed:githunguri/ward:ikinu,Ikinu
+ocd-division/country:ke/county:ke-22/ed:githunguri/ward:ngewa,Ngewa
+ocd-division/country:ke/county:ke-22/ed:githunguri/ward:komothai,Komothai
+ocd-division/country:ke/county:ke-22/ed:kiambu/ward:tinganga,Ting’ang’a
+ocd-division/country:ke/county:ke-22/ed:kiambu/ward:ndumberi,Ndumberi
+ocd-division/country:ke/county:ke-22/ed:kiambu/ward:riabai,Riabai
+ocd-division/country:ke/county:ke-22/ed:kiambu/ward:township,Township
+ocd-division/country:ke/county:ke-22/ed:kiambaa/ward:cianda,Cianda
+ocd-division/country:ke/county:ke-22/ed:kiambaa/ward:karuri,Karuri
+ocd-division/country:ke/county:ke-22/ed:kiambaa/ward:ndenderu,Ndenderu
+ocd-division/country:ke/county:ke-22/ed:kiambaa/ward:muchatha,Muchatha
+ocd-division/country:ke/county:ke-22/ed:kiambaa/ward:kihara,Kihara
+ocd-division/country:ke/county:ke-22/ed:kabete/ward:gitaru,Gitaru
+ocd-division/country:ke/county:ke-22/ed:kabete/ward:muguga,Muguga
+ocd-division/country:ke/county:ke-22/ed:kabete/ward:nyadhuna,Nyadhuna
+ocd-division/country:ke/county:ke-22/ed:kabete/ward:kabete,Kabete
+ocd-division/country:ke/county:ke-22/ed:kabete/ward:uthiru,Uthiru
+ocd-division/country:ke/county:ke-22/ed:kikuyu/ward:karai,Karai
+ocd-division/country:ke/county:ke-22/ed:kikuyu/ward:nachu,Nachu
+ocd-division/country:ke/county:ke-22/ed:kikuyu/ward:sigona,Sigona
+ocd-division/country:ke/county:ke-22/ed:kikuyu/ward:kikuyu,Kikuyu
+ocd-division/country:ke/county:ke-22/ed:kikuyu/ward:kinoo,Kinoo
+ocd-division/country:ke/county:ke-22/ed:limuru/ward:bibirioni,Bibirioni
+ocd-division/country:ke/county:ke-22/ed:limuru/ward:limuru_central,Limuru Central
+ocd-division/country:ke/county:ke-22/ed:limuru/ward:ndeiya,Ndeiya
+ocd-division/country:ke/county:ke-22/ed:limuru/ward:limuru_east,Limuru East
+ocd-division/country:ke/county:ke-22/ed:limuru/ward:ngecha_tigoni,Ngecha Tigoni
+ocd-division/country:ke/county:ke-22/ed:lari/ward:kinale,Kinale
+ocd-division/country:ke/county:ke-22/ed:lari/ward:kijabe,Kijabe
+ocd-division/country:ke/county:ke-22/ed:lari/ward:nyanduma,Nyanduma
+ocd-division/country:ke/county:ke-22/ed:lari/ward:kamburu,Kamburu
+ocd-division/country:ke/county:ke-22/ed:lari/ward:lari_kirenga,Lari-Kirenga
+ocd-division/country:ke/county:ke-23/ed:turkana_north/ward:kaeris,Kaeris
+ocd-division/country:ke/county:ke-23/ed:turkana_north/ward:lake_zone,Lake Zone
+ocd-division/country:ke/county:ke-23/ed:turkana_north/ward:lapur,Lapur
+ocd-division/country:ke/county:ke-23/ed:turkana_north/ward:kaaleng_kaikor,Kaaleng-Kaikor
+ocd-division/country:ke/county:ke-23/ed:turkana_north/ward:kibish,Kibish
+ocd-division/country:ke/county:ke-23/ed:turkana_north/ward:nakalale,Nakalale
+ocd-division/country:ke/county:ke-23/ed:turkana_west/ward:kakuma,Kakuma
+ocd-division/country:ke/county:ke-23/ed:turkana_west/ward:lopur,Lopur
+ocd-division/country:ke/county:ke-23/ed:turkana_west/ward:letea,Letea
+ocd-division/country:ke/county:ke-23/ed:turkana_west/ward:songot,Songot
+ocd-division/country:ke/county:ke-23/ed:turkana_west/ward:kalobeyei,Kalobeyei
+ocd-division/country:ke/county:ke-23/ed:turkana_west/ward:lokichoggio,Lokichoggio
+ocd-division/country:ke/county:ke-23/ed:turkana_west/ward:nanaam,Nanaam
+ocd-division/country:ke/county:ke-23/ed:turkana_central/ward:kerio_delta,Kerio Delta
+ocd-division/country:ke/county:ke-23/ed:turkana_central/ward:kangatotha,Kangatotha
+ocd-division/country:ke/county:ke-23/ed:turkana_central/ward:kalokol,Kalokol
+ocd-division/country:ke/county:ke-23/ed:turkana_central/ward:lodwar_township,Lodwar Township
+ocd-division/country:ke/county:ke-23/ed:turkana_central/ward:kanamkemer,Kanamkemer
+ocd-division/country:ke/county:ke-23/ed:loima/ward:kotaruk_lobei,Kotaruk-Lobei
+ocd-division/country:ke/county:ke-23/ed:loima/ward:turkwel,Turkwel
+ocd-division/country:ke/county:ke-23/ed:loima/ward:loima,Loima
+ocd-division/country:ke/county:ke-23/ed:loima/ward:lokiriama_lorengippi,Lokiriama-Lorengippi
+ocd-division/country:ke/county:ke-23/ed:turkana_south/ward:kaputir,Kaputir
+ocd-division/country:ke/county:ke-23/ed:turkana_south/ward:katilu,Katilu
+ocd-division/country:ke/county:ke-23/ed:turkana_south/ward:lobokat,Lobokat
+ocd-division/country:ke/county:ke-23/ed:turkana_south/ward:kalapata,Kalapata
+ocd-division/country:ke/county:ke-23/ed:turkana_south/ward:lokichar,Lokichar
+ocd-division/country:ke/county:ke-23/ed:turkana_east/ward:kapedo_napeitom,Kapedo-Napeitom
+ocd-division/country:ke/county:ke-23/ed:turkana_east/ward:katilia,Katilia
+ocd-division/country:ke/county:ke-23/ed:turkana_east/ward:lokori_kochodin,Lokori-Kochodin
+ocd-division/country:ke/county:ke-24/ed:kapenguria/ward:riwo,Riwo
+ocd-division/country:ke/county:ke-24/ed:kapenguria/ward:kapenguria,Kapenguria
+ocd-division/country:ke/county:ke-24/ed:kapenguria/ward:mnagei,Mnagei
+ocd-division/country:ke/county:ke-24/ed:kapenguria/ward:siyoi,Siyoi
+ocd-division/country:ke/county:ke-24/ed:kapenguria/ward:endugh,Endugh
+ocd-division/country:ke/county:ke-24/ed:kapenguria/ward:sook,Sook
+ocd-division/country:ke/county:ke-24/ed:sigor/ward:sekerr,Sekerr
+ocd-division/country:ke/county:ke-24/ed:sigor/ward:masool,Masool
+ocd-division/country:ke/county:ke-24/ed:sigor/ward:lomut,Lomut
+ocd-division/country:ke/county:ke-24/ed:sigor/ward:weiwei,Weiwei
+ocd-division/country:ke/county:ke-24/ed:kacheliba/ward:suam,Suam
+ocd-division/country:ke/county:ke-24/ed:kacheliba/ward:kodich,Kodich
+ocd-division/country:ke/county:ke-24/ed:kacheliba/ward:kasei,Kasei
+ocd-division/country:ke/county:ke-24/ed:kacheliba/ward:kapchok,Kapchok
+ocd-division/country:ke/county:ke-24/ed:kacheliba/ward:kiwawa,Kiwawa
+ocd-division/country:ke/county:ke-24/ed:kacheliba/ward:alale,Alale
+ocd-division/country:ke/county:ke-24/ed:pokot_south/ward:chepareria,Chepareria
+ocd-division/country:ke/county:ke-24/ed:pokot_south/ward:batei,Batei
+ocd-division/country:ke/county:ke-24/ed:pokot_south/ward:lelan,Lelan
+ocd-division/country:ke/county:ke-24/ed:pokot_south/ward:tapach,Tapach
+ocd-division/country:ke/county:ke-25/ed:samburu_west/ward:lodokejek,Lodokejek
+ocd-division/country:ke/county:ke-25/ed:samburu_west/ward:suguta_marmar,Suguta Marmar
+ocd-division/country:ke/county:ke-25/ed:samburu_west/ward:maralal,Maralal
+ocd-division/country:ke/county:ke-25/ed:samburu_west/ward:loosuk,Loosuk
+ocd-division/country:ke/county:ke-25/ed:samburu_west/ward:poro,Poro
+ocd-division/country:ke/county:ke-25/ed:samburu_north/ward:el_barta,El-Barta
+ocd-division/country:ke/county:ke-25/ed:samburu_north/ward:nachola,Nachola
+ocd-division/country:ke/county:ke-25/ed:samburu_north/ward:ndoto,Ndoto
+ocd-division/country:ke/county:ke-25/ed:samburu_north/ward:nyiro,Nyiro
+ocd-division/country:ke/county:ke-25/ed:samburu_north/ward:angata_nanyokie,Angata Nanyokie
+ocd-division/country:ke/county:ke-25/ed:samburu_north/ward:baawa,Baawa
+ocd-division/country:ke/county:ke-25/ed:samburu_east/ward:waso,Waso
+ocd-division/country:ke/county:ke-25/ed:samburu_east/ward:wamba_west,Wamba West
+ocd-division/country:ke/county:ke-25/ed:samburu_east/ward:wamba_east,Wamba East
+ocd-division/country:ke/county:ke-25/ed:samburu_east/ward:wamba_north,Wamba North
+ocd-division/country:ke/county:ke-26/ed:kwanza/ward:kapomboi,Kapomboi
+ocd-division/country:ke/county:ke-26/ed:kwanza/ward:kwanza,Kwanza
+ocd-division/country:ke/county:ke-26/ed:kwanza/ward:keiyo,Keiyo
+ocd-division/country:ke/county:ke-26/ed:kwanza/ward:bidii,Bidii
+ocd-division/country:ke/county:ke-26/ed:endebess/ward:chepchoina,Chepchoina
+ocd-division/country:ke/county:ke-26/ed:endebess/ward:endebess,Endebess
+ocd-division/country:ke/county:ke-26/ed:endebess/ward:matumbei,Matumbei
+ocd-division/country:ke/county:ke-26/ed:saboti/ward:kinyoro,Kinyoro
+ocd-division/country:ke/county:ke-26/ed:saboti/ward:matisi,Matisi
+ocd-division/country:ke/county:ke-26/ed:saboti/ward:tuwani,Tuwani
+ocd-division/country:ke/county:ke-26/ed:saboti/ward:saboti,Saboti
+ocd-division/country:ke/county:ke-26/ed:saboti/ward:machewa,Machewa
+ocd-division/country:ke/county:ke-26/ed:kiminini/ward:kiminini,Kiminini
+ocd-division/country:ke/county:ke-26/ed:kiminini/ward:waitaluk,Waitaluk
+ocd-division/country:ke/county:ke-26/ed:kiminini/ward:sirende,Sirende
+ocd-division/country:ke/county:ke-26/ed:kiminini/ward:hospital,Hospital
+ocd-division/country:ke/county:ke-26/ed:kiminini/ward:sikhendu,Sikhendu
+ocd-division/country:ke/county:ke-26/ed:kiminini/ward:nabiswa,Nabiswa
+ocd-division/country:ke/county:ke-26/ed:cherangany/ward:sinyerere,Sinyerere
+ocd-division/country:ke/county:ke-26/ed:cherangany/ward:makutano,Makutano
+ocd-division/country:ke/county:ke-26/ed:cherangany/ward:kaplamai,Kaplamai
+ocd-division/country:ke/county:ke-26/ed:cherangany/ward:motosiet,Motosiet
+ocd-division/country:ke/county:ke-26/ed:cherangany/ward:cherangany_suwerwa,Cherangany-Suwerwa
+ocd-division/country:ke/county:ke-26/ed:cherangany/ward:chepsiro_kiptoror,Chepsiro-Kiptoror
+ocd-division/country:ke/county:ke-26/ed:cherangany/ward:sitatunga,Sitatunga
+ocd-division/country:ke/county:ke-27/ed:soy/ward:mois_bridge,Moi’s Bridge
+ocd-division/country:ke/county:ke-27/ed:soy/ward:kapkures,Kapkures
+ocd-division/country:ke/county:ke-27/ed:soy/ward:ziwa,Ziwa
+ocd-division/country:ke/county:ke-27/ed:soy/ward:segero_barsombe,Segero-Barsombe
+ocd-division/country:ke/county:ke-27/ed:soy/ward:kipsomba,Kipsomba
+ocd-division/country:ke/county:ke-27/ed:soy/ward:soy,Soy
+ocd-division/country:ke/county:ke-27/ed:soy/ward:kuinet_kapsuswa,Kuinet-Kapsuswa
+ocd-division/country:ke/county:ke-27/ed:turbo/ward:ngenyilel,Ngenyilel
+ocd-division/country:ke/county:ke-27/ed:turbo/ward:tapsagoi,Tapsagoi
+ocd-division/country:ke/county:ke-27/ed:turbo/ward:kamagut,Kamagut
+ocd-division/country:ke/county:ke-27/ed:turbo/ward:kiplombe,Kiplombe
+ocd-division/country:ke/county:ke-27/ed:turbo/ward:kapsaos,Kapsaos
+ocd-division/country:ke/county:ke-27/ed:turbo/ward:huruma,Huruma
+ocd-division/country:ke/county:ke-27/ed:moiben/ward:tembelio,Tembelio
+ocd-division/country:ke/county:ke-27/ed:moiben/ward:sergoit,Sergoit
+ocd-division/country:ke/county:ke-27/ed:moiben/ward:karuna_meibeki,Karuna-Meibeki
+ocd-division/country:ke/county:ke-27/ed:moiben/ward:moiben,Moiben
+ocd-division/country:ke/county:ke-27/ed:moiben/ward:kimumu,Kimumu
+ocd-division/country:ke/county:ke-27/ed:ainabkoi/ward:kapsoya,Kapsoya
+ocd-division/country:ke/county:ke-27/ed:ainabkoi/ward:kaptagat,Kaptagat
+ocd-division/country:ke/county:ke-27/ed:ainabkoi/ward:ainabkoi_olare,Ainabkoi-Olare
+ocd-division/country:ke/county:ke-27/ed:kapseret/ward:simat_kapseret,Simat-Kapseret
+ocd-division/country:ke/county:ke-27/ed:kapseret/ward:kipkenyo,Kipkenyo
+ocd-division/country:ke/county:ke-27/ed:kapseret/ward:ngeria,Ngeria
+ocd-division/country:ke/county:ke-27/ed:kapseret/ward:megun,Megun
+ocd-division/country:ke/county:ke-27/ed:kapseret/ward:langas,Langas
+ocd-division/country:ke/county:ke-27/ed:kesses/ward:racecourse,Racecourse
+ocd-division/country:ke/county:ke-27/ed:kesses/ward:cheptiret_kipchamo,Cheptiret-Kipchamo
+ocd-division/country:ke/county:ke-27/ed:kesses/ward:tulwet_chuiyat,Tulwet-Chuiyat
+ocd-division/country:ke/county:ke-27/ed:kesses/ward:tarakwa,Tarakwa
+ocd-division/country:ke/county:ke-28/ed:marakwet_east/ward:kapyego,Kapyego
+ocd-division/country:ke/county:ke-28/ed:marakwet_east/ward:sambirir,Sambirir
+ocd-division/country:ke/county:ke-28/ed:marakwet_east/ward:endo,Endo
+ocd-division/country:ke/county:ke-28/ed:marakwet_east/ward:embobut_embulot,Embobut - Embulot
+ocd-division/country:ke/county:ke-28/ed:marakwet_west/ward:lelan,Lelan
+ocd-division/country:ke/county:ke-28/ed:marakwet_west/ward:sengwer,Sengwer
+ocd-division/country:ke/county:ke-28/ed:marakwet_west/ward:cherangany_chebororwa,Cherang’any-Chebororwa
+ocd-division/country:ke/county:ke-28/ed:marakwet_west/ward:moiben_kuserwo,Moiben-Kuserwo
+ocd-division/country:ke/county:ke-28/ed:marakwet_west/ward:kapsowar,Kapsowar
+ocd-division/country:ke/county:ke-28/ed:marakwet_west/ward:arror,Arror
+ocd-division/country:ke/county:ke-28/ed:keiyo_north/ward:emsoo,Emsoo
+ocd-division/country:ke/county:ke-28/ed:keiyo_north/ward:kamariny,Kamariny
+ocd-division/country:ke/county:ke-28/ed:keiyo_north/ward:kapchemutwa,Kapchemutwa
+ocd-division/country:ke/county:ke-28/ed:keiyo_north/ward:tambach,Tambach
+ocd-division/country:ke/county:ke-28/ed:keiyo_south/ward:kaptarakwa,Kaptarakwa
+ocd-division/country:ke/county:ke-28/ed:keiyo_south/ward:chepkorio,Chepkorio
+ocd-division/country:ke/county:ke-28/ed:keiyo_south/ward:soy_north,Soy North
+ocd-division/country:ke/county:ke-28/ed:keiyo_south/ward:soy_south,Soy South
+ocd-division/country:ke/county:ke-28/ed:keiyo_south/ward:kabiemit,Kabiemit
+ocd-division/country:ke/county:ke-28/ed:keiyo_south/ward:metkei,Metkei
+ocd-division/country:ke/county:ke-29/ed:tinderet/ward:songhor_soba,Songhor-Soba
+ocd-division/country:ke/county:ke-29/ed:tinderet/ward:tindiret,Tindiret
+ocd-division/country:ke/county:ke-29/ed:tinderet/ward:chemelil_chemase,Chemelil-Chemase
+ocd-division/country:ke/county:ke-29/ed:tinderet/ward:kapsimotwo,Kapsimotwo
+ocd-division/country:ke/county:ke-29/ed:aldai/ward:kabwareng,Kabwareng
+ocd-division/country:ke/county:ke-29/ed:aldai/ward:terik,Terik
+ocd-division/country:ke/county:ke-29/ed:aldai/ward:kemeloi_maraba,Kemeloi-Maraba
+ocd-division/country:ke/county:ke-29/ed:aldai/ward:kobujoi,Kobujoi
+ocd-division/country:ke/county:ke-29/ed:aldai/ward:kaptumo_kaboi,Kaptumo-Kaboi
+ocd-division/country:ke/county:ke-29/ed:aldai/ward:koyo_ndurio,Koyo-Ndurio
+ocd-division/country:ke/county:ke-29/ed:nandi_hills/ward:nandi_hills,Nandi Hills
+ocd-division/country:ke/county:ke-29/ed:nandi_hills/ward:chepkunyuk,Chepkunyuk
+ocd-division/country:ke/county:ke-29/ed:nandi_hills/ward:ollessos,Ol’lessos
+ocd-division/country:ke/county:ke-29/ed:nandi_hills/ward:kapchorua,Kapchorua
+ocd-division/country:ke/county:ke-29/ed:chesumei/ward:chemundu_kapngetuny,Chemundu-Kapng’etuny
+ocd-division/country:ke/county:ke-29/ed:chesumei/ward:kosirai,Kosirai
+ocd-division/country:ke/county:ke-29/ed:chesumei/ward:lelmokwo_ngechek,Lelmokwo-Ngechek
+ocd-division/country:ke/county:ke-29/ed:chesumei/ward:kaptel_kamoiywo,Kaptel-Kamoiywo
+ocd-division/country:ke/county:ke-29/ed:chesumei/ward:kiptuya,Kiptuya
+ocd-division/country:ke/county:ke-29/ed:emgwen/ward:chepkumia,Chepkumia
+ocd-division/country:ke/county:ke-29/ed:emgwen/ward:kapkangani,Kapkangani
+ocd-division/country:ke/county:ke-29/ed:emgwen/ward:kapsabet,Kapsabet
+ocd-division/country:ke/county:ke-29/ed:emgwen/ward:kilibwoni,Kilibwoni
+ocd-division/country:ke/county:ke-29/ed:mosop/ward:chepterwai,Chepterwai
+ocd-division/country:ke/county:ke-29/ed:mosop/ward:kipkaren,Kipkaren
+ocd-division/country:ke/county:ke-29/ed:mosop/ward:kurgung_surungai,Kurgung-Surungai
+ocd-division/country:ke/county:ke-29/ed:mosop/ward:kabiyet,Kabiyet
+ocd-division/country:ke/county:ke-29/ed:mosop/ward:ndalat,Ndalat
+ocd-division/country:ke/county:ke-29/ed:mosop/ward:kabisaga,Kabisaga
+ocd-division/country:ke/county:ke-29/ed:mosop/ward:sangalo_kebulonik,Sangalo-Kebulonik
+ocd-division/country:ke/county:ke-30/ed:tiaty/ward:tirioko,Tirioko
+ocd-division/country:ke/county:ke-30/ed:tiaty/ward:kolowa,Kolowa
+ocd-division/country:ke/county:ke-30/ed:tiaty/ward:ribkwo,Ribkwo
+ocd-division/country:ke/county:ke-30/ed:tiaty/ward:silale,Silale
+ocd-division/country:ke/county:ke-30/ed:tiaty/ward:loiyamorock,Loiyamorock
+ocd-division/country:ke/county:ke-30/ed:tiaty/ward:tangulbei_korossi,Tangulbei-Korossi
+ocd-division/country:ke/county:ke-30/ed:tiaty/ward:churo_amaya,Churo-Amaya
+ocd-division/country:ke/county:ke-30/ed:baringo_north/ward:barwessa,Barwessa
+ocd-division/country:ke/county:ke-30/ed:baringo_north/ward:kabartonjo,Kabartonjo
+ocd-division/country:ke/county:ke-30/ed:baringo_north/ward:saimo_kipsaraman,Saimo-Kipsaraman
+ocd-division/country:ke/county:ke-30/ed:baringo_north/ward:saimo_soi,Saimo-Soi
+ocd-division/country:ke/county:ke-30/ed:baringo_north/ward:bartabwa,Bartabwa
+ocd-division/country:ke/county:ke-30/ed:baringo_central/ward:kabarnet,Kabarnet
+ocd-division/country:ke/county:ke-30/ed:baringo_central/ward:sacho,Sacho
+ocd-division/country:ke/county:ke-30/ed:baringo_central/ward:tenges,Tenges
+ocd-division/country:ke/county:ke-30/ed:baringo_central/ward:ewalel_chapchap,Ewalel-Chapchap
+ocd-division/country:ke/county:ke-30/ed:baringo_central/ward:kapropita,Kapropita
+ocd-division/country:ke/county:ke-30/ed:baringo_south/ward:marigat,Marigat
+ocd-division/country:ke/county:ke-30/ed:baringo_south/ward:ilchamus,Ilchamus
+ocd-division/country:ke/county:ke-30/ed:baringo_south/ward:mochongoi,Mochongoi
+ocd-division/country:ke/county:ke-30/ed:baringo_south/ward:mukutani,Mukutani
+ocd-division/country:ke/county:ke-30/ed:mogotio/ward:mogotio,Mogotio
+ocd-division/country:ke/county:ke-30/ed:mogotio/ward:emining,Emining
+ocd-division/country:ke/county:ke-30/ed:mogotio/ward:kisanana,Kisanana
+ocd-division/country:ke/county:ke-30/ed:eldama_ravine/ward:lembus,Lembus
+ocd-division/country:ke/county:ke-30/ed:eldama_ravine/ward:lembus_kwen,Lembus Kwen
+ocd-division/country:ke/county:ke-30/ed:eldama_ravine/ward:ravine,Ravine
+ocd-division/country:ke/county:ke-30/ed:eldama_ravine/ward:mumberes_maji_mazuri,Mumberes-Maji Mazuri
+ocd-division/country:ke/county:ke-30/ed:eldama_ravine/ward:lembus_perkerra,Lembus-Perkerra
+ocd-division/country:ke/county:ke-30/ed:eldama_ravine/ward:koibatek,Koibatek
+ocd-division/country:ke/county:ke-31/ed:laikipia_west/ward:ol_moran,Ol-Moran
+ocd-division/country:ke/county:ke-31/ed:laikipia_west/ward:rumuruti_township,Rumuruti Township
+ocd-division/country:ke/county:ke-31/ed:laikipia_west/ward:githiga,Githiga
+ocd-division/country:ke/county:ke-31/ed:laikipia_west/ward:marmanet,Marmanet
+ocd-division/country:ke/county:ke-31/ed:laikipia_west/ward:igwamiti,Igwamiti
+ocd-division/country:ke/county:ke-31/ed:laikipia_west/ward:salama,Salama
+ocd-division/country:ke/county:ke-31/ed:laikipia_east/ward:ngobit,Ngobit
+ocd-division/country:ke/county:ke-31/ed:laikipia_east/ward:tigithi,Tigithi
+ocd-division/country:ke/county:ke-31/ed:laikipia_east/ward:thingithu,Thingithu
+ocd-division/country:ke/county:ke-31/ed:laikipia_east/ward:nanyuki,Nanyuki
+ocd-division/country:ke/county:ke-31/ed:laikipia_east/ward:umande,Umande
+ocd-division/country:ke/county:ke-31/ed:laikipia_north/ward:sosian,Sosian
+ocd-division/country:ke/county:ke-31/ed:laikipia_north/ward:segera,Segera
+ocd-division/country:ke/county:ke-31/ed:laikipia_north/ward:mugogodo_west,Mugogodo West
+ocd-division/country:ke/county:ke-31/ed:laikipia_north/ward:mugogodo_east,Mugogodo East
+ocd-division/country:ke/county:ke-32/ed:molo/ward:mariashoni,Mariashoni
+ocd-division/country:ke/county:ke-32/ed:molo/ward:elburgon,Elburgon
+ocd-division/country:ke/county:ke-32/ed:molo/ward:turi,Turi
+ocd-division/country:ke/county:ke-32/ed:molo/ward:molo,Molo
+ocd-division/country:ke/county:ke-32/ed:njoro/ward:mau_narok,Mau Narok
+ocd-division/country:ke/county:ke-32/ed:njoro/ward:mauche,Mauche
+ocd-division/country:ke/county:ke-32/ed:njoro/ward:kihingo,Kihingo
+ocd-division/country:ke/county:ke-32/ed:njoro/ward:nessuit,Nessuit
+ocd-division/country:ke/county:ke-32/ed:njoro/ward:lare,Lare
+ocd-division/country:ke/county:ke-32/ed:njoro/ward:njoro,Njoro
+ocd-division/country:ke/county:ke-32/ed:naivasha/ward:biashara,Biashara
+ocd-division/country:ke/county:ke-32/ed:naivasha/ward:hells_gate,Hells Gate
+ocd-division/country:ke/county:ke-32/ed:naivasha/ward:lake_view,Lake View
+ocd-division/country:ke/county:ke-32/ed:naivasha/ward:mai_mahiu,Mai Mahiu
+ocd-division/country:ke/county:ke-32/ed:naivasha/ward:maiella,Maiella
+ocd-division/country:ke/county:ke-32/ed:naivasha/ward:olkaria,Olkaria
+ocd-division/country:ke/county:ke-32/ed:naivasha/ward:naivasha_east,Naivasha East
+ocd-division/country:ke/county:ke-32/ed:naivasha/ward:viwandani,Viwandani
+ocd-division/country:ke/county:ke-32/ed:gilgil/ward:gilgil,Gilgil
+ocd-division/country:ke/county:ke-32/ed:gilgil/ward:elementaita,Elementaita
+ocd-division/country:ke/county:ke-32/ed:gilgil/ward:mbaruk_eburu,Mbaruk-Eburu
+ocd-division/country:ke/county:ke-32/ed:gilgil/ward:malewa_west,Malewa West
+ocd-division/country:ke/county:ke-32/ed:gilgil/ward:murindati,Murindati
+ocd-division/country:ke/county:ke-32/ed:kuresoi_south/ward:amalo,Amalo
+ocd-division/country:ke/county:ke-32/ed:kuresoi_south/ward:keringet,Keringet
+ocd-division/country:ke/county:ke-32/ed:kuresoi_south/ward:kiptagich,Kiptagich
+ocd-division/country:ke/county:ke-32/ed:kuresoi_south/ward:tinet,Tinet
+ocd-division/country:ke/county:ke-32/ed:kuresoi_north/ward:kiptororo,Kiptororo
+ocd-division/country:ke/county:ke-32/ed:kuresoi_north/ward:nyota,Nyota
+ocd-division/country:ke/county:ke-32/ed:kuresoi_north/ward:sirikwa,Sirikwa
+ocd-division/country:ke/county:ke-32/ed:kuresoi_north/ward:kamara,Kamara
+ocd-division/country:ke/county:ke-32/ed:subukia/ward:subukia,Subukia
+ocd-division/country:ke/county:ke-32/ed:subukia/ward:waseges,Waseges
+ocd-division/country:ke/county:ke-32/ed:subukia/ward:kabazi,Kabazi
+ocd-division/country:ke/county:ke-32/ed:rongai/ward:menengai_west,Menengai West
+ocd-division/country:ke/county:ke-32/ed:rongai/ward:soin,Soin
+ocd-division/country:ke/county:ke-32/ed:rongai/ward:visoi,Visoi
+ocd-division/country:ke/county:ke-32/ed:rongai/ward:mosop,Mosop
+ocd-division/country:ke/county:ke-32/ed:rongai/ward:solai,Solai
+ocd-division/country:ke/county:ke-32/ed:bahati/ward:dundori,Dundori
+ocd-division/country:ke/county:ke-32/ed:bahati/ward:kabatini,Kabatini
+ocd-division/country:ke/county:ke-32/ed:bahati/ward:kiamaina,Kiamaina
+ocd-division/country:ke/county:ke-32/ed:bahati/ward:lanet_umoja,Lanet-Umoja
+ocd-division/country:ke/county:ke-32/ed:bahati/ward:bahati,Bahati
+ocd-division/country:ke/county:ke-32/ed:nakuru_town_west/ward:barut,Barut
+ocd-division/country:ke/county:ke-32/ed:nakuru_town_west/ward:london,London
+ocd-division/country:ke/county:ke-32/ed:nakuru_town_west/ward:kaptembwo,Kaptembwo
+ocd-division/country:ke/county:ke-32/ed:nakuru_town_west/ward:kapkures,Kapkures
+ocd-division/country:ke/county:ke-32/ed:nakuru_town_west/ward:rhoda,Rhoda
+ocd-division/country:ke/county:ke-32/ed:nakuru_town_west/ward:shaabab,Shaabab
+ocd-division/country:ke/county:ke-32/ed:nakuru_town_east/ward:biashara,Biashara
+ocd-division/country:ke/county:ke-32/ed:nakuru_town_east/ward:kivumbini,Kivumbini
+ocd-division/country:ke/county:ke-32/ed:nakuru_town_east/ward:flamingo,Flamingo
+ocd-division/country:ke/county:ke-32/ed:nakuru_town_east/ward:menengai,Menengai
+ocd-division/country:ke/county:ke-32/ed:nakuru_town_east/ward:nakuru_east,Nakuru East
+ocd-division/country:ke/county:ke-33/ed:kilgoris/ward:kilgoris_central,Kilgoris Central
+ocd-division/country:ke/county:ke-33/ed:kilgoris/ward:keyian,Keyian
+ocd-division/country:ke/county:ke-33/ed:kilgoris/ward:angata_barikoi,Angata Barikoi
+ocd-division/country:ke/county:ke-33/ed:kilgoris/ward:shankoe,Shankoe
+ocd-division/country:ke/county:ke-33/ed:kilgoris/ward:kimintet,Kimintet
+ocd-division/country:ke/county:ke-33/ed:kilgoris/ward:lolgorian,Lolgorian
+ocd-division/country:ke/county:ke-33/ed:emurua_dikirr/ward:ilkerin,Ilkerin
+ocd-division/country:ke/county:ke-33/ed:emurua_dikirr/ward:ololmasani,Ololmasani
+ocd-division/country:ke/county:ke-33/ed:emurua_dikirr/ward:mogondo,Mogondo
+ocd-division/country:ke/county:ke-33/ed:emurua_dikirr/ward:kapsasian,Kapsasian
+ocd-division/country:ke/county:ke-33/ed:narok_north/ward:olpusimoru,Olpusimoru
+ocd-division/country:ke/county:ke-33/ed:narok_north/ward:olokurto,Olokurto
+ocd-division/country:ke/county:ke-33/ed:narok_north/ward:narok_town,Narok Town
+ocd-division/country:ke/county:ke-33/ed:narok_north/ward:nkareta,Nkareta
+ocd-division/country:ke/county:ke-33/ed:narok_north/ward:olorropil,Olorropil
+ocd-division/country:ke/county:ke-33/ed:narok_north/ward:melili,Melili
+ocd-division/country:ke/county:ke-33/ed:narok_east/ward:mosiro,Mosiro
+ocd-division/country:ke/county:ke-33/ed:narok_east/ward:ildamat,Ildamat
+ocd-division/country:ke/county:ke-33/ed:narok_east/ward:keekonyokie,Keekonyokie
+ocd-division/country:ke/county:ke-33/ed:narok_east/ward:suswa,Suswa
+ocd-division/country:ke/county:ke-33/ed:narok_south/ward:majimoto_naroosura,Majimoto-Naroosura
+ocd-division/country:ke/county:ke-33/ed:narok_south/ward:ololulunga,Ololulung’a
+ocd-division/country:ke/county:ke-33/ed:narok_south/ward:melelo,Melelo
+ocd-division/country:ke/county:ke-33/ed:narok_south/ward:loita,Loita
+ocd-division/country:ke/county:ke-33/ed:narok_south/ward:sogoo,Sogoo
+ocd-division/country:ke/county:ke-33/ed:narok_south/ward:sagamian,Sagamian
+ocd-division/country:ke/county:ke-33/ed:narok_west/ward:ilmotiok,Ilmotiok
+ocd-division/country:ke/county:ke-33/ed:narok_west/ward:mara,Mara
+ocd-division/country:ke/county:ke-33/ed:narok_west/ward:siana,Siana
+ocd-division/country:ke/county:ke-33/ed:narok_west/ward:naikarra,Naikarra
+ocd-division/country:ke/county:ke-34/ed:kajiado_north/ward:olkeri,Olkeri
+ocd-division/country:ke/county:ke-34/ed:kajiado_north/ward:ongata_rongai,Ongata Rongai
+ocd-division/country:ke/county:ke-34/ed:kajiado_north/ward:nkaimurunya,Nkaimurunya
+ocd-division/country:ke/county:ke-34/ed:kajiado_north/ward:oloolua,Oloolua
+ocd-division/country:ke/county:ke-34/ed:kajiado_north/ward:ngong,Ngong
+ocd-division/country:ke/county:ke-34/ed:kajiado_central/ward:purko,Purko
+ocd-division/country:ke/county:ke-34/ed:kajiado_central/ward:ildamat,Ildamat
+ocd-division/country:ke/county:ke-34/ed:kajiado_central/ward:dalalekutuk,Dalalekutuk
+ocd-division/country:ke/county:ke-34/ed:kajiado_central/ward:matapato_north,Matapato North
+ocd-division/country:ke/county:ke-34/ed:kajiado_central/ward:matapato_south,Matapato South
+ocd-division/country:ke/county:ke-34/ed:kajiado_east/ward:kaputiei_north,Kaputiei North
+ocd-division/country:ke/county:ke-34/ed:kajiado_east/ward:kitengela,Kitengela
+ocd-division/country:ke/county:ke-34/ed:kajiado_east/ward:oloosirkon_sholinke,Oloosirkon-Sholinke
+ocd-division/country:ke/county:ke-34/ed:kajiado_east/ward:kenyawa_poka,Kenyawa-Poka
+ocd-division/country:ke/county:ke-34/ed:kajiado_east/ward:imaroro,Imaroro
+ocd-division/country:ke/county:ke-34/ed:kajiado_west/ward:keekonyokie,Keekonyokie
+ocd-division/country:ke/county:ke-34/ed:kajiado_west/ward:iloodokilani,Iloodokilani
+ocd-division/country:ke/county:ke-34/ed:kajiado_west/ward:magadi,Magadi
+ocd-division/country:ke/county:ke-34/ed:kajiado_west/ward:ewuaso_oonkidongi,Ewuaso Oonkidong’i
+ocd-division/country:ke/county:ke-34/ed:kajiado_west/ward:mosiro,Mosiro
+ocd-division/country:ke/county:ke-34/ed:kajiado_south/ward:entonet_lenkisim,Entonet-Lenkisim
+ocd-division/country:ke/county:ke-34/ed:kajiado_south/ward:mbirikani_eselenkei,Mbirikani-Eselenkei
+ocd-division/country:ke/county:ke-34/ed:kajiado_south/ward:kuku,Kuku
+ocd-division/country:ke/county:ke-34/ed:kajiado_south/ward:rombo,Rombo
+ocd-division/country:ke/county:ke-34/ed:kajiado_south/ward:kimana,Kimana
+ocd-division/country:ke/county:ke-35/ed:kipkelion_east/ward:londiani,Londiani
+ocd-division/country:ke/county:ke-35/ed:kipkelion_east/ward:kedowa_kimugul,Kedowa-Kimugul
+ocd-division/country:ke/county:ke-35/ed:kipkelion_east/ward:chepseon,Chepseon
+ocd-division/country:ke/county:ke-35/ed:kipkelion_east/ward:tendeno_sorget,Tendeno-Sorget
+ocd-division/country:ke/county:ke-35/ed:kipkelion_west/ward:kunyak,Kunyak
+ocd-division/country:ke/county:ke-35/ed:kipkelion_west/ward:kamasian,Kamasian
+ocd-division/country:ke/county:ke-35/ed:kipkelion_west/ward:kipkelion,Kipkelion
+ocd-division/country:ke/county:ke-35/ed:kipkelion_west/ward:chilchila,Chilchila
+ocd-division/country:ke/county:ke-35/ed:ainamoi/ward:kapsoit,Kapsoit
+ocd-division/country:ke/county:ke-35/ed:ainamoi/ward:ainamoi,Ainamoi
+ocd-division/country:ke/county:ke-35/ed:ainamoi/ward:kapkugerwet,Kapkugerwet
+ocd-division/country:ke/county:ke-35/ed:ainamoi/ward:kipchebor,Kipchebor
+ocd-division/country:ke/county:ke-35/ed:ainamoi/ward:kipchimchim,Kipchimchim
+ocd-division/country:ke/county:ke-35/ed:ainamoi/ward:kapsaos,Kapsaos
+ocd-division/country:ke/county:ke-35/ed:bureti/ward:kisiara,Kisiara
+ocd-division/country:ke/county:ke-35/ed:bureti/ward:tebesonik,Tebesonik
+ocd-division/country:ke/county:ke-35/ed:bureti/ward:cheboin,Cheboin
+ocd-division/country:ke/county:ke-35/ed:bureti/ward:chemosot,Chemosot
+ocd-division/country:ke/county:ke-35/ed:bureti/ward:litein,Litein
+ocd-division/country:ke/county:ke-35/ed:bureti/ward:cheplanget,Cheplanget
+ocd-division/country:ke/county:ke-35/ed:bureti/ward:kapkatet,Kapkatet
+ocd-division/country:ke/county:ke-35/ed:belgut/ward:waldai,Waldai
+ocd-division/country:ke/county:ke-35/ed:belgut/ward:kabianga,Kabianga
+ocd-division/country:ke/county:ke-35/ed:belgut/ward:cheptororiet_seretut,Cheptororiet-Seretut
+ocd-division/country:ke/county:ke-35/ed:belgut/ward:chaik,Chaik
+ocd-division/country:ke/county:ke-35/ed:belgut/ward:kapsuser,Kapsuser
+ocd-division/country:ke/county:ke-35/ed:sigowet_soin/ward:sigowet,Sigowet
+ocd-division/country:ke/county:ke-35/ed:sigowet_soin/ward:kaplelartet,Kaplelartet
+ocd-division/country:ke/county:ke-35/ed:sigowet_soin/ward:soliat,Soliat
+ocd-division/country:ke/county:ke-35/ed:sigowet_soin/ward:soin,Soin
+ocd-division/country:ke/county:ke-36/ed:sotik/ward:ndanai_abosi,Ndanai-Abosi
+ocd-division/country:ke/county:ke-36/ed:sotik/ward:chemagel,Chemagel
+ocd-division/country:ke/county:ke-36/ed:sotik/ward:kipsonoi,Kipsonoi
+ocd-division/country:ke/county:ke-36/ed:sotik/ward:kapletundo,Kapletundo
+ocd-division/country:ke/county:ke-36/ed:sotik/ward:rongena_manaret,Rongena-Manaret
+ocd-division/country:ke/county:ke-36/ed:chepalungu/ward:kongasis,Kong’asis
+ocd-division/country:ke/county:ke-36/ed:chepalungu/ward:nyangores,Nyangores
+ocd-division/country:ke/county:ke-36/ed:chepalungu/ward:sigor,Sigor
+ocd-division/country:ke/county:ke-36/ed:chepalungu/ward:chebunyo,Chebunyo
+ocd-division/country:ke/county:ke-36/ed:chepalungu/ward:siongiroi,Siongiroi
+ocd-division/country:ke/county:ke-36/ed:bomet_east/ward:merigi,Merigi
+ocd-division/country:ke/county:ke-36/ed:bomet_east/ward:kembu,Kembu
+ocd-division/country:ke/county:ke-36/ed:bomet_east/ward:longisa,Longisa
+ocd-division/country:ke/county:ke-36/ed:bomet_east/ward:kipreres,Kipreres
+ocd-division/country:ke/county:ke-36/ed:bomet_east/ward:chemaner,Chemaner
+ocd-division/country:ke/county:ke-36/ed:bomet_central/ward:silibwet_township,Silibwet Township
+ocd-division/country:ke/county:ke-36/ed:bomet_central/ward:ndaraweta,Ndaraweta
+ocd-division/country:ke/county:ke-36/ed:bomet_central/ward:singorwet,Singorwet
+ocd-division/country:ke/county:ke-36/ed:bomet_central/ward:chesoen,Chesoen
+ocd-division/country:ke/county:ke-36/ed:bomet_central/ward:mutarakwa,Mutarakwa
+ocd-division/country:ke/county:ke-36/ed:konoin/ward:chepchabas,Chepchabas
+ocd-division/country:ke/county:ke-36/ed:konoin/ward:kimulot,Kimulot
+ocd-division/country:ke/county:ke-36/ed:konoin/ward:mogogosiek,Mogogosiek
+ocd-division/country:ke/county:ke-36/ed:konoin/ward:boito,Boito
+ocd-division/country:ke/county:ke-36/ed:konoin/ward:embomos,Embomos
+ocd-division/country:ke/county:ke-37/ed:lugari/ward:mautuma,Mautuma
+ocd-division/country:ke/county:ke-37/ed:lugari/ward:lugari,Lugari
+ocd-division/country:ke/county:ke-37/ed:lugari/ward:lumakanda,Lumakanda
+ocd-division/country:ke/county:ke-37/ed:lugari/ward:chekalini,Chekalini
+ocd-division/country:ke/county:ke-37/ed:lugari/ward:chevaywa,Chevaywa
+ocd-division/country:ke/county:ke-37/ed:lugari/ward:lwandeti,Lwandeti
+ocd-division/country:ke/county:ke-37/ed:likuyani/ward:likuyani,Likuyani
+ocd-division/country:ke/county:ke-37/ed:likuyani/ward:sango,Sango
+ocd-division/country:ke/county:ke-37/ed:likuyani/ward:kongoni,Kongoni
+ocd-division/country:ke/county:ke-37/ed:likuyani/ward:nzoia,Nzoia
+ocd-division/country:ke/county:ke-37/ed:likuyani/ward:sinoko,Sinoko
+ocd-division/country:ke/county:ke-37/ed:malava/ward:west_kabras,West Kabras
+ocd-division/country:ke/county:ke-37/ed:malava/ward:chemuche,Chemuche
+ocd-division/country:ke/county:ke-37/ed:malava/ward:east_kabras,East Kabras
+ocd-division/country:ke/county:ke-37/ed:malava/ward:butali_chegulo,Butali-Chegulo
+ocd-division/country:ke/county:ke-37/ed:malava/ward:manda_shivanga,Manda-Shivanga
+ocd-division/country:ke/county:ke-37/ed:malava/ward:shirugu_mugai,Shirugu-Mugai
+ocd-division/country:ke/county:ke-37/ed:malava/ward:south_kabras,South Kabras
+ocd-division/country:ke/county:ke-37/ed:lurambi/ward:butsotso_east,Butsotso East
+ocd-division/country:ke/county:ke-37/ed:lurambi/ward:butsotso_south,Butsotso South
+ocd-division/country:ke/county:ke-37/ed:lurambi/ward:butsotso_central,Butsotso Central
+ocd-division/country:ke/county:ke-37/ed:lurambi/ward:sheywe,Sheywe
+ocd-division/country:ke/county:ke-37/ed:lurambi/ward:mahiakalo,Mahiakalo
+ocd-division/country:ke/county:ke-37/ed:lurambi/ward:shirere,Shirere
+ocd-division/country:ke/county:ke-37/ed:navakholo/ward:ingostse_mathia,Ingostse-Mathia
+ocd-division/country:ke/county:ke-37/ed:navakholo/ward:shinoyi_shikomari_esumeyia,Shinoyi-Shikomari-Esumeyia
+ocd-division/country:ke/county:ke-37/ed:navakholo/ward:bunyala_west,Bunyala West
+ocd-division/country:ke/county:ke-37/ed:navakholo/ward:bunyala_east,Bunyala East
+ocd-division/country:ke/county:ke-37/ed:navakholo/ward:bunyala_central,Bunyala Central
+ocd-division/country:ke/county:ke-37/ed:mumias_west/ward:mumias_central,Mumias Central
+ocd-division/country:ke/county:ke-37/ed:mumias_west/ward:mumias_north,Mumias North
+ocd-division/country:ke/county:ke-37/ed:mumias_west/ward:etenje,Etenje
+ocd-division/country:ke/county:ke-37/ed:mumias_west/ward:musanda,Musanda
+ocd-division/country:ke/county:ke-37/ed:mumias_east/ward:lusheya_lubinu,Lusheya-Lubinu
+ocd-division/country:ke/county:ke-37/ed:mumias_east/ward:malaha_isongo_makunga,Malaha-Isongo-Makunga
+ocd-division/country:ke/county:ke-37/ed:mumias_east/ward:east_wanga,East Wanga
+ocd-division/country:ke/county:ke-37/ed:matungu/ward:koyonzo,Koyonzo
+ocd-division/country:ke/county:ke-37/ed:matungu/ward:kholera,Kholera
+ocd-division/country:ke/county:ke-37/ed:matungu/ward:khalaba,Khalaba
+ocd-division/country:ke/county:ke-37/ed:matungu/ward:mayoni,Mayoni
+ocd-division/country:ke/county:ke-37/ed:matungu/ward:namamali,Namamali
+ocd-division/country:ke/county:ke-37/ed:butere/ward:marama_west,Marama West
+ocd-division/country:ke/county:ke-37/ed:butere/ward:marama_central,Marama Central
+ocd-division/country:ke/county:ke-37/ed:butere/ward:marenyo_shianda,Marenyo - Shianda
+ocd-division/country:ke/county:ke-37/ed:butere/ward:marama_north,Marama North
+ocd-division/country:ke/county:ke-37/ed:butere/ward:marama_south,Marama South
+ocd-division/country:ke/county:ke-37/ed:khwisero/ward:kisa_north,Kisa North
+ocd-division/country:ke/county:ke-37/ed:khwisero/ward:kisa_east,Kisa East
+ocd-division/country:ke/county:ke-37/ed:khwisero/ward:kisa_west,Kisa West
+ocd-division/country:ke/county:ke-37/ed:khwisero/ward:kisa_central,Kisa Central
+ocd-division/country:ke/county:ke-37/ed:shinyalu/ward:isukha_north,Isukha North
+ocd-division/country:ke/county:ke-37/ed:shinyalu/ward:murhanda,Murhanda
+ocd-division/country:ke/county:ke-37/ed:shinyalu/ward:isukha_central,Isukha Central
+ocd-division/country:ke/county:ke-37/ed:shinyalu/ward:isukha_south,Isukha South
+ocd-division/country:ke/county:ke-37/ed:shinyalu/ward:isukha_east,Isukha East
+ocd-division/country:ke/county:ke-37/ed:shinyalu/ward:isukha_west,Isukha West
+ocd-division/country:ke/county:ke-37/ed:ikolomani/ward:idakho_south,Idakho South
+ocd-division/country:ke/county:ke-37/ed:ikolomani/ward:idakho_east,Idakho East
+ocd-division/country:ke/county:ke-37/ed:ikolomani/ward:idakho_north,Idakho North
+ocd-division/country:ke/county:ke-37/ed:ikolomani/ward:idakho_central,Idakho Central
+ocd-division/country:ke/county:ke-38/ed:vihiga/ward:lugaga_wamuluma,Lugaga-Wamuluma
+ocd-division/country:ke/county:ke-38/ed:vihiga/ward:south_maragoli,South Maragoli
+ocd-division/country:ke/county:ke-38/ed:vihiga/ward:central_maragoli,Central Maragoli
+ocd-division/country:ke/county:ke-38/ed:vihiga/ward:mungoma,Mungoma
+ocd-division/country:ke/county:ke-38/ed:sabatia/ward:lyaduywa_izava,Lyaduywa-Izava
+ocd-division/country:ke/county:ke-38/ed:sabatia/ward:west_sabatia,West Sabatia
+ocd-division/country:ke/county:ke-38/ed:sabatia/ward:chavakali,Chavakali
+ocd-division/country:ke/county:ke-38/ed:sabatia/ward:north_maragoli,North Maragoli
+ocd-division/country:ke/county:ke-38/ed:sabatia/ward:wodanga,Wodanga
+ocd-division/country:ke/county:ke-38/ed:sabatia/ward:busali,Busali
+ocd-division/country:ke/county:ke-38/ed:hamisi/ward:shiru,Shiru
+ocd-division/country:ke/county:ke-38/ed:hamisi/ward:gisambai,Gisambai
+ocd-division/country:ke/county:ke-38/ed:hamisi/ward:shamakhokho,Shamakhokho
+ocd-division/country:ke/county:ke-38/ed:hamisi/ward:banja,Banja
+ocd-division/country:ke/county:ke-38/ed:hamisi/ward:muhudu,Muhudu
+ocd-division/country:ke/county:ke-38/ed:hamisi/ward:tambua,Tambua
+ocd-division/country:ke/county:ke-38/ed:hamisi/ward:jepkoyai,Jepkoyai
+ocd-division/country:ke/county:ke-38/ed:luanda/ward:luanda_township,Luanda Township
+ocd-division/country:ke/county:ke-38/ed:luanda/ward:wemilabi,Wemilabi
+ocd-division/country:ke/county:ke-38/ed:luanda/ward:mwibona,Mwibona
+ocd-division/country:ke/county:ke-38/ed:luanda/ward:luanda_south,Luanda South
+ocd-division/country:ke/county:ke-38/ed:luanda/ward:emabungo,Emabungo
+ocd-division/country:ke/county:ke-38/ed:emuhaya/ward:north_east_bunyore,North East Bunyore
+ocd-division/country:ke/county:ke-38/ed:emuhaya/ward:central_bunyore,Central Bunyore
+ocd-division/country:ke/county:ke-38/ed:emuhaya/ward:west_bunyore,West Bunyore
+ocd-division/country:ke/county:ke-39/ed:mt._elgon/ward:cheptais,Cheptais
+ocd-division/country:ke/county:ke-39/ed:mt._elgon/ward:chesikaki,Chesikaki
+ocd-division/country:ke/county:ke-39/ed:mt._elgon/ward:chepyuk,Chepyuk
+ocd-division/country:ke/county:ke-39/ed:mt._elgon/ward:kapkateny,Kapkateny
+ocd-division/country:ke/county:ke-39/ed:mt._elgon/ward:kaptama,Kaptama
+ocd-division/country:ke/county:ke-39/ed:mt._elgon/ward:elgon,Elgon
+ocd-division/country:ke/county:ke-39/ed:sirisia/ward:namwela,Namwela
+ocd-division/country:ke/county:ke-39/ed:sirisia/ward:malakisi_south_kulisiru,Malakisi-South Kulisiru
+ocd-division/country:ke/county:ke-39/ed:sirisia/ward:lwandanyi,Lwandanyi
+ocd-division/country:ke/county:ke-39/ed:kabuchai/ward:kabuchai_chwele,Kabuchai-Chwele
+ocd-division/country:ke/county:ke-39/ed:kabuchai/ward:west_nalondo,West Nalondo
+ocd-division/country:ke/county:ke-39/ed:kabuchai/ward:bwake_luuya,Bwake-Luuya
+ocd-division/country:ke/county:ke-39/ed:kabuchai/ward:mukuyuni,Mukuyuni
+ocd-division/country:ke/county:ke-39/ed:bumula/ward:south_bukusu,South Bukusu
+ocd-division/country:ke/county:ke-39/ed:bumula/ward:bumula,Bumula
+ocd-division/country:ke/county:ke-39/ed:bumula/ward:khasoko,Khasoko
+ocd-division/country:ke/county:ke-39/ed:bumula/ward:kabula,Kabula
+ocd-division/country:ke/county:ke-39/ed:bumula/ward:kimaeti,Kimaeti
+ocd-division/country:ke/county:ke-39/ed:bumula/ward:west_bukusu,West Bukusu
+ocd-division/country:ke/county:ke-39/ed:bumula/ward:siboti,Siboti
+ocd-division/country:ke/county:ke-39/ed:kanduyi/ward:bukembe_west,Bukembe West
+ocd-division/country:ke/county:ke-39/ed:kanduyi/ward:bukembe_east,Bukembe East
+ocd-division/country:ke/county:ke-39/ed:kanduyi/ward:township,Township
+ocd-division/country:ke/county:ke-39/ed:kanduyi/ward:khalaba,Khalaba
+ocd-division/country:ke/county:ke-39/ed:kanduyi/ward:musikoma,Musikoma
+ocd-division/country:ke/county:ke-39/ed:kanduyi/ward:east_sangalo,East Sang’alo
+ocd-division/country:ke/county:ke-39/ed:kanduyi/ward:marakaru_tuuti,Marakaru-Tuuti
+ocd-division/country:ke/county:ke-39/ed:kanduyi/ward:west_sangalo,West Sang’alo
+ocd-division/country:ke/county:ke-39/ed:webuye_east/ward:mihuu,Mihuu
+ocd-division/country:ke/county:ke-39/ed:webuye_east/ward:ndivisi,Ndivisi
+ocd-division/country:ke/county:ke-39/ed:webuye_east/ward:maraka,Maraka
+ocd-division/country:ke/county:ke-39/ed:webuye_west/ward:misikhu,Misikhu
+ocd-division/country:ke/county:ke-39/ed:webuye_west/ward:sitikho,Sitikho
+ocd-division/country:ke/county:ke-39/ed:webuye_west/ward:matulo,Matulo
+ocd-division/country:ke/county:ke-39/ed:webuye_west/ward:bokoli,Bokoli
+ocd-division/country:ke/county:ke-39/ed:kimilili/ward:kibingei,Kibingei
+ocd-division/country:ke/county:ke-39/ed:kimilili/ward:kimilili,Kimilili
+ocd-division/country:ke/county:ke-39/ed:kimilili/ward:maeni,Maeni
+ocd-division/country:ke/county:ke-39/ed:kimilili/ward:kamukuywa,Kamukuywa
+ocd-division/country:ke/county:ke-39/ed:tongaren/ward:mbakalo,Mbakalo
+ocd-division/country:ke/county:ke-39/ed:tongaren/ward:naitiri_kabuyefwe,Naitiri-Kabuyefwe
+ocd-division/country:ke/county:ke-39/ed:tongaren/ward:milima,Milima
+ocd-division/country:ke/county:ke-39/ed:tongaren/ward:ndalu_tabani,Ndalu- Tabani
+ocd-division/country:ke/county:ke-39/ed:tongaren/ward:tongaren,Tongaren
+ocd-division/country:ke/county:ke-39/ed:tongaren/ward:soysambu_mitua,Soysambu- Mitua
+ocd-division/country:ke/county:ke-40/ed:teso_north/ward:malaba_central,Malaba Central
+ocd-division/country:ke/county:ke-40/ed:teso_north/ward:malaba_north,Malaba North
+ocd-division/country:ke/county:ke-40/ed:teso_north/ward:angurai_south,Ang’urai South
+ocd-division/country:ke/county:ke-40/ed:teso_north/ward:angurai_north,Ang’urai North
+ocd-division/country:ke/county:ke-40/ed:teso_north/ward:angurai_east,Ang’urai East
+ocd-division/country:ke/county:ke-40/ed:teso_north/ward:malaba_south,Malaba South
+ocd-division/country:ke/county:ke-40/ed:teso_south/ward:angorom,Ang’orom
+ocd-division/country:ke/county:ke-40/ed:teso_south/ward:chakol_south,Chakol South
+ocd-division/country:ke/county:ke-40/ed:teso_south/ward:chakol_north,Chakol North
+ocd-division/country:ke/county:ke-40/ed:teso_south/ward:amukura_west,Amukura West
+ocd-division/country:ke/county:ke-40/ed:teso_south/ward:amukura_east,Amukura East
+ocd-division/country:ke/county:ke-40/ed:teso_south/ward:amukura_central,Amukura Central
+ocd-division/country:ke/county:ke-40/ed:nambale/ward:nambale_township,Nambale Township
+ocd-division/country:ke/county:ke-40/ed:nambale/ward:bukhayo_north_waltsi,Bukhayo North-Waltsi
+ocd-division/country:ke/county:ke-40/ed:nambale/ward:bukhayo_east,Bukhayo East
+ocd-division/country:ke/county:ke-40/ed:nambale/ward:bukhayo_central,Bukhayo Central
+ocd-division/country:ke/county:ke-40/ed:matayos/ward:bukhayo_west,Bukhayo West
+ocd-division/country:ke/county:ke-40/ed:matayos/ward:mayenje,Mayenje
+ocd-division/country:ke/county:ke-40/ed:matayos/ward:matayos_south,Matayos South
+ocd-division/country:ke/county:ke-40/ed:matayos/ward:busibwabo,Busibwabo
+ocd-division/country:ke/county:ke-40/ed:matayos/ward:burumba,Burumba
+ocd-division/country:ke/county:ke-40/ed:butula/ward:marachi_west,Marachi West
+ocd-division/country:ke/county:ke-40/ed:butula/ward:kingandole,Kingandole
+ocd-division/country:ke/county:ke-40/ed:butula/ward:marachi_central,Marachi Central
+ocd-division/country:ke/county:ke-40/ed:butula/ward:marachi_east,Marachi East
+ocd-division/country:ke/county:ke-40/ed:butula/ward:marachi_north,Marachi North
+ocd-division/country:ke/county:ke-40/ed:butula/ward:elugulu,Elugulu
+ocd-division/country:ke/county:ke-40/ed:funyula/ward:namboboto_nambuku,Namboboto Nambuku
+ocd-division/country:ke/county:ke-40/ed:funyula/ward:nangina,Nangina
+ocd-division/country:ke/county:ke-40/ed:funyula/ward:agenga_nanguba,Ageng’a Nanguba
+ocd-division/country:ke/county:ke-40/ed:funyula/ward:bwiri,Bwiri
+ocd-division/country:ke/county:ke-40/ed:budalangi/ward:bunyala_central,Bunyala Central
+ocd-division/country:ke/county:ke-40/ed:budalangi/ward:bunyala_north,Bunyala North
+ocd-division/country:ke/county:ke-40/ed:budalangi/ward:bunyala_west,Bunyala West
+ocd-division/country:ke/county:ke-40/ed:budalangi/ward:bunyala_south,Bunyala South
+ocd-division/country:ke/county:ke-41/ed:ugenya/ward:west_ugenya,West Ugenya
+ocd-division/country:ke/county:ke-41/ed:ugenya/ward:ukwala,Ukwala
+ocd-division/country:ke/county:ke-41/ed:ugenya/ward:north_ugenya,North Ugenya
+ocd-division/country:ke/county:ke-41/ed:ugenya/ward:east_ugenya,East Ugenya
+ocd-division/country:ke/county:ke-41/ed:ugunja/ward:sidindi,Sidindi
+ocd-division/country:ke/county:ke-41/ed:ugunja/ward:sigomere,Sigomere
+ocd-division/country:ke/county:ke-41/ed:ugunja/ward:ugunja,Ugunja
+ocd-division/country:ke/county:ke-41/ed:alego_usonga/ward:usonga,Usonga
+ocd-division/country:ke/county:ke-41/ed:alego_usonga/ward:west_alego,West Alego
+ocd-division/country:ke/county:ke-41/ed:alego_usonga/ward:central_alego,Central Alego
+ocd-division/country:ke/county:ke-41/ed:alego_usonga/ward:siaya_township,Siaya Township
+ocd-division/country:ke/county:ke-41/ed:alego_usonga/ward:north_alego,North Alego
+ocd-division/country:ke/county:ke-41/ed:alego_usonga/ward:south_east_alego,South East Alego
+ocd-division/country:ke/county:ke-41/ed:gem/ward:north_gem,North Gem
+ocd-division/country:ke/county:ke-41/ed:gem/ward:west_gem,West Gem
+ocd-division/country:ke/county:ke-41/ed:gem/ward:central_gem,Central Gem
+ocd-division/country:ke/county:ke-41/ed:gem/ward:yala_township,Yala Township
+ocd-division/country:ke/county:ke-41/ed:gem/ward:east_gem,East Gem
+ocd-division/country:ke/county:ke-41/ed:gem/ward:south_gem,South Gem
+ocd-division/country:ke/county:ke-41/ed:bondo/ward:west_yimbo,West Yimbo
+ocd-division/country:ke/county:ke-41/ed:bondo/ward:central_sakwa,Central Sakwa
+ocd-division/country:ke/county:ke-41/ed:bondo/ward:south_sakwa,South Sakwa
+ocd-division/country:ke/county:ke-41/ed:bondo/ward:yimbo_east,Yimbo East
+ocd-division/country:ke/county:ke-41/ed:bondo/ward:west_sakwa,West Sakwa
+ocd-division/country:ke/county:ke-41/ed:bondo/ward:north_sakwa,North Sakwa
+ocd-division/country:ke/county:ke-41/ed:rarieda/ward:east_asembo,East Asembo
+ocd-division/country:ke/county:ke-41/ed:rarieda/ward:west_asembo,West Asembo
+ocd-division/country:ke/county:ke-41/ed:rarieda/ward:north_uyoma,North Uyoma
+ocd-division/country:ke/county:ke-41/ed:rarieda/ward:south_uyoma,South Uyoma
+ocd-division/country:ke/county:ke-41/ed:rarieda/ward:west_uyoma,West Uyoma
+ocd-division/country:ke/county:ke-42/ed:kisumu_east/ward:kajulu,Kajulu
+ocd-division/country:ke/county:ke-42/ed:kisumu_east/ward:kolwa_east,Kolwa East
+ocd-division/country:ke/county:ke-42/ed:kisumu_east/ward:manyatta,Manyatta
+ocd-division/country:ke/county:ke-42/ed:kisumu_east/ward:nyalenda,Nyalenda
+ocd-division/country:ke/county:ke-42/ed:kisumu_east/ward:kolwa_central,Kolwa Central
+ocd-division/country:ke/county:ke-42/ed:kisumu_west/ward:south_west_kisumu,South West Kisumu
+ocd-division/country:ke/county:ke-42/ed:kisumu_west/ward:central_kisumu,Central Kisumu
+ocd-division/country:ke/county:ke-42/ed:kisumu_west/ward:kisumu_north,Kisumu North
+ocd-division/country:ke/county:ke-42/ed:kisumu_west/ward:west_kisumu,West Kisumu
+ocd-division/country:ke/county:ke-42/ed:kisumu_west/ward:north_west_kisumu,North West Kisumu
+ocd-division/country:ke/county:ke-42/ed:kisumu_central/ward:railways,Railways
+ocd-division/country:ke/county:ke-42/ed:kisumu_central/ward:migosi,Migosi
+ocd-division/country:ke/county:ke-42/ed:kisumu_central/ward:shaurimoyo_kaloleni,Shaurimoyo Kaloleni
+ocd-division/country:ke/county:ke-42/ed:kisumu_central/ward:market_milimani,Market Milimani
+ocd-division/country:ke/county:ke-42/ed:kisumu_central/ward:kondele,Kondele
+ocd-division/country:ke/county:ke-42/ed:kisumu_central/ward:nyalenda_b,Nyalenda B
+ocd-division/country:ke/county:ke-42/ed:seme/ward:west_seme,West Seme
+ocd-division/country:ke/county:ke-42/ed:seme/ward:central_seme,Central Seme
+ocd-division/country:ke/county:ke-42/ed:seme/ward:east_seme,East Seme
+ocd-division/country:ke/county:ke-42/ed:seme/ward:north_seme,North Seme
+ocd-division/country:ke/county:ke-42/ed:nyando/ward:east_kano_wawidhi,East Kano-Wawidhi
+ocd-division/country:ke/county:ke-42/ed:nyando/ward:awasi_onjiko,Awasi-Onjiko
+ocd-division/country:ke/county:ke-42/ed:nyando/ward:ahero,Ahero
+ocd-division/country:ke/county:ke-42/ed:nyando/ward:kabonyo_kanyagwal,Kabonyo-Kanyagwal
+ocd-division/country:ke/county:ke-42/ed:nyando/ward:kobura,Kobura
+ocd-division/country:ke/county:ke-42/ed:muhoroni/ward:miwani,Miwani
+ocd-division/country:ke/county:ke-42/ed:muhoroni/ward:ombeyi,Ombeyi
+ocd-division/country:ke/county:ke-42/ed:muhoroni/ward:masogo_nyangoma,Masogo-Nyangoma
+ocd-division/country:ke/county:ke-42/ed:muhoroni/ward:chemelil,Chemelil
+ocd-division/country:ke/county:ke-42/ed:muhoroni/ward:muhoroni_koru,Muhoroni-Koru
+ocd-division/country:ke/county:ke-42/ed:nyakach/ward:south_west_nyakach,South West Nyakach
+ocd-division/country:ke/county:ke-42/ed:nyakach/ward:north_nyakach,North Nyakach
+ocd-division/country:ke/county:ke-42/ed:nyakach/ward:central_nyakach,Central Nyakach
+ocd-division/country:ke/county:ke-42/ed:nyakach/ward:west_nyakach,West Nyakach
+ocd-division/country:ke/county:ke-42/ed:nyakach/ward:south_east_nyakach,South East Nyakach
+ocd-division/country:ke/county:ke-43/ed:kasipul/ward:west_kasipul,West Kasipul
+ocd-division/country:ke/county:ke-43/ed:kasipul/ward:south_kasipul,South Kasipul
+ocd-division/country:ke/county:ke-43/ed:kasipul/ward:central_kasipul,Central Kasipul
+ocd-division/country:ke/county:ke-43/ed:kasipul/ward:east_kamagak,East Kamagak
+ocd-division/country:ke/county:ke-43/ed:kasipul/ward:west_kamagak,West Kamagak
+ocd-division/country:ke/county:ke-43/ed:kabondo_kasipul/ward:kabondo_east,Kabondo East
+ocd-division/country:ke/county:ke-43/ed:kabondo_kasipul/ward:kabondo_west,Kabondo West
+ocd-division/country:ke/county:ke-43/ed:kabondo_kasipul/ward:kokwanyo_kakelo,Kokwanyo-Kakelo
+ocd-division/country:ke/county:ke-43/ed:kabondo_kasipul/ward:kojwach,Kojwach
+ocd-division/country:ke/county:ke-43/ed:karachuonyo/ward:west_karachuonyo,West Karachuonyo
+ocd-division/country:ke/county:ke-43/ed:karachuonyo/ward:north_karachuonyo,North Karachuonyo
+ocd-division/country:ke/county:ke-43/ed:karachuonyo/ward:central,Central
+ocd-division/country:ke/county:ke-43/ed:karachuonyo/ward:kanyaluo,Kanyaluo
+ocd-division/country:ke/county:ke-43/ed:karachuonyo/ward:kibiri,Kibiri
+ocd-division/country:ke/county:ke-43/ed:karachuonyo/ward:wangchieng,Wangchieng
+ocd-division/country:ke/county:ke-43/ed:karachuonyo/ward:kendu_bay_town,Kendu Bay Town
+ocd-division/country:ke/county:ke-43/ed:rangwe/ward:west_gem,West Gem
+ocd-division/country:ke/county:ke-43/ed:rangwe/ward:east_gem,East Gem
+ocd-division/country:ke/county:ke-43/ed:rangwe/ward:kagan,Kagan
+ocd-division/country:ke/county:ke-43/ed:rangwe/ward:kochia,Kochia
+ocd-division/country:ke/county:ke-43/ed:homa_bay_town/ward:homa_bay_central,Homa Bay Central
+ocd-division/country:ke/county:ke-43/ed:homa_bay_town/ward:homa_bay_arujo,Homa Bay Arujo
+ocd-division/country:ke/county:ke-43/ed:homa_bay_town/ward:homa_bay_west,Homa Bay West
+ocd-division/country:ke/county:ke-43/ed:homa_bay_town/ward:homa_bay_east,Homa Bay East
+ocd-division/country:ke/county:ke-43/ed:ndhiwa/ward:kwabwai,Kwabwai
+ocd-division/country:ke/county:ke-43/ed:ndhiwa/ward:kanyadoto,Kanyadoto
+ocd-division/country:ke/county:ke-43/ed:ndhiwa/ward:kanyikela,Kanyikela
+ocd-division/country:ke/county:ke-43/ed:ndhiwa/ward:kabuoch_north,Kabuoch North
+ocd-division/country:ke/county:ke-43/ed:ndhiwa/ward:kabuoch_south_pala,Kabuoch South-Pala
+ocd-division/country:ke/county:ke-43/ed:ndhiwa/ward:kanyamwa_kologi,Kanyamwa Kologi
+ocd-division/country:ke/county:ke-43/ed:ndhiwa/ward:kanyamwa_kosewe,Kanyamwa Kosewe
+ocd-division/country:ke/county:ke-43/ed:suba_north/ward:mfangano_island,Mfangano Island
+ocd-division/country:ke/county:ke-43/ed:suba_north/ward:rusinga_island,Rusinga Island
+ocd-division/country:ke/county:ke-43/ed:suba_north/ward:kasgunga,Kasgunga
+ocd-division/country:ke/county:ke-43/ed:suba_north/ward:gembe,Gembe
+ocd-division/country:ke/county:ke-43/ed:suba_north/ward:lambwe,Lambwe
+ocd-division/country:ke/county:ke-43/ed:suba_south/ward:gwassi_south,Gwassi South
+ocd-division/country:ke/county:ke-43/ed:suba_south/ward:gwassi_north,Gwassi North
+ocd-division/country:ke/county:ke-43/ed:suba_south/ward:kaksingri_west,Kaksingri West
+ocd-division/country:ke/county:ke-43/ed:suba_south/ward:ruma_kaksingri,Ruma-Kaksingri
+ocd-division/country:ke/county:ke-44/ed:rongo/ward:north_kamagambo,North Kamagambo
+ocd-division/country:ke/county:ke-44/ed:rongo/ward:central_kamagambo,Central Kamagambo
+ocd-division/country:ke/county:ke-44/ed:rongo/ward:east_kamagambo,East Kamagambo
+ocd-division/country:ke/county:ke-44/ed:rongo/ward:south_kamagambo,South Kamagambo
+ocd-division/country:ke/county:ke-44/ed:awendo/ward:north_sakwa,North Sakwa
+ocd-division/country:ke/county:ke-44/ed:awendo/ward:south_sakwa,South Sakwa
+ocd-division/country:ke/county:ke-44/ed:awendo/ward:west_sakwa,West Sakwa
+ocd-division/country:ke/county:ke-44/ed:awendo/ward:central_sakwa,Central Sakwa
+ocd-division/country:ke/county:ke-44/ed:suna_east/ward:god_jope,God Jope
+ocd-division/country:ke/county:ke-44/ed:suna_east/ward:suna_central,Suna Central
+ocd-division/country:ke/county:ke-44/ed:suna_east/ward:kakrao,Kakrao
+ocd-division/country:ke/county:ke-44/ed:suna_east/ward:kwa,Kwa
+ocd-division/country:ke/county:ke-44/ed:suna_west/ward:wiga,Wiga
+ocd-division/country:ke/county:ke-44/ed:suna_west/ward:wasweta_ii,Wasweta II
+ocd-division/country:ke/county:ke-44/ed:suna_west/ward:ragana_oruba,Ragana-Oruba
+ocd-division/country:ke/county:ke-44/ed:suna_west/ward:wasimbete,Wasimbete
+ocd-division/country:ke/county:ke-44/ed:uriri/ward:west_kanyamkago,West Kanyamkago
+ocd-division/country:ke/county:ke-44/ed:uriri/ward:north_kanyamkago,North Kanyamkago
+ocd-division/country:ke/county:ke-44/ed:uriri/ward:central_kanyamkago,Central Kanyamkago
+ocd-division/country:ke/county:ke-44/ed:uriri/ward:south_kanyamkago,South Kanyamkago
+ocd-division/country:ke/county:ke-44/ed:uriri/ward:east_kanyamkago,East Kanyamkago
+ocd-division/country:ke/county:ke-44/ed:nyatike/ward:kachieng,Kachieng
+ocd-division/country:ke/county:ke-44/ed:nyatike/ward:kanyasa,Kanyasa
+ocd-division/country:ke/county:ke-44/ed:nyatike/ward:north_kadem,North Kadem
+ocd-division/country:ke/county:ke-44/ed:nyatike/ward:macalder_kanyarwanda,Macalder-Kanyarwanda
+ocd-division/country:ke/county:ke-44/ed:nyatike/ward:kaler,Kaler
+ocd-division/country:ke/county:ke-44/ed:nyatike/ward:got_kachola,Got Kachola
+ocd-division/country:ke/county:ke-44/ed:nyatike/ward:muhuru,Muhuru
+ocd-division/country:ke/county:ke-44/ed:kuria_west/ward:bukira_east,Bukira East
+ocd-division/country:ke/county:ke-44/ed:kuria_west/ward:bukira_centrl_ikerege,Bukira Centrl-Ikerege
+ocd-division/country:ke/county:ke-44/ed:kuria_west/ward:isibania,Isibania
+ocd-division/country:ke/county:ke-44/ed:kuria_west/ward:makerero,Makerero
+ocd-division/country:ke/county:ke-44/ed:kuria_west/ward:masaba,Masaba
+ocd-division/country:ke/county:ke-44/ed:kuria_west/ward:tagare,Tagare
+ocd-division/country:ke/county:ke-44/ed:kuria_west/ward:nyamosense_komosoko,Nyamosense-Komosoko
+ocd-division/country:ke/county:ke-44/ed:kuria_east/ward:gokeharaka_getambwega,Gokeharaka-Getambwega
+ocd-division/country:ke/county:ke-44/ed:kuria_east/ward:ntimaru_west,Ntimaru West
+ocd-division/country:ke/county:ke-44/ed:kuria_east/ward:ntimaru_east,Ntimaru East
+ocd-division/country:ke/county:ke-44/ed:kuria_east/ward:nyabasi_east,Nyabasi East
+ocd-division/country:ke/county:ke-44/ed:kuria_east/ward:nyabasi_west,Nyabasi West
+ocd-division/country:ke/county:ke-45/ed:bonchari/ward:bomariba,Bomariba
+ocd-division/country:ke/county:ke-45/ed:bonchari/ward:bogiakumu,Bogiakumu
+ocd-division/country:ke/county:ke-45/ed:bonchari/ward:bomorenda,Bomorenda
+ocd-division/country:ke/county:ke-45/ed:bonchari/ward:riana,Riana
+ocd-division/country:ke/county:ke-45/ed:south_mugirango/ward:tabaka,Tabaka
+ocd-division/country:ke/county:ke-45/ed:south_mugirango/ward:boikanga,Boikanga
+ocd-division/country:ke/county:ke-45/ed:south_mugirango/ward:bogetenga,Bogetenga
+ocd-division/country:ke/county:ke-45/ed:south_mugirango/ward:borabu_chitago,Borabu - Chitago
+ocd-division/country:ke/county:ke-45/ed:south_mugirango/ward:moticho,Moticho
+ocd-division/country:ke/county:ke-45/ed:south_mugirango/ward:getenga,Getenga
+ocd-division/country:ke/county:ke-45/ed:bomachoge_borabu/ward:bombaba_borabu,Bombaba Borabu
+ocd-division/country:ke/county:ke-45/ed:bomachoge_borabu/ward:boochi_borabu,Boochi Borabu
+ocd-division/country:ke/county:ke-45/ed:bomachoge_borabu/ward:bokimonge,Bokimonge
+ocd-division/country:ke/county:ke-45/ed:bomachoge_borabu/ward:magenche,Magenche
+ocd-division/country:ke/county:ke-45/ed:bobasi/ward:masige_west,Masige West
+ocd-division/country:ke/county:ke-45/ed:bobasi/ward:masige_east,Masige East
+ocd-division/country:ke/county:ke-45/ed:bobasi/ward:basi_central,Basi Central
+ocd-division/country:ke/county:ke-45/ed:bobasi/ward:nyacheki,Nyacheki
+ocd-division/country:ke/county:ke-45/ed:bobasi/ward:basi_bogetaorio,Basi Bogetaorio
+ocd-division/country:ke/county:ke-45/ed:bobasi/ward:bobasi_chache,Bobasi Chache
+ocd-division/country:ke/county:ke-45/ed:bobasi/ward:sameta_mokwerero,Sameta-Mokwerero
+ocd-division/country:ke/county:ke-45/ed:bobasi/ward:bobasi_boitangare,Bobasi Boitangare
+ocd-division/country:ke/county:ke-45/ed:bomachoge_chache/ward:majoge_basi,Majoge Basi
+ocd-division/country:ke/county:ke-45/ed:bomachoge_chache/ward:boochi_tendere,Boochi-Tendere
+ocd-division/country:ke/county:ke-45/ed:bomachoge_chache/ward:bosoti_sengera,Bosoti-Sengera
+ocd-division/country:ke/county:ke-45/ed:nyaribari_masaba/ward:ichuni,Ichuni
+ocd-division/country:ke/county:ke-45/ed:nyaribari_masaba/ward:nyamasibi,Nyamasibi
+ocd-division/country:ke/county:ke-45/ed:nyaribari_masaba/ward:masimba,Masimba
+ocd-division/country:ke/county:ke-45/ed:nyaribari_masaba/ward:gesusu,Gesusu
+ocd-division/country:ke/county:ke-45/ed:nyaribari_masaba/ward:kiamokama,Kiamokama
+ocd-division/country:ke/county:ke-45/ed:nyaribari_chache/ward:bobaracho,Bobaracho
+ocd-division/country:ke/county:ke-45/ed:nyaribari_chache/ward:kisii_central,Kisii Central
+ocd-division/country:ke/county:ke-45/ed:nyaribari_chache/ward:keumbu,Keumbu
+ocd-division/country:ke/county:ke-45/ed:nyaribari_chache/ward:kiogoro,Kiogoro
+ocd-division/country:ke/county:ke-45/ed:nyaribari_chache/ward:birongo,Birongo
+ocd-division/country:ke/county:ke-45/ed:nyaribari_chache/ward:ibeno,Ibeno
+ocd-division/country:ke/county:ke-45/ed:kitutu_chache_north/ward:monyerero,Monyerero
+ocd-division/country:ke/county:ke-45/ed:kitutu_chache_north/ward:sensi,Sensi
+ocd-division/country:ke/county:ke-45/ed:kitutu_chache_north/ward:marani,Marani
+ocd-division/country:ke/county:ke-45/ed:kitutu_chache_north/ward:kegogi,Kegogi
+ocd-division/country:ke/county:ke-45/ed:kitutu_chache_south/ward:bogusero,Bogusero
+ocd-division/country:ke/county:ke-45/ed:kitutu_chache_south/ward:bogeka,Bogeka
+ocd-division/country:ke/county:ke-45/ed:kitutu_chache_south/ward:nyakoe,Nyakoe
+ocd-division/country:ke/county:ke-45/ed:kitutu_chache_south/ward:kitutu_central,Kitutu Central
+ocd-division/country:ke/county:ke-45/ed:kitutu_chache_south/ward:nyatieko,Nyatieko
+ocd-division/country:ke/county:ke-46/ed:kitutu_masaba/ward:rigoma,Rigoma
+ocd-division/country:ke/county:ke-46/ed:kitutu_masaba/ward:gachuba,Gachuba
+ocd-division/country:ke/county:ke-46/ed:kitutu_masaba/ward:kemera,Kemera
+ocd-division/country:ke/county:ke-46/ed:kitutu_masaba/ward:magombo,Magombo
+ocd-division/country:ke/county:ke-46/ed:kitutu_masaba/ward:manga,Manga
+ocd-division/country:ke/county:ke-46/ed:kitutu_masaba/ward:gesima,Gesima
+ocd-division/country:ke/county:ke-46/ed:west_mugirango/ward:nyamaiya,Nyamaiya
+ocd-division/country:ke/county:ke-46/ed:west_mugirango/ward:bogichora,Bogichora
+ocd-division/country:ke/county:ke-46/ed:west_mugirango/ward:bosamaro,Bosamaro
+ocd-division/country:ke/county:ke-46/ed:west_mugirango/ward:bonyamatuta,Bonyamatuta
+ocd-division/country:ke/county:ke-46/ed:west_mugirango/ward:township,Township
+ocd-division/country:ke/county:ke-46/ed:north_mugirango/ward:itibo,Itibo
+ocd-division/country:ke/county:ke-46/ed:north_mugirango/ward:bomwagamo,Bomwagamo
+ocd-division/country:ke/county:ke-46/ed:north_mugirango/ward:bokeira,Bokeira
+ocd-division/country:ke/county:ke-46/ed:north_mugirango/ward:magwagwa,Magwagwa
+ocd-division/country:ke/county:ke-46/ed:north_mugirango/ward:ekerenyo,Ekerenyo
+ocd-division/country:ke/county:ke-46/ed:borabu/ward:mekenene,Mekenene
+ocd-division/country:ke/county:ke-46/ed:borabu/ward:kiabonyoru,Kiabonyoru
+ocd-division/country:ke/county:ke-46/ed:borabu/ward:nyansiongo,Nyansiongo
+ocd-division/country:ke/county:ke-46/ed:borabu/ward:esise,Esise
+ocd-division/country:ke/county:ke-47/ed:westlands/ward:kitisuru,Kitisuru
+ocd-division/country:ke/county:ke-47/ed:westlands/ward:parklands_highridge,Parklands-Highridge
+ocd-division/country:ke/county:ke-47/ed:westlands/ward:karura,Karura
+ocd-division/country:ke/county:ke-47/ed:westlands/ward:kangemi,Kangemi
+ocd-division/country:ke/county:ke-47/ed:westlands/ward:mountain_view,Mountain View
+ocd-division/country:ke/county:ke-47/ed:dagoretti_north/ward:kilimani,Kilimani
+ocd-division/country:ke/county:ke-47/ed:dagoretti_north/ward:kawangware,Kawangware
+ocd-division/country:ke/county:ke-47/ed:dagoretti_north/ward:gatina,Gatina
+ocd-division/country:ke/county:ke-47/ed:dagoretti_north/ward:kileleshwa,Kileleshwa
+ocd-division/country:ke/county:ke-47/ed:dagoretti_north/ward:kabiro,Kabiro
+ocd-division/country:ke/county:ke-47/ed:dagoretti_south/ward:mutu_ini,Mutu-ini
+ocd-division/country:ke/county:ke-47/ed:dagoretti_south/ward:ngando,Ngando
+ocd-division/country:ke/county:ke-47/ed:dagoretti_south/ward:riruta,Riruta
+ocd-division/country:ke/county:ke-47/ed:dagoretti_south/ward:uthiru_ruthimitu,Uthiru-Ruthimitu
+ocd-division/country:ke/county:ke-47/ed:dagoretti_south/ward:waithaka,Waithaka
+ocd-division/country:ke/county:ke-47/ed:langata/ward:karen,Karen
+ocd-division/country:ke/county:ke-47/ed:langata/ward:nairobi_west,Nairobi West
+ocd-division/country:ke/county:ke-47/ed:langata/ward:mugumu_ini,Mugumu-ini
+ocd-division/country:ke/county:ke-47/ed:langata/ward:south_c,South C
+ocd-division/country:ke/county:ke-47/ed:langata/ward:nyayo_highrise,Nyayo Highrise
+ocd-division/country:ke/county:ke-47/ed:kibra/ward:laini_saba,Laini Saba
+ocd-division/country:ke/county:ke-47/ed:kibra/ward:lindi,Lindi
+ocd-division/country:ke/county:ke-47/ed:kibra/ward:makina,Makina
+ocd-division/country:ke/county:ke-47/ed:kibra/ward:woodley_kenyatta_golf_course,Woodley-Kenyatta Golf Course
+ocd-division/country:ke/county:ke-47/ed:kibra/ward:sarangombe,Sarangombe
+ocd-division/country:ke/county:ke-47/ed:roysambu/ward:githurai,Githurai
+ocd-division/country:ke/county:ke-47/ed:roysambu/ward:kahawa_west,Kahawa West
+ocd-division/country:ke/county:ke-47/ed:roysambu/ward:zimmerman,Zimmerman
+ocd-division/country:ke/county:ke-47/ed:roysambu/ward:roysambu,Roysambu
+ocd-division/country:ke/county:ke-47/ed:roysambu/ward:kahawa,Kahawa
+ocd-division/country:ke/county:ke-47/ed:kasarani/ward:clay_city,Clay City
+ocd-division/country:ke/county:ke-47/ed:kasarani/ward:mwiki,Mwiki
+ocd-division/country:ke/county:ke-47/ed:kasarani/ward:kasarani,Kasarani
+ocd-division/country:ke/county:ke-47/ed:kasarani/ward:njiru,Njiru
+ocd-division/country:ke/county:ke-47/ed:kasarani/ward:ruai,Ruai
+ocd-division/country:ke/county:ke-47/ed:ruaraka/ward:baba_dogo,Baba Dogo
+ocd-division/country:ke/county:ke-47/ed:ruaraka/ward:utalii,Utalii
+ocd-division/country:ke/county:ke-47/ed:ruaraka/ward:mathare_north,Mathare North
+ocd-division/country:ke/county:ke-47/ed:ruaraka/ward:lucky_summer,Lucky Summer
+ocd-division/country:ke/county:ke-47/ed:ruaraka/ward:korogocho,Korogocho
+ocd-division/country:ke/county:ke-47/ed:embakasi_south/ward:imara_daima,Imara Daima
+ocd-division/country:ke/county:ke-47/ed:embakasi_south/ward:kwa_njenga,Kwa Njenga
+ocd-division/country:ke/county:ke-47/ed:embakasi_south/ward:kwa_reuben,Kwa Reuben
+ocd-division/country:ke/county:ke-47/ed:embakasi_south/ward:pipeline,Pipeline
+ocd-division/country:ke/county:ke-47/ed:embakasi_south/ward:kware,Kware
+ocd-division/country:ke/county:ke-47/ed:embakasi_north/ward:kariobangi_north,Kariobangi North
+ocd-division/country:ke/county:ke-47/ed:embakasi_north/ward:dandora_area_i,Dandora Area I
+ocd-division/country:ke/county:ke-47/ed:embakasi_north/ward:dandora_area_ii,Dandora Area II
+ocd-division/country:ke/county:ke-47/ed:embakasi_north/ward:dandora_area_iii,Dandora Area III
+ocd-division/country:ke/county:ke-47/ed:embakasi_north/ward:dandora_area_iv,Dandora Area IV
+ocd-division/country:ke/county:ke-47/ed:embakasi_central/ward:kayole_north,Kayole North
+ocd-division/country:ke/county:ke-47/ed:embakasi_central/ward:kayole_central,Kayole Central
+ocd-division/country:ke/county:ke-47/ed:embakasi_central/ward:kayole_south,Kayole South
+ocd-division/country:ke/county:ke-47/ed:embakasi_central/ward:komarock,Komarock
+ocd-division/country:ke/county:ke-47/ed:embakasi_central/ward:matopeni_spring_valley,Matopeni-Spring Valley
+ocd-division/country:ke/county:ke-47/ed:embakasi_east/ward:upper_savannah,Upper Savannah
+ocd-division/country:ke/county:ke-47/ed:embakasi_east/ward:lower_savannah,Lower Savannah
+ocd-division/country:ke/county:ke-47/ed:embakasi_east/ward:embakasi,Embakasi
+ocd-division/country:ke/county:ke-47/ed:embakasi_east/ward:utawala,Utawala
+ocd-division/country:ke/county:ke-47/ed:embakasi_east/ward:mihango,Mihango
+ocd-division/country:ke/county:ke-47/ed:embakasi_west/ward:umoja_i,Umoja I
+ocd-division/country:ke/county:ke-47/ed:embakasi_west/ward:umoja_ii,Umoja II
+ocd-division/country:ke/county:ke-47/ed:embakasi_west/ward:mowlem,Mowlem
+ocd-division/country:ke/county:ke-47/ed:embakasi_west/ward:kariobangi_south,Kariobangi South
+ocd-division/country:ke/county:ke-47/ed:makadara/ward:maringo_hamza,Maringo-Hamza
+ocd-division/country:ke/county:ke-47/ed:makadara/ward:viwandani,Viwandani
+ocd-division/country:ke/county:ke-47/ed:makadara/ward:harambee,Harambee
+ocd-division/country:ke/county:ke-47/ed:makadara/ward:makongeni,Makongeni
+ocd-division/country:ke/county:ke-47/ed:kamukunji/ward:pumwani,Pumwani
+ocd-division/country:ke/county:ke-47/ed:kamukunji/ward:eastleigh_north,Eastleigh North
+ocd-division/country:ke/county:ke-47/ed:kamukunji/ward:eastleigh_south,Eastleigh South
+ocd-division/country:ke/county:ke-47/ed:kamukunji/ward:airbase,Airbase
+ocd-division/country:ke/county:ke-47/ed:kamukunji/ward:california,California
+ocd-division/country:ke/county:ke-47/ed:starehe/ward:nairobi_central,Nairobi Central
+ocd-division/country:ke/county:ke-47/ed:starehe/ward:ngara,Ngara
+ocd-division/country:ke/county:ke-47/ed:starehe/ward:pangani,Pangani
+ocd-division/country:ke/county:ke-47/ed:starehe/ward:ziwani_kariokor,Ziwani-Kariokor
+ocd-division/country:ke/county:ke-47/ed:starehe/ward:landimawe,Landimawe
+ocd-division/country:ke/county:ke-47/ed:starehe/ward:nairobi_south,Nairobi South
+ocd-division/country:ke/county:ke-47/ed:mathare/ward:hospital,Hospital
+ocd-division/country:ke/county:ke-47/ed:mathare/ward:mabatini,Mabatini
+ocd-division/country:ke/county:ke-47/ed:mathare/ward:huruma,Huruma
+ocd-division/country:ke/county:ke-47/ed:mathare/ward:ngei,Ngei
+ocd-division/country:ke/county:ke-47/ed:mathare/ward:mlango_kubwa,Mlango Kubwa
+ocd-division/country:ke/county:ke-47/ed:mathare/ward:kiamaiko,Kiamaiko

--- a/identifiers/country-ke/national_assembly.csv
+++ b/identifiers/country-ke/national_assembly.csv
@@ -1,0 +1,291 @@
+id,name
+ocd-division/country:ke/county:ke-01/ed:changamwe,Changamwe
+ocd-division/country:ke/county:ke-01/ed:jomvu,Jomvu
+ocd-division/country:ke/county:ke-01/ed:kisauni,Kisauni
+ocd-division/country:ke/county:ke-01/ed:nyali,Nyali
+ocd-division/country:ke/county:ke-01/ed:likoni,Likoni
+ocd-division/country:ke/county:ke-01/ed:mvita,Mvita
+ocd-division/country:ke/county:ke-02/ed:msambweni,Msambweni
+ocd-division/country:ke/county:ke-02/ed:lungalunga,Lungalunga
+ocd-division/country:ke/county:ke-02/ed:matuga,Matuga
+ocd-division/country:ke/county:ke-02/ed:kinango,Kinango
+ocd-division/country:ke/county:ke-03/ed:kilifi_north,Kilifi North
+ocd-division/country:ke/county:ke-03/ed:kilifi_south,Kilifi South
+ocd-division/country:ke/county:ke-03/ed:kaloleni,Kaloleni
+ocd-division/country:ke/county:ke-03/ed:rabai,Rabai
+ocd-division/country:ke/county:ke-03/ed:ganze,Ganze
+ocd-division/country:ke/county:ke-03/ed:malindi,Malindi
+ocd-division/country:ke/county:ke-03/ed:magarini,Magarini
+ocd-division/country:ke/county:ke-04/ed:garsen,Garsen
+ocd-division/country:ke/county:ke-04/ed:galole,Galole
+ocd-division/country:ke/county:ke-04/ed:bura,Bura
+ocd-division/country:ke/county:ke-05/ed:lamu_east,Lamu East
+ocd-division/country:ke/county:ke-05/ed:lamu_west,Lamu West
+ocd-division/country:ke/county:ke-06/ed:taveta,Taveta
+ocd-division/country:ke/county:ke-06/ed:wundanyi,Wundanyi
+ocd-division/country:ke/county:ke-06/ed:mwatate,Mwatate
+ocd-division/country:ke/county:ke-06/ed:voi,Voi
+ocd-division/country:ke/county:ke-07/ed:garissa_township,Garissa Township
+ocd-division/country:ke/county:ke-07/ed:balambala,Balambala
+ocd-division/country:ke/county:ke-07/ed:lagdera,Lagdera
+ocd-division/country:ke/county:ke-07/ed:dadaab,Dadaab
+ocd-division/country:ke/county:ke-07/ed:fafi,Fafi
+ocd-division/country:ke/county:ke-07/ed:ijara,Ijara
+ocd-division/country:ke/county:ke-08/ed:wajir_north,Wajir North
+ocd-division/country:ke/county:ke-08/ed:wajir_east,Wajir East
+ocd-division/country:ke/county:ke-08/ed:tarbaj,Tarbaj
+ocd-division/country:ke/county:ke-08/ed:wajir_west,Wajir West
+ocd-division/country:ke/county:ke-08/ed:eldas,Eldas
+ocd-division/country:ke/county:ke-08/ed:wajir_south,Wajir South
+ocd-division/country:ke/county:ke-09/ed:mandera_west,Mandera West
+ocd-division/country:ke/county:ke-09/ed:banissa,Banissa
+ocd-division/country:ke/county:ke-09/ed:mandera_north,Mandera North
+ocd-division/country:ke/county:ke-09/ed:mandera_south,Mandera South
+ocd-division/country:ke/county:ke-09/ed:mandera_east,Mandera East
+ocd-division/country:ke/county:ke-09/ed:lafey,Lafey
+ocd-division/country:ke/county:ke-10/ed:moyale,Moyale
+ocd-division/country:ke/county:ke-10/ed:north_horr,North Horr
+ocd-division/country:ke/county:ke-10/ed:saku,Saku
+ocd-division/country:ke/county:ke-10/ed:laisamis,Laisamis
+ocd-division/country:ke/county:ke-11/ed:isiolo_north,Isiolo North
+ocd-division/country:ke/county:ke-11/ed:isiolo_south,Isiolo South
+ocd-division/country:ke/county:ke-12/ed:igembe_south,Igembe South
+ocd-division/country:ke/county:ke-12/ed:igembe_central,Igembe Central
+ocd-division/country:ke/county:ke-12/ed:igembe_north,Igembe North
+ocd-division/country:ke/county:ke-12/ed:tigania_west,Tigania West
+ocd-division/country:ke/county:ke-12/ed:tigania_east,Tigania East
+ocd-division/country:ke/county:ke-12/ed:north_imenti,North Imenti
+ocd-division/country:ke/county:ke-12/ed:buuri,Buuri
+ocd-division/country:ke/county:ke-12/ed:central_imenti,Central Imenti
+ocd-division/country:ke/county:ke-12/ed:south_imenti,South Imenti
+ocd-division/country:ke/county:ke-13/ed:maara,Maara
+ocd-division/country:ke/county:ke-13/ed:chuka_igambangombe,Chuka Igambang'Ombe
+ocd-division/country:ke/county:ke-13/ed:tharaka,Tharaka
+ocd-division/country:ke/county:ke-14/ed:manyatta,Manyatta
+ocd-division/country:ke/county:ke-14/ed:runyenjes,Runyenjes
+ocd-division/country:ke/county:ke-14/ed:mbeere_south,Mbeere South
+ocd-division/country:ke/county:ke-14/ed:mbeere_north,Mbeere North
+ocd-division/country:ke/county:ke-15/ed:mwingi_north,Mwingi North
+ocd-division/country:ke/county:ke-15/ed:mwingi_west,Mwingi West
+ocd-division/country:ke/county:ke-15/ed:mwingi_central,Mwingi Central
+ocd-division/country:ke/county:ke-15/ed:kitui_west,Kitui West
+ocd-division/country:ke/county:ke-15/ed:kitui_rural,Kitui Rural
+ocd-division/country:ke/county:ke-15/ed:kitui_central,Kitui Central
+ocd-division/country:ke/county:ke-15/ed:kitui_east,Kitui East
+ocd-division/country:ke/county:ke-15/ed:kitui_south,Kitui South
+ocd-division/country:ke/county:ke-16/ed:masinga,Masinga
+ocd-division/country:ke/county:ke-16/ed:yatta,Yatta
+ocd-division/country:ke/county:ke-16/ed:kangundo,Kangundo
+ocd-division/country:ke/county:ke-16/ed:matungulu,Matungulu
+ocd-division/country:ke/county:ke-16/ed:kathiani,Kathiani
+ocd-division/country:ke/county:ke-16/ed:mavoko,Mavoko
+ocd-division/country:ke/county:ke-16/ed:machakos_town,Machakos Town
+ocd-division/country:ke/county:ke-16/ed:mwala,Mwala
+ocd-division/country:ke/county:ke-17/ed:mbooni,Mbooni
+ocd-division/country:ke/county:ke-17/ed:kilome,Kilome
+ocd-division/country:ke/county:ke-17/ed:kaiti,Kaiti
+ocd-division/country:ke/county:ke-17/ed:makueni,Makueni
+ocd-division/country:ke/county:ke-17/ed:kibwezi_west,Kibwezi West
+ocd-division/country:ke/county:ke-17/ed:kibwezi_east,Kibwezi East
+ocd-division/country:ke/county:ke-18/ed:kinangop,Kinangop
+ocd-division/country:ke/county:ke-18/ed:kipipiri,Kipipiri
+ocd-division/country:ke/county:ke-18/ed:ol_kalou,Ol Kalou
+ocd-division/country:ke/county:ke-18/ed:ol_jorok,Ol Jorok
+ocd-division/country:ke/county:ke-18/ed:ndaragwa,Ndaragwa
+ocd-division/country:ke/county:ke-19/ed:tetu,Tetu
+ocd-division/country:ke/county:ke-19/ed:kieni,Kieni
+ocd-division/country:ke/county:ke-19/ed:mathira,Mathira
+ocd-division/country:ke/county:ke-19/ed:othaya,Othaya
+ocd-division/country:ke/county:ke-19/ed:mukurweini,Mukurweini
+ocd-division/country:ke/county:ke-19/ed:nyeri_town,Nyeri Town
+ocd-division/country:ke/county:ke-20/ed:mwea,Mwea
+ocd-division/country:ke/county:ke-20/ed:gichugu,Gichugu
+ocd-division/country:ke/county:ke-20/ed:ndia,Ndia
+ocd-division/country:ke/county:ke-20/ed:kirinyaga_central,Kirinyaga Central
+ocd-division/country:ke/county:ke-21/ed:kangema,Kangema
+ocd-division/country:ke/county:ke-21/ed:mathioya,Mathioya
+ocd-division/country:ke/county:ke-21/ed:kiharu,Kiharu
+ocd-division/country:ke/county:ke-21/ed:kigumo,Kigumo
+ocd-division/country:ke/county:ke-21/ed:maragwa,Maragwa
+ocd-division/country:ke/county:ke-21/ed:kandara,Kandara
+ocd-division/country:ke/county:ke-21/ed:gatanga,Gatanga
+ocd-division/country:ke/county:ke-22/ed:gatundu_south,Gatundu South
+ocd-division/country:ke/county:ke-22/ed:gatundu_north,Gatundu North
+ocd-division/country:ke/county:ke-22/ed:juja,Juja
+ocd-division/country:ke/county:ke-22/ed:thika_town,Thika Town
+ocd-division/country:ke/county:ke-22/ed:ruiru,Ruiru
+ocd-division/country:ke/county:ke-22/ed:githunguri,Githunguri
+ocd-division/country:ke/county:ke-22/ed:kiambu,Kiambu
+ocd-division/country:ke/county:ke-22/ed:kiambaa,Kiambaa
+ocd-division/country:ke/county:ke-22/ed:kabete,Kabete
+ocd-division/country:ke/county:ke-22/ed:kikuyu,Kikuyu
+ocd-division/country:ke/county:ke-22/ed:limuru,Limuru
+ocd-division/country:ke/county:ke-22/ed:lari,Lari
+ocd-division/country:ke/county:ke-23/ed:turkana_north,Turkana North
+ocd-division/country:ke/county:ke-23/ed:turkana_west,Turkana West
+ocd-division/country:ke/county:ke-23/ed:turkana_central,Turkana Central
+ocd-division/country:ke/county:ke-23/ed:loima,Loima
+ocd-division/country:ke/county:ke-23/ed:turkana_south,Turkana South
+ocd-division/country:ke/county:ke-23/ed:turkana_east,Turkana East
+ocd-division/country:ke/county:ke-24/ed:kapenguria,Kapenguria
+ocd-division/country:ke/county:ke-24/ed:sigor,Sigor
+ocd-division/country:ke/county:ke-24/ed:kacheliba,Kacheliba
+ocd-division/country:ke/county:ke-24/ed:pokot_south,Pokot South
+ocd-division/country:ke/county:ke-25/ed:samburu_west,Samburu West
+ocd-division/country:ke/county:ke-25/ed:samburu_north,Samburu North
+ocd-division/country:ke/county:ke-25/ed:samburu_east,Samburu East
+ocd-division/country:ke/county:ke-26/ed:kwanza,Kwanza
+ocd-division/country:ke/county:ke-26/ed:endebess,Endebess
+ocd-division/country:ke/county:ke-26/ed:saboti,Saboti
+ocd-division/country:ke/county:ke-26/ed:kiminini,Kiminini
+ocd-division/country:ke/county:ke-26/ed:cherangany,Cherangany
+ocd-division/country:ke/county:ke-27/ed:soy,Soy
+ocd-division/country:ke/county:ke-27/ed:turbo,Turbo
+ocd-division/country:ke/county:ke-27/ed:moiben,Moiben
+ocd-division/country:ke/county:ke-27/ed:ainabkoi,Ainabkoi
+ocd-division/country:ke/county:ke-27/ed:kapseret,Kapseret
+ocd-division/country:ke/county:ke-27/ed:kesses,Kesses
+ocd-division/country:ke/county:ke-28/ed:marakwet_east,Marakwet East
+ocd-division/country:ke/county:ke-28/ed:marakwet_west,Marakwet West
+ocd-division/country:ke/county:ke-28/ed:keiyo_north,Keiyo North
+ocd-division/country:ke/county:ke-28/ed:keiyo_south,Keiyo South
+ocd-division/country:ke/county:ke-29/ed:tinderet,Tinderet
+ocd-division/country:ke/county:ke-29/ed:aldai,Aldai
+ocd-division/country:ke/county:ke-29/ed:nandi_hills,Nandi Hills
+ocd-division/country:ke/county:ke-29/ed:chesumei,Chesumei
+ocd-division/country:ke/county:ke-29/ed:emgwen,Emgwen
+ocd-division/country:ke/county:ke-29/ed:mosop,Mosop
+ocd-division/country:ke/county:ke-30/ed:tiaty,Tiaty
+ocd-division/country:ke/county:ke-30/ed:baringo_north,Baringo North
+ocd-division/country:ke/county:ke-30/ed:baringo_central,Baringo Central
+ocd-division/country:ke/county:ke-30/ed:baringo_south,Baringo South
+ocd-division/country:ke/county:ke-30/ed:mogotio,Mogotio
+ocd-division/country:ke/county:ke-30/ed:eldama_ravine,Eldama Ravine
+ocd-division/country:ke/county:ke-31/ed:laikipia_west,Laikipia West
+ocd-division/country:ke/county:ke-31/ed:laikipia_east,Laikipia East
+ocd-division/country:ke/county:ke-31/ed:laikipia_north,Laikipia North
+ocd-division/country:ke/county:ke-32/ed:molo,Molo
+ocd-division/country:ke/county:ke-32/ed:njoro,Njoro
+ocd-division/country:ke/county:ke-32/ed:naivasha,Naivasha
+ocd-division/country:ke/county:ke-32/ed:gilgil,Gilgil
+ocd-division/country:ke/county:ke-32/ed:kuresoi_south,Kuresoi South
+ocd-division/country:ke/county:ke-32/ed:kuresoi_north,Kuresoi North
+ocd-division/country:ke/county:ke-32/ed:subukia,Subukia
+ocd-division/country:ke/county:ke-32/ed:rongai,Rongai
+ocd-division/country:ke/county:ke-32/ed:bahati,Bahati
+ocd-division/country:ke/county:ke-32/ed:nakuru_town_west,Nakuru Town West
+ocd-division/country:ke/county:ke-32/ed:nakuru_town_east,Nakuru Town East
+ocd-division/country:ke/county:ke-33/ed:kilgoris,Kilgoris
+ocd-division/country:ke/county:ke-33/ed:emurua_dikirr,Emurua Dikirr
+ocd-division/country:ke/county:ke-33/ed:narok_north,Narok North
+ocd-division/country:ke/county:ke-33/ed:narok_east,Narok East
+ocd-division/country:ke/county:ke-33/ed:narok_south,Narok South
+ocd-division/country:ke/county:ke-33/ed:narok_west,Narok West
+ocd-division/country:ke/county:ke-34/ed:kajiado_north,Kajiado North
+ocd-division/country:ke/county:ke-34/ed:kajiado_central,Kajiado Central
+ocd-division/country:ke/county:ke-34/ed:kajiado_east,Kajiado East
+ocd-division/country:ke/county:ke-34/ed:kajiado_west,Kajiado West
+ocd-division/country:ke/county:ke-34/ed:kajiado_south,Kajiado South
+ocd-division/country:ke/county:ke-35/ed:kipkelion_east,Kipkelion East
+ocd-division/country:ke/county:ke-35/ed:kipkelion_west,Kipkelion West
+ocd-division/country:ke/county:ke-35/ed:ainamoi,Ainamoi
+ocd-division/country:ke/county:ke-35/ed:bureti,Bureti
+ocd-division/country:ke/county:ke-35/ed:belgut,Belgut
+ocd-division/country:ke/county:ke-35/ed:sigowet_soin,Sigowet Soin
+ocd-division/country:ke/county:ke-36/ed:sotik,Sotik
+ocd-division/country:ke/county:ke-36/ed:chepalungu,Chepalungu
+ocd-division/country:ke/county:ke-36/ed:bomet_east,Bomet East
+ocd-division/country:ke/county:ke-36/ed:bomet_central,Bomet Central
+ocd-division/country:ke/county:ke-36/ed:konoin,Konoin
+ocd-division/country:ke/county:ke-37/ed:lugari,Lugari
+ocd-division/country:ke/county:ke-37/ed:likuyani,Likuyani
+ocd-division/country:ke/county:ke-37/ed:malava,Malava
+ocd-division/country:ke/county:ke-37/ed:lurambi,Lurambi
+ocd-division/country:ke/county:ke-37/ed:navakholo,Navakholo
+ocd-division/country:ke/county:ke-37/ed:mumias_west,Mumias West
+ocd-division/country:ke/county:ke-37/ed:mumias_east,Mumias East
+ocd-division/country:ke/county:ke-37/ed:matungu,Matungu
+ocd-division/country:ke/county:ke-37/ed:butere,Butere
+ocd-division/country:ke/county:ke-37/ed:khwisero,Khwisero
+ocd-division/country:ke/county:ke-37/ed:shinyalu,Shinyalu
+ocd-division/country:ke/county:ke-37/ed:ikolomani,Ikolomani
+ocd-division/country:ke/county:ke-38/ed:vihiga,Vihiga
+ocd-division/country:ke/county:ke-38/ed:sabatia,Sabatia
+ocd-division/country:ke/county:ke-38/ed:hamisi,Hamisi
+ocd-division/country:ke/county:ke-38/ed:luanda,Luanda
+ocd-division/country:ke/county:ke-38/ed:emuhaya,Emuhaya
+ocd-division/country:ke/county:ke-39/ed:mt._elgon,Mt. Elgon
+ocd-division/country:ke/county:ke-39/ed:sirisia,Sirisia
+ocd-division/country:ke/county:ke-39/ed:kabuchai,Kabuchai
+ocd-division/country:ke/county:ke-39/ed:bumula,Bumula
+ocd-division/country:ke/county:ke-39/ed:kanduyi,Kanduyi
+ocd-division/country:ke/county:ke-39/ed:webuye_east,Webuye East
+ocd-division/country:ke/county:ke-39/ed:webuye_west,Webuye West
+ocd-division/country:ke/county:ke-39/ed:kimilili,Kimilili
+ocd-division/country:ke/county:ke-39/ed:tongaren,Tongaren
+ocd-division/country:ke/county:ke-40/ed:teso_north,Teso North
+ocd-division/country:ke/county:ke-40/ed:teso_south,Teso South
+ocd-division/country:ke/county:ke-40/ed:nambale,Nambale
+ocd-division/country:ke/county:ke-40/ed:matayos,Matayos
+ocd-division/country:ke/county:ke-40/ed:butula,Butula
+ocd-division/country:ke/county:ke-40/ed:funyula,Funyula
+ocd-division/country:ke/county:ke-40/ed:budalangi,Budalangi
+ocd-division/country:ke/county:ke-41/ed:ugenya,Ugenya
+ocd-division/country:ke/county:ke-41/ed:ugunja,Ugunja
+ocd-division/country:ke/county:ke-41/ed:alego_usonga,Alego Usonga
+ocd-division/country:ke/county:ke-41/ed:gem,Gem
+ocd-division/country:ke/county:ke-41/ed:bondo,Bondo
+ocd-division/country:ke/county:ke-41/ed:rarieda,Rarieda
+ocd-division/country:ke/county:ke-42/ed:kisumu_east,Kisumu East
+ocd-division/country:ke/county:ke-42/ed:kisumu_west,Kisumu West
+ocd-division/country:ke/county:ke-42/ed:kisumu_central,Kisumu Central
+ocd-division/country:ke/county:ke-42/ed:seme,Seme
+ocd-division/country:ke/county:ke-42/ed:nyando,Nyando
+ocd-division/country:ke/county:ke-42/ed:muhoroni,Muhoroni
+ocd-division/country:ke/county:ke-42/ed:nyakach,Nyakach
+ocd-division/country:ke/county:ke-43/ed:kasipul,Kasipul
+ocd-division/country:ke/county:ke-43/ed:kabondo_kasipul,Kabondo Kasipul
+ocd-division/country:ke/county:ke-43/ed:karachuonyo,Karachuonyo
+ocd-division/country:ke/county:ke-43/ed:rangwe,Rangwe
+ocd-division/country:ke/county:ke-43/ed:homa_bay_town,Homa Bay Town
+ocd-division/country:ke/county:ke-43/ed:ndhiwa,Ndhiwa
+ocd-division/country:ke/county:ke-43/ed:suba_north,Suba North
+ocd-division/country:ke/county:ke-43/ed:suba_south,Suba South
+ocd-division/country:ke/county:ke-44/ed:rongo,Rongo
+ocd-division/country:ke/county:ke-44/ed:awendo,Awendo
+ocd-division/country:ke/county:ke-44/ed:suna_east,Suna East
+ocd-division/country:ke/county:ke-44/ed:suna_west,Suna West
+ocd-division/country:ke/county:ke-44/ed:uriri,Uriri
+ocd-division/country:ke/county:ke-44/ed:nyatike,Nyatike
+ocd-division/country:ke/county:ke-44/ed:kuria_west,Kuria West
+ocd-division/country:ke/county:ke-44/ed:kuria_east,Kuria East
+ocd-division/country:ke/county:ke-45/ed:bonchari,Bonchari
+ocd-division/country:ke/county:ke-45/ed:south_mugirango,South Mugirango
+ocd-division/country:ke/county:ke-45/ed:bomachoge_borabu,Bomachoge Borabu
+ocd-division/country:ke/county:ke-45/ed:bobasi,Bobasi
+ocd-division/country:ke/county:ke-45/ed:bomachoge_chache,Bomachoge Chache
+ocd-division/country:ke/county:ke-45/ed:nyaribari_masaba,Nyaribari Masaba
+ocd-division/country:ke/county:ke-45/ed:nyaribari_chache,Nyaribari Chache
+ocd-division/country:ke/county:ke-45/ed:kitutu_chache_north,Kitutu Chache North
+ocd-division/country:ke/county:ke-45/ed:kitutu_chache_south,Kitutu Chache South
+ocd-division/country:ke/county:ke-46/ed:kitutu_masaba,Kitutu Masaba
+ocd-division/country:ke/county:ke-46/ed:west_mugirango,West Mugirango
+ocd-division/country:ke/county:ke-46/ed:north_mugirango,North Mugirango
+ocd-division/country:ke/county:ke-46/ed:borabu,Borabu
+ocd-division/country:ke/county:ke-47/ed:westlands,Westlands
+ocd-division/country:ke/county:ke-47/ed:dagoretti_north,Dagoretti North
+ocd-division/country:ke/county:ke-47/ed:dagoretti_south,Dagoretti South
+ocd-division/country:ke/county:ke-47/ed:langata,Langata
+ocd-division/country:ke/county:ke-47/ed:kibra,Kibra
+ocd-division/country:ke/county:ke-47/ed:roysambu,Roysambu
+ocd-division/country:ke/county:ke-47/ed:kasarani,Kasarani
+ocd-division/country:ke/county:ke-47/ed:ruaraka,Ruaraka
+ocd-division/country:ke/county:ke-47/ed:embakasi_south,Embakasi South
+ocd-division/country:ke/county:ke-47/ed:embakasi_north,Embakasi North
+ocd-division/country:ke/county:ke-47/ed:embakasi_central,Embakasi Central
+ocd-division/country:ke/county:ke-47/ed:embakasi_east,Embakasi East
+ocd-division/country:ke/county:ke-47/ed:embakasi_west,Embakasi West
+ocd-division/country:ke/county:ke-47/ed:makadara,Makadara
+ocd-division/country:ke/county:ke-47/ed:kamukunji,Kamukunji
+ocd-division/country:ke/county:ke-47/ed:starehe,Starehe
+ocd-division/country:ke/county:ke-47/ed:mathare,Mathare


### PR DESCRIPTION
Adding lists for the following administrative divisions of Kenya:

* counties: contains Contains 47 counties of Kenya
* national_assembly: Contains 290 constituencies in Kenya for Kenyan National Assembly
* county_assembly: Contains 1450 wards in Kenya for the 47 County Assemblies. 