### PR TITLE
Update US state legislative districts for 2020 census redistricting

### DIFF
--- a/identifiers/country-us/census_autogenerated/us_sldl.csv
+++ b/identifiers/country-us/census_autogenerated/us_sldl.csv
@@ -4872,6 +4872,8 @@ ocd-division/country:us/state:wy/sldl:57,Wyoming State House district 57
 ocd-division/country:us/state:wy/sldl:58,Wyoming State House district 58
 ocd-division/country:us/state:wy/sldl:59,Wyoming State House district 59
 ocd-division/country:us/state:wy/sldl:60,Wyoming State House district 60
+ocd-division/country:us/state:wy/sldl:61,Wyoming State House district 61
+ocd-division/country:us/state:wy/sldl:62,Wyoming State House district 62
 ocd-division/country:us/territory:pr/sldl:1,Puerto Rico State House district 1
 ocd-division/country:us/territory:pr/sldl:2,Puerto Rico State House district 2
 ocd-division/country:us/territory:pr/sldl:3,Puerto Rico State House district 3

--- a/identifiers/country-us/census_autogenerated/us_sldl.csv
+++ b/identifiers/country-us/census_autogenerated/us_sldl.csv
@@ -4325,50 +4325,75 @@ ocd-division/country:us/state:vt/sldl:addison-4,Vermont Addison-4 State House di
 ocd-division/country:us/state:vt/sldl:addison-5,Vermont Addison-5 State House district
 ocd-division/country:us/state:vt/sldl:addison-rutland,Vermont Addison-Rutland State House district
 ocd-division/country:us/state:vt/sldl:bennington-1,Vermont Bennington-1 State House district
+ocd-division/country:us/state:vt/sldl:bennington-2,Vermont Bennington-2 State House district
 ocd-division/country:us/state:vt/sldl:bennington-3,Vermont Bennington-3 State House district
 ocd-division/country:us/state:vt/sldl:bennington-4,Vermont Bennington-4 State House district
 ocd-division/country:us/state:vt/sldl:bennington-rutland,Vermont Bennington-Rutland State House district
-ocd-division/country:us/state:vt/sldl:bennington-2-1,Vermont Bennington-2-1 State House district
-ocd-division/country:us/state:vt/sldl:bennington-2-2,Vermont Bennington-2-2 State House district
+ocd-division/country:us/state:vt/sldl:bennington-2-1,Vermont Bennington-2-1 State House district (obsolete)
+ocd-division/country:us/state:vt/sldl:bennington-2-2,Vermont Bennington-2-2 State House district (obsolete)
 ocd-division/country:us/state:vt/sldl:chittenden-1,Vermont Chittenden-1 State House district
 ocd-division/country:us/state:vt/sldl:chittenden-2,Vermont Chittenden-2 State House district
 ocd-division/country:us/state:vt/sldl:chittenden-3,Vermont Chittenden-3 State House district
+ocd-division/country:us/state:vt/sldl:chittenden-4,Vermont Chittenden-4 State House district
+ocd-division/country:us/state:vt/sldl:chittenden-5,Vermont Chittenden-5 State House district
+ocd-division/country:us/state:vt/sldl:chittenden-6,Vermont Chittenden-6 State House district
+ocd-division/country:us/state:vt/sldl:chittenden-7,Vermont Chittenden-7 State House district
+ocd-division/country:us/state:vt/sldl:chittenden-8,Vermont Chittenden-8 State House district
+ocd-division/country:us/state:vt/sldl:chittenden-9,Vermont Chittenden-9 State House district
 ocd-division/country:us/state:vt/sldl:chittenden-10,Vermont Chittenden-10 State House district
