### PR TITLE
Nesting Gallatin, MO under county:daviess

### DIFF
--- a/identifiers/country-us/census_autogenerated/us_census_places.csv
+++ b/identifiers/country-us/census_autogenerated/us_census_places.csv
@@ -18889,7 +18889,7 @@ ocd-division/country:us/state:mo/place:frontenac,Frontenac city,place-2926110
 ocd-division/country:us/state:mo/place:fulton,Fulton city,place-2926182
 ocd-division/country:us/state:mo/place:gainesville,Gainesville city,place-2926218
 ocd-division/country:us/state:mo/place:galena,Galena city,place-2926254
-ocd-division/country:us/state:mo/place:gallatin,Gallatin city,place-2926308
+ocd-division/country:us/state:mo/county:daviess/place:gallatin,Gallatin city,place-2926308
 ocd-division/country:us/state:mo/place:galt,Galt city,place-2926362
 ocd-division/country:us/state:mo/place:garden_city,Garden City city,place-2926434
 ocd-division/country:us/state:mo/place:gasconade,Gasconade city,place-2926578


### PR DESCRIPTION
Gallatin, MO is the county seat of Daviess County and there are instances of addresses in Gladstone, MO being incorrectly assigned to the existing `state:mo/place:gallatin` OCDID. Gladstone is a part of Clay County, which contains a [now inactive](https://en.wikipedia.org/wiki/Gallatin_Township,_Clay_County,_Missouri) Gallatin Township. 

This PR is an attempt to disambiguate the active Gallatin City (in Daviess County) with the inactive Gallatin Township (in Clay County). 