### PR TITLE
Add Lok Sabha districts for territory:jk

### DIFF
--- a/identifiers/country-in.csv
+++ b/identifiers/country-in.csv
@@ -1761,12 +1761,12 @@ ocd-division/country:in/state:jh/lok_sabha:rajmahal,Jharkhand Lok Sabha constitu
 ocd-division/country:in/state:jh/lok_sabha:ranchi,Jharkhand Lok Sabha constituency Ranchi,ocd-division/country:in/state:jh/cd:ranchi,Added for backwards compatibility with lok_sabha identifiers,,
 ocd-division/country:in/state:jh/lok_sabha:singhbhum,Jharkhand Lok Sabha constituency Singhbhum (ST),ocd-division/country:in/state:jh/cd:singhbhum,Added for backwards compatibility with lok_sabha identifiers,,
 ocd-division/country:in/state:jk,Jammu and Kashmir,,,,2019-10-30
-ocd-division/country:in/state:jk/cd:anantnag,Jammu and Kashmir Lok Sabha constituency Anantnag,,,,
-ocd-division/country:in/state:jk/cd:baramulla,Jammu and Kashmir Lok Sabha constituency Baramulla,,,,
-ocd-division/country:in/state:jk/cd:jammu,Jammu and Kashmir Lok Sabha constituency Jammu,,,,
-ocd-division/country:in/state:jk/cd:ladakh,Jammu and Kashmir Lok Sabha constituency Ladakh,,,,
-ocd-division/country:in/state:jk/cd:srinagar,Jammu and Kashmir Lok Sabha constituency Srinagar,,,,
-ocd-division/country:in/state:jk/cd:udhampur,Jammu and Kashmir Lok Sabha constituency Udhampur,,,,
+ocd-division/country:in/state:jk/cd:anantnag,Jammu and Kashmir Lok Sabha constituency Anantnag,,,,2019-10-30
+ocd-division/country:in/state:jk/cd:baramulla,Jammu and Kashmir Lok Sabha constituency Baramulla,,,,2019-10-30
+ocd-division/country:in/state:jk/cd:jammu,Jammu and Kashmir Lok Sabha constituency Jammu,,,,2019-10-30
+ocd-division/country:in/state:jk/cd:ladakh,Jammu and Kashmir Lok Sabha constituency Ladakh,,,,2019-10-30
+ocd-division/country:in/state:jk/cd:srinagar,Jammu and Kashmir Lok Sabha constituency Srinagar,,,,2019-10-30
+ocd-division/country:in/state:jk/cd:udhampur,Jammu and Kashmir Lok Sabha constituency Udhampur,,,,2019-10-30
 ocd-division/country:in/state:jk/lok_sabha:anantnag,Jammu and Kashmir Lok Sabha constituency Anantnag,ocd-division/country:in/state:jk/cd:anantnag,Added for backwards compatibility with lok_sabha identifiers,,
 ocd-division/country:in/state:jk/lok_sabha:baramulla,Jammu and Kashmir Lok Sabha constituency Baramulla,ocd-division/country:in/state:jk/cd:baramulla,Added for backwards compatibility with lok_sabha identifiers,,
 ocd-division/country:in/state:jk/lok_sabha:jammu,Jammu and Kashmir Lok Sabha constituency Jammu,ocd-division/country:in/state:jk/cd:jammu,Added for backwards compatibility with lok_sabha identifiers,,
@@ -6043,6 +6043,12 @@ ocd-division/country:in/territory:dn,Dadra and Nagar Haveli,,,,2020-01-25
 ocd-division/country:in/territory:dn/cd:dadra_and_nagar_haveli,Dadra and Nagar Haveli Lok Sabha constituency Dadra and Nagar Haveli (ST),,,,2020-01-25
 ocd-division/country:in/territory:dn/lok_sabha:dadra_and_nagar_haveli,Dadra and Nagar Haveli and Daman and Diu Lok Sabha constituency Nagar Haveli,ocd-division/country:in/territory:dh/cd:dadra_and_nagar_haveli,Updated as per Bill No. 366 of 2019 for Merger of Union Territories,,
 ocd-division/country:in/territory:jk,Jammu and Kashmir,,,2019-10-31,
+ocd-division/country:in/territory:jk/cd:anantnag,Jammu and Kashmir Lok Sabha constituency Anantnag,,,2019-10-31,
+ocd-division/country:in/territory:jk/cd:baramulla,Jammu and Kashmir Lok Sabha constituency Baramulla,,,2019-10-31,
+ocd-division/country:in/territory:jk/cd:jammu,Jammu and Kashmir Lok Sabha constituency Jammu,,,2019-10-31,
+ocd-division/country:in/territory:jk/cd:ladakh,Jammu and Kashmir Lok Sabha constituency Ladakh,,,2019-10-31,
+ocd-division/country:in/territory:jk/cd:srinagar,Jammu and Kashmir Lok Sabha constituency Srinagar,,,2019-10-31,
+ocd-division/country:in/territory:jk/cd:udhampur,Jammu and Kashmir Lok Sabha constituency Udhampur,,,2019-10-31,
 ocd-division/country:in/territory:la,Ladakh,,,2019-10-31,
 ocd-division/country:in/territory:ld,Lakshadweep,,,,
 ocd-division/country:in/territory:ld/cd:lakshadweep,Lakshadweep Lok Sabha constituency Lakshadweep (ST),,,,