-ocd-division/country:us/state:vt/sldl:chittenden-4-1,Vermont Chittenden-4-1 State House district
-ocd-division/country:us/state:vt/sldl:chittenden-4-2,Vermont Chittenden-4-2 State House district
-ocd-division/country:us/state:vt/sldl:chittenden-5-1,Vermont Chittenden-5-1 State House district
-ocd-division/country:us/state:vt/sldl:chittenden-5-2,Vermont Chittenden-5-2 State House district
-ocd-division/country:us/state:vt/sldl:chittenden-6-1,Vermont Chittenden-6-1 State House district
-ocd-division/country:us/state:vt/sldl:chittenden-6-2,Vermont Chittenden-6-2 State House district
-ocd-division/country:us/state:vt/sldl:chittenden-6-3,Vermont Chittenden-6-3 State House district
-ocd-division/country:us/state:vt/sldl:chittenden-6-4,Vermont Chittenden-6-4 State House district
-ocd-division/country:us/state:vt/sldl:chittenden-6-5,Vermont Chittenden-6-5 State House district
-ocd-division/country:us/state:vt/sldl:chittenden-6-6,Vermont Chittenden-6-6 State House district
-ocd-division/country:us/state:vt/sldl:chittenden-6-7,Vermont Chittenden-6-7 State House district
-ocd-division/country:us/state:vt/sldl:chittenden-7-1,Vermont Chittenden-7-1 State House district
-ocd-division/country:us/state:vt/sldl:chittenden-7-2,Vermont Chittenden-7-2 State House district
-ocd-division/country:us/state:vt/sldl:chittenden-7-3,Vermont Chittenden-7-3 State House district
-ocd-division/country:us/state:vt/sldl:chittenden-7-4,Vermont Chittenden-7-4 State House district
-ocd-division/country:us/state:vt/sldl:chittenden-8-1,Vermont Chittenden-8-1 State House district
-ocd-division/country:us/state:vt/sldl:chittenden-8-2,Vermont Chittenden-8-2 State House district
-ocd-division/country:us/state:vt/sldl:chittenden-8-3,Vermont Chittenden-8-3 State House district
-ocd-division/country:us/state:vt/sldl:chittenden-9-1,Vermont Chittenden-9-1 State House district
-ocd-division/country:us/state:vt/sldl:chittenden-9-2,Vermont Chittenden-9-2 State House district
+ocd-division/country:us/state:vt/sldl:chittenden-11,Vermont Chittenden-11 State House district
+ocd-division/country:us/state:vt/sldl:chittenden-12,Vermont Chittenden-12 State House district
+ocd-division/country:us/state:vt/sldl:chittenden-13,Vermont Chittenden-13 State House district
+ocd-division/country:us/state:vt/sldl:chittenden-14,Vermont Chittenden-14 State House district
+ocd-division/country:us/state:vt/sldl:chittenden-15,Vermont Chittenden-15 State House district
+ocd-division/country:us/state:vt/sldl:chittenden-16,Vermont Chittenden-16 State House district
+ocd-division/country:us/state:vt/sldl:chittenden-17,Vermont Chittenden-17 State House district
+ocd-division/country:us/state:vt/sldl:chittenden-18,Vermont Chittenden-18 State House district
+ocd-division/country:us/state:vt/sldl:chittenden-19,Vermont Chittenden-19 State House district
+ocd-division/country:us/state:vt/sldl:chittenden-20,Vermont Chittenden-20 State House district
+ocd-division/country:us/state:vt/sldl:chittenden-21,Vermont Chittenden-21 State House district
+ocd-division/country:us/state:vt/sldl:chittenden-22,Vermont Chittenden-22 State House district
+ocd-division/country:us/state:vt/sldl:chittenden-23,Vermont Chittenden-23 State House district
+ocd-division/country:us/state:vt/sldl:chittenden-24,Vermont Chittenden-24 State House district
+ocd-division/country:us/state:vt/sldl:chittenden-25,Vermont Chittenden-25 State House district
+ocd-division/country:us/state:vt/sldl:chittenden-4-1,Vermont Chittenden-4-1 State House district (obsolete)
+ocd-division/country:us/state:vt/sldl:chittenden-4-2,Vermont Chittenden-4-2 State House district (obsolete)
+ocd-division/country:us/state:vt/sldl:chittenden-5-1,Vermont Chittenden-5-1 State House district (obsolete)
+ocd-division/country:us/state:vt/sldl:chittenden-5-2,Vermont Chittenden-5-2 State House district (obsolete)
+ocd-division/country:us/state:vt/sldl:chittenden-6-1,Vermont Chittenden-6-1 State House district (obsolete)
+ocd-division/country:us/state:vt/sldl:chittenden-6-2,Vermont Chittenden-6-2 State House district (obsolete)
+ocd-division/country:us/state:vt/sldl:chittenden-6-3,Vermont Chittenden-6-3 State House district (obsolete)
+ocd-division/country:us/state:vt/sldl:chittenden-6-4,Vermont Chittenden-6-4 State House district (obsolete)
+ocd-division/country:us/state:vt/sldl:chittenden-6-5,Vermont Chittenden-6-5 State House district (obsolete)
+ocd-division/country:us/state:vt/sldl:chittenden-6-6,Vermont Chittenden-6-6 State House district (obsolete)
+ocd-division/country:us/state:vt/sldl:chittenden-6-7,Vermont Chittenden-6-7 State House district (obsolete)
+ocd-division/country:us/state:vt/sldl:chittenden-7-1,Vermont Chittenden-7-1 State House district (obsolete)
+ocd-division/country:us/state:vt/sldl:chittenden-7-2,Vermont Chittenden-7-2 State House district (obsolete)
+ocd-division/country:us/state:vt/sldl:chittenden-7-3,Vermont Chittenden-7-3 State House district (obsolete)
+ocd-division/country:us/state:vt/sldl:chittenden-7-4,Vermont Chittenden-7-4 State House district (obsolete)
+ocd-division/country:us/state:vt/sldl:chittenden-8-1,Vermont Chittenden-8-1 State House district (obsolete)
+ocd-division/country:us/state:vt/sldl:chittenden-8-2,Vermont Chittenden-8-2 State House district (obsolete)
+ocd-division/country:us/state:vt/sldl:chittenden-8-3,Vermont Chittenden-8-3 State House district (obsolete)
+ocd-division/country:us/state:vt/sldl:chittenden-9-1,Vermont Chittenden-9-1 State House district (obsolete)
+ocd-division/country:us/state:vt/sldl:chittenden-9-2,Vermont Chittenden-9-2 State House district (obsolete)
+ocd-division/country:us/state:vt/sldl:chittenden-franklin,Vermont Chittenden-Franklin State House district
 ocd-division/country:us/state:vt/sldl:caledonia-1,Vermont Caledonia-1 State House district
 ocd-division/country:us/state:vt/sldl:caledonia-2,Vermont Caledonia-2 State House district
 ocd-division/country:us/state:vt/sldl:caledonia-3,Vermont Caledonia-3 State House district
 ocd-division/country:us/state:vt/sldl:caledonia-4,Vermont Caledonia-4 State House district
 ocd-division/country:us/state:vt/sldl:caledonia-washington,Vermont Caledonia-Washington State House district
 ocd-division/country:us/state:vt/sldl:essex-caledonia,Vermont Essex-Caledonia State House district
-ocd-division/country:us/state:vt/sldl:essex-caledonia-orleans,Vermont Essex-Caledonia-Orleans State House district
+ocd-division/country:us/state:vt/sldl:essex-orleans,Vermont Essex-Orleans State House district
+ocd-division/country:us/state:vt/sldl:essex-caledonia-orleans,Vermont Essex-Caledonia-Orleans State House district (obsolete)
 ocd-division/country:us/state:vt/sldl:franklin-1,Vermont Franklin-1 State House district
 ocd-division/country:us/state:vt/sldl:franklin-2,Vermont Franklin-2 State House district
 ocd-division/country:us/state:vt/sldl:franklin-4,Vermont Franklin-4 State House district
 ocd-division/country:us/state:vt/sldl:franklin-5,Vermont Franklin-5 State House district
 ocd-division/country:us/state:vt/sldl:franklin-6,Vermont Franklin-6 State House district
 ocd-division/country:us/state:vt/sldl:franklin-7,Vermont Franklin-7 State House district
-ocd-division/country:us/state:vt/sldl:franklin-3-1,Vermont Franklin-3-1 State House district
-ocd-division/country:us/state:vt/sldl:franklin-3-2,Vermont Franklin-3-2 State House district
+ocd-division/country:us/state:vt/sldl:franklin-8,Vermont Franklin-8 State House district
+ocd-division/country:us/state:vt/sldl:franklin-3-1,Vermont Franklin-3-1 State House district (obsolete)
+ocd-division/country:us/state:vt/sldl:franklin-3-2,Vermont Franklin-3-2 State House district (obsolete)
 ocd-division/country:us/state:vt/sldl:grand_isle-chittenden,Vermont Grand-Isle-Chittenden State House district
 ocd-division/country:us/state:vt/sldl:lamoille-1,Vermont Lamoille-1 State House district
 ocd-division/country:us/state:vt/sldl:lamoille-2,Vermont Lamoille-2 State House district
@@ -4376,32 +4401,45 @@ ocd-division/country:us/state:vt/sldl:lamoille-3,Vermont Lamoille-3 State House 
 ocd-division/country:us/state:vt/sldl:lamoille-washington,Vermont Lamoille-Washington State House district
 ocd-division/country:us/state:vt/sldl:orleans-1,Vermont Orleans-1 State House district
 ocd-division/country:us/state:vt/sldl:orleans-2,Vermont Orleans-2 State House district
