### PR TITLE
Fix for readme docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The goal of this project is to assign somewhat predictable and globally unique identifiers to political divisions.
 
-The canonical documentation of OCD-IDs is expressed as [OCDEP 2: Open Civic Data Divisions](https://opencivicdata.readthedocs.io/en/latest/proposals/0002.html).
+The canonical documentation of OCD-IDs is expressed as [OCDEP 2: Open Civic Data Divisions](https://github.com/opencivicdata/docs.opencivicdata.org/blob/master/proposals/0002.rst).
 
 Tests can be run with [Bazel](https://bazel.build/):
 


### PR DESCRIPTION
The current link to https://opencivicdata.readthedocs.io/en/latest/proposals/0002.html has been down (possibly hacked?) for ages, I believe this link points to the correct doc.