### PR TITLE
Add Ladakh as a Union Territory

### DIFF
--- a/identifiers/country-in.csv
+++ b/identifiers/country-in.csv
@@ -6042,7 +6042,8 @@ ocd-division/country:in/territory:dl/lok_sabha:west_delhi,Delhi Lok Sabha consti
 ocd-division/country:in/territory:dn,Dadra and Nagar Haveli,,,,2020-01-25
 ocd-division/country:in/territory:dn/cd:dadra_and_nagar_haveli,Dadra and Nagar Haveli Lok Sabha constituency Dadra and Nagar Haveli (ST),,,,2020-01-25
 ocd-division/country:in/territory:dn/lok_sabha:dadra_and_nagar_haveli,Dadra and Nagar Haveli and Daman and Diu Lok Sabha constituency Nagar Haveli,ocd-division/country:in/territory:dh/cd:dadra_and_nagar_haveli,Updated as per Bill No. 366 of 2019 for Merger of Union Territories,,
-ocd-division/country:in/territory:jk,Jammu and Kashmir and Ladakh,,,2019-10-31,
+ocd-division/country:in/territory:jk,Jammu and Kashmir,,,2019-10-31,
+ocd-division/country:in/territory:la,Ladakh,,,2019-10-31,
 ocd-division/country:in/territory:ld,Lakshadweep,,,,
 ocd-division/country:in/territory:ld/cd:lakshadweep,Lakshadweep Lok Sabha constituency Lakshadweep (ST),,,,
 ocd-division/country:in/territory:ld/lok_sabha:lakshadweep,Lakshadweep Lok Sabha constituency Lakshadweep (ST),ocd-division/country:in/territory:ld/cd:lakshadweep,Added for backwards compatibility with lok_sabha identifiers,,

--- a/identifiers/country-in/federal_states_territories.csv
+++ b/identifiers/country-in/federal_states_territories.csv
@@ -35,6 +35,7 @@ ocd-division/country:in/territory:dd,Daman and Diu,,2020-01-25
 ocd-division/country:in/territory:dh,Dadra and Nagar Haveli and Daman and Diu,2020-01-26,
 ocd-division/country:in/territory:dl,Delhi,,
 ocd-division/country:in/territory:dn,Dadra and Nagar Haveli,,2020-01-25
-ocd-division/country:in/territory:jk,Jammu and Kashmir and Ladakh,2019-10-31,
+ocd-division/country:in/territory:jk,Jammu and Kashmir,2019-10-31,
+ocd-division/country:in/territory:la,Ladakh,2019-10-31,
 ocd-division/country:in/territory:ld,Lakshadweep,,
 ocd-division/country:in/territory:py,Puducherry,,


### PR DESCRIPTION
Add Ladakh as a Union Territory, it should be separate from Jammu and Kashmir since 2019-10-31.

https://en.wikipedia.org/wiki/Jammu_and_Kashmir_(union_territory)
https://en.wikipedia.org/wiki/Ladakh