+ocd-division/country:us/state:vt/sldl:orleans-3,Vermont Orleans-3 State House district
+ocd-division/country:us/state:vt/sldl:orleans-4,Vermont Orleans-4 State House district
 ocd-division/country:us/state:vt/sldl:orange-caledonia,Vermont Orange-Caledonia State House district
 ocd-division/country:us/state:vt/sldl:orleans-lamoille,Vermont Orleans-Lamoille State House district
 ocd-division/country:us/state:vt/sldl:orleans-caledonia,Vermont Orleans-Caledonia State House district
 ocd-division/country:us/state:vt/sldl:orange-1,Vermont Orange-1 State House district
 ocd-division/country:us/state:vt/sldl:orange-2,Vermont Orange-2 State House district
+ocd-division/country:us/state:vt/sldl:orange-3,Vermont Orange-3 State House district
 ocd-division/country:us/state:vt/sldl:orange-washington-addison,Vermont Orange-Washington-Addison State House district
 ocd-division/country:us/state:vt/sldl:rutland-1,Vermont Rutland-1 State House district
 ocd-division/country:us/state:vt/sldl:rutland-2,Vermont Rutland-2 State House district
 ocd-division/country:us/state:vt/sldl:rutland-3,Vermont Rutland-3 State House district
 ocd-division/country:us/state:vt/sldl:rutland-4,Vermont Rutland-4 State House district
+ocd-division/country:us/state:vt/sldl:rutland-5,Vermont Rutland-5 State House district
 ocd-division/country:us/state:vt/sldl:rutland-6,Vermont Rutland-6 State House district
+ocd-division/country:us/state:vt/sldl:rutland-7,Vermont Rutland-7 State House district
+ocd-division/country:us/state:vt/sldl:rutland-8,Vermont Rutland-8 State House district
+ocd-division/country:us/state:vt/sldl:rutland-9,Vermont Rutland-9 State House district
+ocd-division/country:us/state:vt/sldl:rutland-10,Vermont Rutland-10 State House district
+ocd-division/country:us/state:vt/sldl:rutland-11,Vermont Rutland-11 State House district
 ocd-division/country:us/state:vt/sldl:rutland-bennington,Vermont Rutland-Bennington State House district
-ocd-division/country:us/state:vt/sldl:rutland-windsor-1,Vermont Rutland-Windsor-1 State House district
-ocd-division/country:us/state:vt/sldl:rutland-5-1,Vermont Rutland-5-1 State House district
-ocd-division/country:us/state:vt/sldl:rutland-5-2,Vermont Rutland-5-2 State House district
-ocd-division/country:us/state:vt/sldl:rutland-5-3,Vermont Rutland-5-3 State House district
-ocd-division/country:us/state:vt/sldl:rutland-5-4,Vermont Rutland-5-4 State House district
-ocd-division/country:us/state:vt/sldl:rutland-windsor-2,Vermont Rutland-Windsor-2 State House district
+ocd-division/country:us/state:vt/sldl:rutland-windsor,Vermont Rutland-Windsor State House district
+ocd-division/country:us/state:vt/sldl:rutland-windsor-1,Vermont Rutland-Windsor-1 State House district (obsolete)
+ocd-division/country:us/state:vt/sldl:rutland-5-1,Vermont Rutland-5-1 State House district (obsolete)
+ocd-division/country:us/state:vt/sldl:rutland-5-2,Vermont Rutland-5-2 State House district (obsolete)
+ocd-division/country:us/state:vt/sldl:rutland-5-3,Vermont Rutland-5-3 State House district (obsolete)
+ocd-division/country:us/state:vt/sldl:rutland-5-4,Vermont Rutland-5-4 State House district (obsolete)
+ocd-division/country:us/state:vt/sldl:rutland-windsor-2,Vermont Rutland-Windsor-2 State House district (obsolete)
 ocd-division/country:us/state:vt/sldl:windham-1,Vermont Windham-1 State House district
 ocd-division/country:us/state:vt/sldl:windham-3,Vermont Windham-3 State House district
 ocd-division/country:us/state:vt/sldl:windham-4,Vermont Windham-4 State House district
 ocd-division/country:us/state:vt/sldl:windham-5,Vermont Windham-5 State House district
 ocd-division/country:us/state:vt/sldl:windham-6,Vermont Windham-6 State House district
-ocd-division/country:us/state:vt/sldl:windham-2-1,Vermont Windham-2-1 State House district
-ocd-division/country:us/state:vt/sldl:windham-2-2,Vermont Windham-2-2 State House district
-ocd-division/country:us/state:vt/sldl:windham-2-3,Vermont Windham-2-3 State House district
+ocd-division/country:us/state:vt/sldl:windham-7,Vermont Windham-7 State House district
+ocd-division/country:us/state:vt/sldl:windham-8,Vermont Windham-8 State House district
+ocd-division/country:us/state:vt/sldl:windham-9,Vermont Windham-9 State House district
+ocd-division/country:us/state:vt/sldl:windham-2-1,Vermont Windham-2-1 State House district (obsolete)
+ocd-division/country:us/state:vt/sldl:windham-2-2,Vermont Windham-2-2 State House district (obsolete)
+ocd-division/country:us/state:vt/sldl:windham-2-3,Vermont Windham-2-3 State House district (obsolete)
 ocd-division/country:us/state:vt/sldl:washington-1,Vermont Washington-1 State House district
 ocd-division/country:us/state:vt/sldl:washington-2,Vermont Washington-2 State House district
 ocd-division/country:us/state:vt/sldl:washington-3,Vermont Washington-3 State House district
@@ -4410,16 +4448,18 @@ ocd-division/country:us/state:vt/sldl:washington-5,Vermont Washington-5 State Ho
 ocd-division/country:us/state:vt/sldl:washington-6,Vermont Washington-6 State House district
 ocd-division/country:us/state:vt/sldl:washington-7,Vermont Washington-7 State House district
 ocd-division/country:us/state:vt/sldl:washington-chittenden,Vermont Washington-Chittenden State House district
+ocd-division/country:us/state:vt/sldl:washington-orange,Vermont Washington-Orange State House district
 ocd-division/country:us/state:vt/sldl:windham-bennington-windsor,Vermont Windham-Bennington-Windsor State House district
 ocd-division/country:us/state:vt/sldl:windham-bennington,Vermont Windham-Bennington State House district
 ocd-division/country:us/state:vt/sldl:windsor-1,Vermont Windsor-1 State House district
 ocd-division/country:us/state:vt/sldl:windsor-2,Vermont Windsor-2 State House district
 ocd-division/country:us/state:vt/sldl:windsor-5,Vermont Windsor-5 State House district
+ocd-division/country:us/state:vt/sldl:windsor-6,Vermont Windsor-6 State House district
 ocd-division/country:us/state:vt/sldl:windsor-rutland,Vermont Windsor-Rutland State House district