--- a/identifiers/country-in/lok_sabha.csv
+++ b/identifiers/country-in/lok_sabha.csv
@@ -149,12 +149,12 @@ ocd-division/country:in/state:jh/cd:palamau,Jharkhand Lok Sabha constituency Pal
 ocd-division/country:in/state:jh/cd:rajmahal,Jharkhand Lok Sabha constituency Rajmahal (ST),,
 ocd-division/country:in/state:jh/cd:ranchi,Jharkhand Lok Sabha constituency Ranchi,,
 ocd-division/country:in/state:jh/cd:singhbhum,Jharkhand Lok Sabha constituency Singhbhum (ST),,
-ocd-division/country:in/state:jk/cd:anantnag,Jammu and Kashmir Lok Sabha constituency Anantnag,,
-ocd-division/country:in/state:jk/cd:baramulla,Jammu and Kashmir Lok Sabha constituency Baramulla,,
-ocd-division/country:in/state:jk/cd:jammu,Jammu and Kashmir Lok Sabha constituency Jammu,,
-ocd-division/country:in/state:jk/cd:ladakh,Jammu and Kashmir Lok Sabha constituency Ladakh,,
-ocd-division/country:in/state:jk/cd:srinagar,Jammu and Kashmir Lok Sabha constituency Srinagar,,
-ocd-division/country:in/state:jk/cd:udhampur,Jammu and Kashmir Lok Sabha constituency Udhampur,,
+ocd-division/country:in/state:jk/cd:anantnag,Jammu and Kashmir Lok Sabha constituency Anantnag,,2019-10-30
+ocd-division/country:in/state:jk/cd:baramulla,Jammu and Kashmir Lok Sabha constituency Baramulla,,2019-10-30
+ocd-division/country:in/state:jk/cd:jammu,Jammu and Kashmir Lok Sabha constituency Jammu,,2019-10-30
+ocd-division/country:in/state:jk/cd:ladakh,Jammu and Kashmir Lok Sabha constituency Ladakh,,2019-10-30
+ocd-division/country:in/state:jk/cd:srinagar,Jammu and Kashmir Lok Sabha constituency Srinagar,,2019-10-30
+ocd-division/country:in/state:jk/cd:udhampur,Jammu and Kashmir Lok Sabha constituency Udhampur,,2019-10-30
 ocd-division/country:in/state:ka/cd:bagalkot,Karnataka Lok Sabha constituency Bagalkot,,
 ocd-division/country:in/state:ka/cd:bangalore_central,Karnataka Lok Sabha constituency Bangalore Central,,
 ocd-division/country:in/state:ka/cd:bangalore_north,Karnataka Lok Sabha constituency Bangalore North,,
@@ -544,5 +544,11 @@ ocd-division/country:in/territory:dl/cd:north_west_delhi,Delhi Lok Sabha constit
 ocd-division/country:in/territory:dl/cd:south_delhi,Delhi Lok Sabha constituency South Delhi,,
 ocd-division/country:in/territory:dl/cd:west_delhi,Delhi Lok Sabha constituency West Delhi,,
 ocd-division/country:in/territory:dn/cd:dadra_and_nagar_haveli,Dadra and Nagar Haveli Lok Sabha constituency Dadra and Nagar Haveli (ST),,2020-01-25
+ocd-division/country:in/territory:jk/cd:anantnag,Jammu and Kashmir Lok Sabha constituency Anantnag,2019-10-31,
+ocd-division/country:in/territory:jk/cd:baramulla,Jammu and Kashmir Lok Sabha constituency Baramulla,2019-10-31,
+ocd-division/country:in/territory:jk/cd:jammu,Jammu and Kashmir Lok Sabha constituency Jammu,2019-10-31,
+ocd-division/country:in/territory:jk/cd:ladakh,Jammu and Kashmir Lok Sabha constituency Ladakh,2019-10-31,
+ocd-division/country:in/territory:jk/cd:srinagar,Jammu and Kashmir Lok Sabha constituency Srinagar,2019-10-31,
+ocd-division/country:in/territory:jk/cd:udhampur,Jammu and Kashmir Lok Sabha constituency Udhampur,2019-10-31,
 ocd-division/country:in/territory:ld/cd:lakshadweep,Lakshadweep Lok Sabha constituency Lakshadweep (ST),,
 ocd-division/country:in/territory:py/cd:puducherry,Puducherry Lok Sabha constituency Puducherry,,


### PR DESCRIPTION
Updating Lok Sabha constituencies since `state:jk` becomes `territory:jk` from October 2019. 