-ocd-division/country:us/state:vt/sldl:windsor-3-1,Vermont Windsor-3-1 State House district
-ocd-division/country:us/state:vt/sldl:windsor-3-2,Vermont Windsor-3-2 State House district
-ocd-division/country:us/state:vt/sldl:windsor-4-1,Vermont Windsor-4-1 State House district
-ocd-division/country:us/state:vt/sldl:windsor-4-2,Vermont Windsor-4-2 State House district
+ocd-division/country:us/state:vt/sldl:windsor-3-1,Vermont Windsor-3-1 State House district (obsolete)
+ocd-division/country:us/state:vt/sldl:windsor-3-2,Vermont Windsor-3-2 State House district (obsolete)
+ocd-division/country:us/state:vt/sldl:windsor-4-1,Vermont Windsor-4-1 State House district (obsolete)
+ocd-division/country:us/state:vt/sldl:windsor-4-2,Vermont Windsor-4-2 State House district (obsolete)
 ocd-division/country:us/state:vt/sldl:windsor-orange-1,Vermont Windsor-Orange-1 State House district
 ocd-division/country:us/state:vt/sldl:windsor-orange-2,Vermont Windsor-Orange-2 State House district
 ocd-division/country:us/state:va/sldl:1,Virginia State House district 1
@@ -4853,9 +4893,6 @@ ocd-division/country:us/state:vt/sldl:chittenden-3-10,Vermont Chittenden-3-10 St
 ocd-division/country:us/state:vt/sldl:addison-rutland-1,Vermont Addison-Rutland-1 State House district (obsolete)
 ocd-division/country:us/state:vt/sldl:bennington-5,Vermont Bennington-5 State House district (obsolete)
 ocd-division/country:us/state:vt/sldl:bennington-rutland-1,Vermont Bennington-Rutland-1 State House district (obsolete)
-ocd-division/country:us/state:vt/sldl:chittenden-4,Vermont Chittenden-4 State House district (obsolete)
-ocd-division/country:us/state:vt/sldl:chittenden-8,Vermont Chittenden-8 State House district (obsolete)
-ocd-division/country:us/state:vt/sldl:chittenden-9,Vermont Chittenden-9 State House district (obsolete)
 ocd-division/country:us/state:vt/sldl:chittenden-1-1,Vermont Chittenden-1-1 State House district (obsolete)
 ocd-division/country:us/state:vt/sldl:chittenden-1-2,Vermont Chittenden-1-2 State House district (obsolete)
 ocd-division/country:us/state:vt/sldl:chittenden-3-1,Vermont Chittenden-3-1 State House district (obsolete)
@@ -4878,8 +4915,6 @@ ocd-division/country:us/state:vt/sldl:orange-addison-1,Vermont Orange-Addison-1 
 ocd-division/country:us/state:vt/sldl:orange-caledonia-1,Vermont Orange-Caledonia-1 State House district (obsolete)
 ocd-division/country:us/state:vt/sldl:orleans-caledonia-1,Vermont Orleans-Caledonia-1 State House district (obsolete)
 ocd-division/country:us/state:vt/sldl:orleans-franklin-1,Vermont Orleans-Franklin-1 State House district (obsolete)
-ocd-division/country:us/state:vt/sldl:rutland-7,Vermont Rutland-7 State House district (obsolete)
-ocd-division/country:us/state:vt/sldl:rutland-8,Vermont Rutland-8 State House district (obsolete)
 ocd-division/country:us/state:vt/sldl:rutland-1-1,Vermont Rutland-1-1 State House district (obsolete)
 ocd-division/country:us/state:vt/sldl:rutland-1-2,Vermont Rutland-1-2 State House district (obsolete)
 ocd-division/country:us/state:vt/sldl:washington-3-1,Vermont Washington-3-1 State House district (obsolete)

--- a/identifiers/country-us/census_autogenerated/us_sldl.csv
+++ b/identifiers/country-us/census_autogenerated/us_sldl.csv
@@ -1971,6 +1971,7 @@ ocd-division/country:us/state:ma/sldl:35th_middlesex,Massachusetts 35th Middlese
 ocd-division/country:us/state:ma/sldl:36th_middlesex,Massachusetts 36th Middlesex district
 ocd-division/country:us/state:ma/sldl:37th_middlesex,Massachusetts 37th Middlesex district
 ocd-division/country:us/state:ma/sldl:18th_worcester,Massachusetts 18th Worcester district
+ocd-division/country:us/state:ma/sldl:19th_worcester,Massachusetts 19th Worcester district
 ocd-division/country:us/state:ma/sldl:5th_barnstable,Massachusetts 5th Barnstable district
 ocd-division/country:us/state:ma/sldl:1st_norfolk,Massachusetts 1st Norfolk district
 ocd-division/country:us/state:ma/sldl:2nd_norfolk,Massachusetts 2nd Norfolk district

--- a/identifiers/country-us/census_autogenerated/us_sldl.csv
+++ b/identifiers/country-us/census_autogenerated/us_sldl.csv
@@ -1796,13 +1796,27 @@ ocd-division/country:us/state:me/sldl:148,Maine State House district 148
 ocd-division/country:us/state:me/sldl:149,Maine State House district 149
 ocd-division/country:us/state:me/sldl:150,Maine State House district 150
 ocd-division/country:us/state:me/sldl:151,Maine State House district 151
+ocd-division/country:us/state:md/sldl:1a,Maryland State Legislative Subdistrict 1A
+ocd-division/country:us/state:md/sldl:1b,Maryland State Legislative Subdistrict 1B
+ocd-division/country:us/state:md/sldl:1c,Maryland State Legislative Subdistrict 1C
+ocd-division/country:us/state:md/sldl:2a,Maryland State Legislative Subdistrict 2A
+ocd-division/country:us/state:md/sldl:2b,Maryland State Legislative Subdistrict 2B
+ocd-division/country:us/state:md/sldl:3,Maryland State Legislative district 3
+ocd-division/country:us/state:md/sldl:3a,Maryland State Legislative Subdistrict 3A
+ocd-division/country:us/state:md/sldl:3b,Maryland State Legislative Subdistrict 3B
 ocd-division/country:us/state:md/sldl:4,Maryland State Legislative district 4
 ocd-division/country:us/state:md/sldl:5,Maryland State Legislative district 5
 ocd-division/country:us/state:md/sldl:6,Maryland State Legislative district 6
-ocd-division/country:us/state:md/sldl:7,Maryland State Legislative district 7
+ocd-division/country:us/state:md/sldl:7,Maryland State Legislative district 7 (obsolete)
+ocd-division/country:us/state:md/sldl:7a,Maryland State Legislative Subdistrict 7A
+ocd-division/country:us/state:md/sldl:7b,Maryland State Legislative Subdistrict 7B
 ocd-division/country:us/state:md/sldl:8,Maryland State Legislative district 8
+ocd-division/country:us/state:md/sldl:9a,Maryland State Legislative Subdistrict 9A
+ocd-division/country:us/state:md/sldl:9b,Maryland State Legislative Subdistrict 9B
 ocd-division/country:us/state:md/sldl:10,Maryland State Legislative district 10
 ocd-division/country:us/state:md/sldl:11,Maryland State Legislative district 11
+ocd-division/country:us/state:md/sldl:11a,Maryland State Legislative Subdistrict 11A
+ocd-division/country:us/state:md/sldl:11b,Maryland State Legislative Subdistrict 11B
 ocd-division/country:us/state:md/sldl:12,Maryland State Legislative district 12
 ocd-division/country:us/state:md/sldl:13,Maryland State Legislative district 13
 ocd-division/country:us/state:md/sldl:14,Maryland State Legislative district 14
@@ -1811,36 +1825,19 @@ ocd-division/country:us/state:md/sldl:16,Maryland State Legislative district 16
 ocd-division/country:us/state:md/sldl:17,Maryland State Legislative district 17
 ocd-division/country:us/state:md/sldl:18,Maryland State Legislative district 18
 ocd-division/country:us/state:md/sldl:19,Maryland State Legislative district 19
-ocd-division/country:us/state:md/sldl:1a,Maryland State Legislative Subdistrict 1A
-ocd-division/country:us/state:md/sldl:1b,Maryland State Legislative Subdistrict 1B
-ocd-division/country:us/state:md/sldl:1c,Maryland State Legislative Subdistrict 1C
 ocd-division/country:us/state:md/sldl:20,Maryland State Legislative district 20
 ocd-division/country:us/state:md/sldl:21,Maryland State Legislative district 21
 ocd-division/country:us/state:md/sldl:22,Maryland State Legislative district 22
+ocd-division/country:us/state:md/sldl:23,Maryland State Legislative district 23
+ocd-division/country:us/state:md/sldl:23a,Maryland State Legislative Subdistrict 23A
+ocd-division/country:us/state:md/sldl:23b,Maryland State Legislative Subdistrict 23B
 ocd-division/country:us/state:md/sldl:24,Maryland State Legislative district 24
 ocd-division/country:us/state:md/sldl:25,Maryland State Legislative district 25
 ocd-division/country:us/state:md/sldl:26,Maryland State Legislative district 26
-ocd-division/country:us/state:md/sldl:28,Maryland State Legislative district 28
-ocd-division/country:us/state:md/sldl:2a,Maryland State Legislative Subdistrict 2A
-ocd-division/country:us/state:md/sldl:2b,Maryland State Legislative Subdistrict 2B
-ocd-division/country:us/state:md/sldl:32,Maryland State Legislative district 32
-ocd-division/country:us/state:md/sldl:33,Maryland State Legislative district 33
-ocd-division/country:us/state:md/sldl:36,Maryland State Legislative district 36
-ocd-division/country:us/state:md/sldl:39,Maryland State Legislative district 39
-ocd-division/country:us/state:md/sldl:3a,Maryland State Legislative Subdistrict 3A
-ocd-division/country:us/state:md/sldl:3b,Maryland State Legislative Subdistrict 3B
-ocd-division/country:us/state:md/sldl:40,Maryland State Legislative district 40
-ocd-division/country:us/state:md/sldl:41,Maryland State Legislative district 41
-ocd-division/country:us/state:md/sldl:43,Maryland State Legislative district 43
-ocd-division/country:us/state:md/sldl:45,Maryland State Legislative district 45
-ocd-division/country:us/state:md/sldl:46,Maryland State Legislative district 46
-ocd-division/country:us/state:md/sldl:9a,Maryland State Legislative Subdistrict 9A
-ocd-division/country:us/state:md/sldl:9b,Maryland State Legislative Subdistrict 9B
-ocd-division/country:us/state:md/sldl:23a,Maryland State Legislative Subdistrict 23A
-ocd-division/country:us/state:md/sldl:23b,Maryland State Legislative Subdistrict 23B
 ocd-division/country:us/state:md/sldl:27a,Maryland State Legislative Subdistrict 27A
 ocd-division/country:us/state:md/sldl:27b,Maryland State Legislative Subdistrict 27B
 ocd-division/country:us/state:md/sldl:27c,Maryland State Legislative Subdistrict 27C
+ocd-division/country:us/state:md/sldl:28,Maryland State Legislative district 28
 ocd-division/country:us/state:md/sldl:29a,Maryland State Legislative Subdistrict 29A
 ocd-division/country:us/state:md/sldl:29b,Maryland State Legislative Subdistrict 29B
 ocd-division/country:us/state:md/sldl:29c,Maryland State Legislative Subdistrict 29C
@@ -1848,19 +1845,34 @@ ocd-division/country:us/state:md/sldl:30a,Maryland State Legislative Subdistrict
 ocd-division/country:us/state:md/sldl:30b,Maryland State Legislative Subdistrict 30B
 ocd-division/country:us/state:md/sldl:31a,Maryland State Legislative Subdistrict 31A
 ocd-division/country:us/state:md/sldl:31b,Maryland State Legislative Subdistrict 31B
+ocd-division/country:us/state:md/sldl:32,Maryland State Legislative district 32
+ocd-division/country:us/state:md/sldl:33,Maryland State Legislative district 33 (obsolete)
+ocd-division/country:us/state:md/sldl:33a,Maryland State Legislative Subdistrict 33A
+ocd-division/country:us/state:md/sldl:33b,Maryland State Legislative Subdistrict 33B
+ocd-division/country:us/state:md/sldl:33c,Maryland State Legislative Subdistrict 33C
 ocd-division/country:us/state:md/sldl:34a,Maryland State Legislative Subdistrict 34A
 ocd-division/country:us/state:md/sldl:34b,Maryland State Legislative Subdistrict 34B
 ocd-division/country:us/state:md/sldl:35a,Maryland State Legislative Subdistrict 35A
 ocd-division/country:us/state:md/sldl:35b,Maryland State Legislative Subdistrict 35B
+ocd-division/country:us/state:md/sldl:36,Maryland State Legislative district 36
 ocd-division/country:us/state:md/sldl:37a,Maryland State Legislative Subdistrict 37A
 ocd-division/country:us/state:md/sldl:37b,Maryland State Legislative Subdistrict 37B
 ocd-division/country:us/state:md/sldl:38a,Maryland State Legislative Subdistrict 38A
 ocd-division/country:us/state:md/sldl:38b,Maryland State Legislative Subdistrict 38B
 ocd-division/country:us/state:md/sldl:38c,Maryland State Legislative Subdistrict 38C
+ocd-division/country:us/state:md/sldl:39,Maryland State Legislative district 39
+ocd-division/country:us/state:md/sldl:40,Maryland State Legislative district 40
+ocd-division/country:us/state:md/sldl:41,Maryland State Legislative district 41
 ocd-division/country:us/state:md/sldl:42a,Maryland State Legislative Subdistrict 42A
 ocd-division/country:us/state:md/sldl:42b,Maryland State Legislative Subdistrict 42B
+ocd-division/country:us/state:md/sldl:42c,Maryland State Legislative Subdistrict 42C
+ocd-division/country:us/state:md/sldl:43,Maryland State Legislative district 43 (obsolete)
+ocd-division/country:us/state:md/sldl:43a,Maryland State Legislative Subdistrict 43A
+ocd-division/country:us/state:md/sldl:43b,Maryland State Legislative Subdistrict 43B
 ocd-division/country:us/state:md/sldl:44a,Maryland State Legislative Subdistrict 44A
 ocd-division/country:us/state:md/sldl:44b,Maryland State Legislative Subdistrict 44B
+ocd-division/country:us/state:md/sldl:45,Maryland State Legislative district 45
+ocd-division/country:us/state:md/sldl:46,Maryland State Legislative district 46
 ocd-division/country:us/state:md/sldl:47a,Maryland State Legislative Subdistrict 47A
 ocd-division/country:us/state:md/sldl:47b,Maryland State Legislative Subdistrict 47B
 ocd-division/country:us/state:ma/sldl:1st_barnstable,Massachusetts 1st Barnstable district
@@ -4836,8 +4848,6 @@ ocd-division/country:us/state:md/sldl:5a,Maryland State Legislative Subdistrict 
 ocd-division/country:us/state:md/sldl:5b,Maryland State Legislative Subdistrict 5B (obsolete)
 ocd-division/country:us/state:md/sldl:12a,Maryland State Legislative Subdistrict 12A (obsolete)
 ocd-division/country:us/state:md/sldl:12b,Maryland State Legislative Subdistrict 12B (obsolete)
-ocd-division/country:us/state:md/sldl:33a,Maryland State Legislative Subdistrict 33A (obsolete)
-ocd-division/country:us/state:md/sldl:33b,Maryland State Legislative Subdistrict 33B (obsolete)
 ocd-division/country:us/state:vt/sldl:chittenden-3-10,Vermont Chittenden-3-10 State House district (obsolete)
 ocd-division/country:us/state:vt/sldl:addison-rutland-1,Vermont Addison-Rutland-1 State House district (obsolete)
 ocd-division/country:us/state:vt/sldl:bennington-5,Vermont Bennington-5 State House district (obsolete)

--- a/identifiers/country-us/census_autogenerated/us_sldl.csv
+++ b/identifiers/country-us/census_autogenerated/us_sldl.csv
@@ -4455,6 +4455,8 @@ ocd-division/country:us/state:vt/sldl:windsor-1,Vermont Windsor-1 State House di
 ocd-division/country:us/state:vt/sldl:windsor-2,Vermont Windsor-2 State House district
 ocd-division/country:us/state:vt/sldl:windsor-5,Vermont Windsor-5 State House district
 ocd-division/country:us/state:vt/sldl:windsor-6,Vermont Windsor-6 State House district
+ocd-division/country:us/state:vt/sldl:windsor-addison,Vermont Windsor-Addison State House district
+ocd-division/country:us/state:vt/sldl:windsor-windham,Vermont Windsor-Windham State House district
 ocd-division/country:us/state:vt/sldl:windsor-rutland,Vermont Windsor-Rutland State House district
 ocd-division/country:us/state:vt/sldl:windsor-3-1,Vermont Windsor-3-1 State House district (obsolete)
 ocd-division/country:us/state:vt/sldl:windsor-3-2,Vermont Windsor-3-2 State House district (obsolete)
@@ -4678,6 +4680,39 @@ ocd-division/country:us/state:wv/sldl:64,West Virginia State House district 64
 ocd-division/country:us/state:wv/sldl:65,West Virginia State House district 65
 ocd-division/country:us/state:wv/sldl:66,West Virginia State House district 66
 ocd-division/country:us/state:wv/sldl:67,West Virginia State House district 67
+ocd-division/country:us/state:wv/sldl:68,West Virignia State House District 68
+ocd-division/country:us/state:wv/sldl:69,West Virignia State House District 69
+ocd-division/country:us/state:wv/sldl:70,West Virignia State House District 70
+ocd-division/country:us/state:wv/sldl:71,West Virignia State House District 71
+ocd-division/country:us/state:wv/sldl:72,West Virignia State House District 72
+ocd-division/country:us/state:wv/sldl:73,West Virignia State House District 73
+ocd-division/country:us/state:wv/sldl:74,West Virignia State House District 74
+ocd-division/country:us/state:wv/sldl:75,West Virignia State House District 75
+ocd-division/country:us/state:wv/sldl:76,West Virignia State House District 76
+ocd-division/country:us/state:wv/sldl:77,West Virignia State House District 77
+ocd-division/country:us/state:wv/sldl:78,West Virignia State House District 78
+ocd-division/country:us/state:wv/sldl:79,West Virignia State House District 79
+ocd-division/country:us/state:wv/sldl:80,West Virignia State House District 80
+ocd-division/country:us/state:wv/sldl:81,West Virignia State House District 81
+ocd-division/country:us/state:wv/sldl:82,West Virignia State House District 82
+ocd-division/country:us/state:wv/sldl:83,West Virignia State House District 83
+ocd-division/country:us/state:wv/sldl:84,West Virignia State House District 84
+ocd-division/country:us/state:wv/sldl:85,West Virignia State House District 85
+ocd-division/country:us/state:wv/sldl:86,West Virignia State House District 86
+ocd-division/country:us/state:wv/sldl:87,West Virignia State House District 87
+ocd-division/country:us/state:wv/sldl:88,West Virignia State House District 88
+ocd-division/country:us/state:wv/sldl:89,West Virignia State House District 89
+ocd-division/country:us/state:wv/sldl:90,West Virignia State House District 90
+ocd-division/country:us/state:wv/sldl:91,West Virignia State House District 91
+ocd-division/country:us/state:wv/sldl:92,West Virignia State House District 92
+ocd-division/country:us/state:wv/sldl:93,West Virignia State House District 93
+ocd-division/country:us/state:wv/sldl:94,West Virignia State House District 94
+ocd-division/country:us/state:wv/sldl:95,West Virignia State House District 95
+ocd-division/country:us/state:wv/sldl:96,West Virignia State House District 96
+ocd-division/country:us/state:wv/sldl:97,West Virignia State House District 97
+ocd-division/country:us/state:wv/sldl:98,West Virignia State House District 98
+ocd-division/country:us/state:wv/sldl:99,West Virignia State House District 99
+ocd-division/country:us/state:wv/sldl:100,West Virignia State House District 100
 ocd-division/country:us/state:wi/sldl:1,Wisconsin Assembly district 1
 ocd-division/country:us/state:wi/sldl:2,Wisconsin Assembly district 2
 ocd-division/country:us/state:wi/sldl:3,Wisconsin Assembly district 3

--- a/identifiers/country-us/census_autogenerated/us_sldu.csv
+++ b/identifiers/country-us/census_autogenerated/us_sldu.csv
@@ -1778,12 +1778,18 @@ ocd-division/country:us/state:ut/sldu:29,Utah State Senate district 29
 ocd-division/country:us/state:vt/sldu:addison,Vermont Addison State Senate district
 ocd-division/country:us/state:vt/sldu:bennington,Vermont Bennington State Senate district
 ocd-division/country:us/state:vt/sldu:caledonia,Vermont Caledonia State Senate district
-ocd-division/country:us/state:vt/sldu:grand_isle-chittenden,Vermont Grand-Isle-Chittenden State Senate district
-ocd-division/country:us/state:vt/sldu:chittenden,Vermont Chittenden State Senate district
-ocd-division/country:us/state:vt/sldu:essex-orleans,Vermont Essex-Orleans State Senate district
+ocd-division/country:us/state:vt/sldu:grand_isle,Vermont Grand Isle State Senate district
+ocd-division/country:us/state:vt/sldu:grand_isle-chittenden,Vermont Grand-Isle-Chittenden State Senate district (obsolete)
+ocd-division/country:us/state:vt/sldu:chittenden,Vermont Chittenden State Senate district (obsolete)
+ocd-division/country:us/state:vt/sldu:chittenden_central,Vermont Chittenden Central State Senate district
+ocd-division/country:us/state:vt/sldu:chittenden_north,Vermont Chittenden North State Senate district
+ocd-division/country:us/state:vt/sldu:chittenden_southeast,Vermont Chittenden Southeast State Senate district
+ocd-division/country:us/state:vt/sldu:essex,Vermont Essex State Senate district
+ocd-division/country:us/state:vt/sldu:essex-orleans,Vermont Essex-Orleans State Senate district (obsolete)
 ocd-division/country:us/state:vt/sldu:franklin,Vermont Franklin State Senate district
 ocd-division/country:us/state:vt/sldu:lamoille,Vermont Lamoille State Senate district
 ocd-division/country:us/state:vt/sldu:orange,Vermont Orange State Senate district
+ocd-division/country:us/state:vt/sldu:orleans,Vermont Orleans State Senate district
 ocd-division/country:us/state:vt/sldu:rutland,Vermont Rutland State Senate district
 ocd-division/country:us/state:vt/sldu:washington,Vermont Washington State Senate district
 ocd-division/country:us/state:vt/sldu:windham,Vermont Windham State Senate district
@@ -1992,5 +1998,4 @@ ocd-division/country:us/state:nv/sldu:washoe_county_4,Nevada Washoe County Senat
 ocd-division/country:us/state:nv/sldu:capital,Nevada Capital Senatorial district (obsolete)
 ocd-division/country:us/state:nv/sldu:central_nevada,Nevada Central Nevada Senatorial district (obsolete)
 ocd-division/country:us/state:nv/sldu:rural_nevada,Nevada Rural Nevada Senatorial district (obsolete)
-ocd-division/country:us/state:vt/sldu:grand_isle,Vermont Grand Isle State Senate district (obsolete)
 ocd-division/country:us/state:wv/sldu:817,West Virginia State Senate district 817 (obsolete)

--- a/identifiers/country-us/census_autogenerated/us_sldu.csv
+++ b/identifiers/country-us/census_autogenerated/us_sldu.csv
@@ -775,42 +775,54 @@ ocd-division/country:us/state:md/sldu:46,Maryland State Senate district 46
 ocd-division/country:us/state:md/sldu:47,Maryland State Senate district 47
 ocd-division/country:us/state:ma/sldu:1st_suffolk,Massachusetts First Suffolk district
 ocd-division/country:us/state:ma/sldu:2nd_suffolk,Massachusetts Second Suffolk district
+ocd-division/country:us/state:ma/sldu:3rd_suffolk,Massachusetts Third Suffolk district
 ocd-division/country:us/state:ma/sldu:hampden,Massachusetts Hampden district
+ocd-division/country:us/state:ma/sldu:hampden_hampshire_and_worcester,"Massachusetts Hampden, Hampshire & Worcester district"
 ocd-division/country:us/state:ma/sldu:berkshire_hampshire_franklin_and_hampden,"Massachusetts Berkshire, Hampshire, Franklin & Hampden district"
-ocd-division/country:us/state:ma/sldu:2nd_hampden_and_hampshire,Massachusetts Second Hampden & Hampshire district
+ocd-division/country:us/state:ma/sldu:2nd_hampden_and_hampshire,Massachusetts Second Hampden & Hampshire district (obsolete)
 ocd-division/country:us/state:ma/sldu:hampshire_franklin_and_worcester,"Massachusetts Hampshire, Franklin & Worcester district"
 ocd-division/country:us/state:ma/sldu:1st_hampden_and_hampshire,Massachusetts First Hampden & Hampshire district
-ocd-division/country:us/state:ma/sldu:worcester_hampden_hampshire_and_middlesex,"Massachusetts Worcester, Hampden, Hampshire & Middlesex district"
+ocd-division/country:us/state:ma/sldu:worcester_hampden_hampshire_and_middlesex,"Massachusetts Worcester, Hampden, Hampshire & Middlesex district (obsolete)"
 ocd-division/country:us/state:ma/sldu:worcester_and_middlesex,Massachusetts Worcester & Middlesex district
 ocd-division/country:us/state:ma/sldu:1st_worcester,Massachusetts First Worcester district
 ocd-division/country:us/state:ma/sldu:2nd_worcester,Massachusetts Second Worcester district
-ocd-division/country:us/state:ma/sldu:worcester_and_norfolk,Massachusetts Worcester & Norfolk district
+ocd-division/country:us/state:ma/sldu:3rd_worcester,Massachusetts Third Worcester district
+ocd-division/country:us/state:ma/sldu:4th_worcester,Massachusetts Fourth Worcester district
+ocd-division/country:us/state:ma/sldu:worcester_and_norfolk,Massachusetts Worcester & Norfolk district (obsolete)
 ocd-division/country:us/state:ma/sldu:1st_middlesex,Massachusetts First Middlesex district
-ocd-division/country:us/state:ma/sldu:middlesex_and_worcester,Massachusetts Middlesex & Worcester district
-ocd-division/country:us/state:ma/sldu:2nd_middlesex_and_norfolk,Massachusetts Second Middlesex & Norfolk district
-ocd-division/country:us/state:ma/sldu:3rd_middlesex,Massachusetts Third Middlesex district
-ocd-division/country:us/state:ma/sldu:norfolk_bristol_and_middlesex,"Massachusetts Norfolk, Bristol & Middlesex district"
+ocd-division/country:us/state:ma/sldu:2nd_middlesex_and_norfolk,Massachusetts Second Middlesex & Norfolk district (obsolete)
+ocd-division/country:us/state:ma/sldu:norfolk_bristol_and_middlesex,"Massachusetts Norfolk, Bristol & Middlesex district (obsolete)"
 ocd-division/country:us/state:ma/sldu:2nd_essex_and_middlesex,Massachusetts Second Essex & Middlesex district
 ocd-division/country:us/state:ma/sldu:1st_essex,Massachusetts First Essex district
 ocd-division/country:us/state:ma/sldu:1st_essex_and_middlesex,Massachusetts First Essex & Middlesex district
 ocd-division/country:us/state:ma/sldu:2nd_essex,Massachusetts Second Essex district
 ocd-division/country:us/state:ma/sldu:3rd_essex,Massachusetts Third Essex district
-ocd-division/country:us/state:ma/sldu:5th_middlesex,Massachusetts Fifth Middlesex district
-ocd-division/country:us/state:ma/sldu:4th_middlesex,Massachusetts Fourth Middlesex district
+ocd-division/country:us/state:ma/sldu:5th_middlesex,Massachusetts Fifth Middlesex district (obsolete)
+ocd-division/country:us/state:ma/sldu:4th_middlesex,Massachusetts Fourth Middlesex district (obsolete)
 ocd-division/country:us/state:ma/sldu:2nd_middlesex,Massachusetts Second Middlesex district
+ocd-division/country:us/state:ma/sldu:3rd_middlesex,Massachusetts Third Middlesex district
 ocd-division/country:us/state:ma/sldu:middlesex_and_suffolk,Massachusetts Middlesex & Suffolk district
-ocd-division/country:us/state:ma/sldu:1st_suffolk_and_middlesex,Massachusetts First Suffolk & Middlesex district
-ocd-division/country:us/state:ma/sldu:2nd_suffolk_and_middlesex,Massachusetts Second Suffolk & Middlesex district
+ocd-division/country:us/state:ma/sldu:middlesex_and_worcester,Massachusetts Middlesex & Worcester district
+ocd-division/country:us/state:ma/sldu:norfolk_and_middlesex,Massachusetts Norfolk & Middlesex district
+ocd-division/country:us/state:ma/sldu:1st_suffolk_and_middlesex,Massachusetts First Suffolk & Middlesex district (obsolete)
+ocd-division/country:us/state:ma/sldu:suffolk_and_middlesex,Massachusetts Suffolk & Middlesex district
+ocd-division/country:us/state:ma/sldu:worcester_and_hampden,Massachusetts Worcester & Hampden district
+ocd-division/country:us/state:ma/sldu:worcester_and_hampshire,Massachusetts Worcester & Hampshire district
+ocd-division/country:us/state:ma/sldu:2nd_suffolk_and_middlesex,Massachusetts Second Suffolk & Middlesex district (obsolete)
 ocd-division/country:us/state:ma/sldu:1st_middlesex_and_norfolk,Massachusetts First Middlesex & Norfolk district
 ocd-division/country:us/state:ma/sldu:norfolk_and_suffolk,Massachusetts Norfolk & Suffolk district
 ocd-division/country:us/state:ma/sldu:bristol_and_norfolk,Massachusetts Bristol & Norfolk district
 ocd-division/country:us/state:ma/sldu:norfolk_bristol_and_plymouth,"Massachusetts Norfolk, Bristol & Plymouth district"
+ocd-division/country:us/state:ma/sldu:norfolk_worcester_and_middlesex,"Massachusetts Norfolk, Worcester & Middlesex district"
 ocd-division/country:us/state:ma/sldu:norfolk_and_plymouth,Massachusetts Norfolk & Plymouth district
-ocd-division/country:us/state:ma/sldu:plymouth_and_norfolk,Massachusetts Plymouth & Norfolk district
-ocd-division/country:us/state:ma/sldu:2nd_plymouth_and_bristol,Massachusetts Second Plymouth & Bristol district
-ocd-division/country:us/state:ma/sldu:1st_plymouth_and_bristol,Massachusetts First Plymouth & Bristol district
+ocd-division/country:us/state:ma/sldu:plymouth_and_norfolk,Massachusetts Plymouth & Norfolk district (obsolete)
+ocd-division/country:us/state:ma/sldu:1st_plymouth_and_norfolk,Massachusetts First Plymouth & Norfolk district
+ocd-division/country:us/state:ma/sldu:2nd_plymouth_and_norfolk,Massachusetts Second Plymouth & Norfolk district
+ocd-division/country:us/state:ma/sldu:2nd_plymouth_and_bristol,Massachusetts Second Plymouth & Bristol district (obsolete)
+ocd-division/country:us/state:ma/sldu:1st_plymouth_and_bristol,Massachusetts First Plymouth & Bristol district (obsolete)
 ocd-division/country:us/state:ma/sldu:1st_bristol_and_plymouth,Massachusetts First Bristol & Plymouth district
 ocd-division/country:us/state:ma/sldu:2nd_bristol_and_plymouth,Massachusetts Second Bristol & Plymouth district
+ocd-division/country:us/state:ma/sldu:3rd_bristol_and_plymouth,Massachusetts Third Bristol & Plymouth district
 ocd-division/country:us/state:ma/sldu:plymouth_and_barnstable,Massachusetts Plymouth & Barnstable district
 ocd-division/country:us/state:ma/sldu:cape_and_islands,Massachusetts Cape & Islands district
 ocd-division/country:us/state:mi/sldu:1,Michigan State Senate district 1

--- a/identifiers/country-us/census_autogenerated/us_sldu.csv
+++ b/identifiers/country-us/census_autogenerated/us_sldu.csv
@@ -1957,6 +1957,7 @@ ocd-division/country:us/state:wy/sldu:27,Wyoming State Senate district 27
 ocd-division/country:us/state:wy/sldu:28,Wyoming State Senate district 28
 ocd-division/country:us/state:wy/sldu:29,Wyoming State Senate district 29
 ocd-division/country:us/state:wy/sldu:30,Wyoming State Senate district 30
+ocd-division/country:us/state:wy/sldu:31,Wyoming State Senate district 31
 ocd-division/country:us/territory:pr/sldu:1,Puerto Rico State Senate district I
 ocd-division/country:us/territory:pr/sldu:2,Puerto Rico State Senate district II
 ocd-division/country:us/territory:pr/sldu:3,Puerto Rico State Senate district III


### PR DESCRIPTION
This adds new districts (and flag some as obsolete).

The changes affect the following states: MD, MA, VT, WV, WY

We (Geocodio) has collected redistricted boundaries state-by-state and matched them to OCD-ids, this PR is part of this effort.