### PR TITLE
Expansion of the electoral list in spain

### DIFF
--- a/identifiers/country-es.csv
+++ b/identifiers/country-es.csv
@@ -37,7 +37,14 @@ ocd-division/country:es/autonomous_community:cm/province:gu,Guadalajara
 ocd-division/country:es/autonomous_community:cm/province:to,Toledo
 ocd-division/country:es/autonomous_community:cn,Canarias
 ocd-division/country:es/autonomous_community:cn/province:gc,Las Palmas
+ocd-division/country:es/autonomous_community:cn/province:gc-1,Gran Canaria
+ocd-division/country:es/autonomous_community:cn/province:gc-2,Lanzarote
+ocd-division/country:es/autonomous_community:cn/province:gc-3,Fuerteventura
 ocd-division/country:es/autonomous_community:cn/province:tf,Santa Cruz de Tenerife
+ocd-division/country:es/autonomous_community:cn/province:tf-1,Tenerife
+ocd-division/country:es/autonomous_community:cn/province:tf-2,La Gomera
+ocd-division/country:es/autonomous_community:cn/province:tf-3,El Hierro
+ocd-division/country:es/autonomous_community:cn/province:tf-4,La Palma
 ocd-division/country:es/autonomous_community:ct,Cataluña
 ocd-division/country:es/autonomous_community:ct/province:b,Barcelona
 ocd-division/country:es/autonomous_community:ct/province:gi,Girona
@@ -53,6 +60,9 @@ ocd-division/country:es/autonomous_community:ga/province:or,Ourense
 ocd-division/country:es/autonomous_community:ga/province:po,Pontevedra
 ocd-division/country:es/autonomous_community:ib,Illes Balears
 ocd-division/country:es/autonomous_community:ib/province:pm,Baleares
+ocd-division/country:es/autonomous_community:ib/province:pm-1,Mallorca
+ocd-division/country:es/autonomous_community:ib/province:pm-2,Menorca
+ocd-division/country:es/autonomous_community:ib/province:pm-3,Ibiza-Formentera
 ocd-division/country:es/autonomous_community:mc,Región de Murcia
 ocd-division/country:es/autonomous_community:mc/province:mu,Murcia
 ocd-division/country:es/autonomous_community:md,Comunidad de Madrid

--- a/identifiers/country-es.csv
+++ b/identifiers/country-es.csv
@@ -37,14 +37,14 @@ ocd-division/country:es/autonomous_community:cm/province:gu,Guadalajara
 ocd-division/country:es/autonomous_community:cm/province:to,Toledo
 ocd-division/country:es/autonomous_community:cn,Canarias
 ocd-division/country:es/autonomous_community:cn/province:gc,Las Palmas
-ocd-division/country:es/autonomous_community:cn/province:gc-1,Gran Canaria
-ocd-division/country:es/autonomous_community:cn/province:gc-2,Lanzarote
-ocd-division/country:es/autonomous_community:cn/province:gc-3,Fuerteventura
+ocd-division/country:es/autonomous_community:cn/province:gc/ed:1,Gran Canaria
+ocd-division/country:es/autonomous_community:cn/province:gc/ed:2,Lanzarote
+ocd-division/country:es/autonomous_community:cn/province:gc/ed:3,Fuerteventura
 ocd-division/country:es/autonomous_community:cn/province:tf,Santa Cruz de Tenerife
-ocd-division/country:es/autonomous_community:cn/province:tf-1,Tenerife
-ocd-division/country:es/autonomous_community:cn/province:tf-2,La Gomera
-ocd-division/country:es/autonomous_community:cn/province:tf-3,El Hierro
-ocd-division/country:es/autonomous_community:cn/province:tf-4,La Palma
+ocd-division/country:es/autonomous_community:cn/province:tf/ed:1,Tenerife
+ocd-division/country:es/autonomous_community:cn/province:tf/ed:2,La Gomera
+ocd-division/country:es/autonomous_community:cn/province:tf/ed:3,El Hierro
+ocd-division/country:es/autonomous_community:cn/province:tf/ed:4,La Palma
 ocd-division/country:es/autonomous_community:ct,Cataluña
 ocd-division/country:es/autonomous_community:ct/province:b,Barcelona
 ocd-division/country:es/autonomous_community:ct/province:gi,Girona
@@ -60,9 +60,9 @@ ocd-division/country:es/autonomous_community:ga/province:or,Ourense
 ocd-division/country:es/autonomous_community:ga/province:po,Pontevedra
 ocd-division/country:es/autonomous_community:ib,Illes Balears
 ocd-division/country:es/autonomous_community:ib/province:pm,Baleares
-ocd-division/country:es/autonomous_community:ib/province:pm-1,Mallorca
-ocd-division/country:es/autonomous_community:ib/province:pm-2,Menorca
-ocd-division/country:es/autonomous_community:ib/province:pm-3,Ibiza-Formentera
+ocd-division/country:es/autonomous_community:ib/province:pm/ed:1,Mallorca
+ocd-division/country:es/autonomous_community:ib/province:pm/ed:2,Menorca
+ocd-division/country:es/autonomous_community:ib/province:pm/ed:3,Ibiza-Formentera
 ocd-division/country:es/autonomous_community:mc,Región de Murcia
 ocd-division/country:es/autonomous_community:mc/province:mu,Murcia
 ocd-division/country:es/autonomous_community:md,Comunidad de Madrid

--- a/identifiers/country-es/README.md
+++ b/identifiers/country-es/README.md
@@ -6,7 +6,7 @@
 * Autonomous communities listed as **autonomous_community**
 
 **ciudad_autonoma.csv:**
-* [Autonomous communities of Spain](https://en.wikipedia.org/wiki/Autonomous_communities_of_Spain#Autonomous_cities)
+* [Autonomous cities of Spain](https://en.wikipedia.org/wiki/Autonomous_communities_of_Spain#Autonomous_cities)
 * 2 autonomous_city in total
 * Autonomous cities listed as **autonomous_city**
 

--- a/identifiers/country-es/README.md
+++ b/identifiers/country-es/README.md
@@ -1,0 +1,15 @@
+This folder lists the following:
+* comunidad_autonoma.csv:
+ * [Autonomous communities of Spain](https://en.wikipedia.org/wiki/Autonomous_communities_of_Spain#Autonomous_communities);
+ * 17 autonomous_community in total;
+ * Autonomous communities listed as **autonomous_community**.
+ 
+* ciudad_autonoma.csv:
+* [Autonomous communities of Spain](https://en.wikipedia.org/wiki/Autonomous_communities_of_Spain#Autonomous_cities);
+ * 2 autonomous_city in total;
+ * Autonomous cities listed as **autonomous_city**.
+
+* provincia.csv:
+ * [Provinces of Spain](https://en.wikipedia.org/wiki/Provinces_of_Spain);
+ * 60 provinces in total;
+ * Provinces listed as **province**

--- a/identifiers/country-es/README.md
+++ b/identifiers/country-es/README.md
@@ -1,15 +1,21 @@
-This folder lists the following:
-* comunidad_autonoma.csv:
- * [Autonomous communities of Spain](https://en.wikipedia.org/wiki/Autonomous_communities_of_Spain#Autonomous_communities);
- * 17 autonomous_community in total;
- * Autonomous communities listed as **autonomous_community**.
- 
-* ciudad_autonoma.csv:
-* [Autonomous communities of Spain](https://en.wikipedia.org/wiki/Autonomous_communities_of_Spain#Autonomous_cities);
- * 2 autonomous_city in total;
- * Autonomous cities listed as **autonomous_city**.
+# This folder lists the following:
 
-* provincia.csv:
- * [Provinces of Spain](https://en.wikipedia.org/wiki/Provinces_of_Spain);
- * 60 provinces in total;
- * Provinces listed as **province**
+**comunidad_autonoma.csv:**
+* [Autonomous communities of Spain](https://en.wikipedia.org/wiki/Autonomous_communities_of_Spain#Autonomous_communities)
+* 17 autonomous_community in total
+* Autonomous communities listed as **autonomous_community**
+
+**ciudad_autonoma.csv:**
+* [Autonomous communities of Spain](https://en.wikipedia.org/wiki/Autonomous_communities_of_Spain#Autonomous_cities)
+* 2 autonomous_city in total
+* Autonomous cities listed as **autonomous_city**
+
+**provincia.csv:**
+* [Provinces of Spain](https://en.wikipedia.org/wiki/Provinces_of_Spain)
+* 60 provinces in total
+* Provinces listed as **province**
+
+**electoral_districts.csv:**
+* 10 electoral districts in total
+* Electoral districts listed as **ed**
+

--- a/identifiers/country-es/ciudad_autonoma.csv
+++ b/identifiers/country-es/ciudad_autonoma.csv
@@ -1,2 +1,3 @@
+id,name
 ocd-division/country:es/autonomous_city:ce,Ceuta
 ocd-division/country:es/autonomous_city:ml,Melilla

--- a/identifiers/country-es/electoral_districts.csv
+++ b/identifiers/country-es/electoral_districts.csv
@@ -1,0 +1,11 @@
+id,name
+ocd-division/country:es/autonomous_community:cn/province:gc/ed:1,Gran Canaria
+ocd-division/country:es/autonomous_community:cn/province:gc/ed:2,Lanzarote
+ocd-division/country:es/autonomous_community:cn/province:gc/ed:3,Fuerteventura
+ocd-division/country:es/autonomous_community:cn/province:tf/ed:1,Tenerife
+ocd-division/country:es/autonomous_community:cn/province:tf/ed:2,La Gomera
+ocd-division/country:es/autonomous_community:cn/province:tf/ed:3,El Hierro
+ocd-division/country:es/autonomous_community:cn/province:tf/ed:4,La Palma
+ocd-division/country:es/autonomous_community:ib/province:pm/ed:1,Mallorca
+ocd-division/country:es/autonomous_community:ib/province:pm/ed:2,Menorca
+ocd-division/country:es/autonomous_community:ib/province:pm/ed:3,Ibiza-Formentera

--- a/identifiers/country-es/provincia.csv
+++ b/identifiers/country-es/provincia.csv
@@ -26,7 +26,14 @@ ocd-division/country:es/autonomous_community:cm/province:cu,Cuenca
 ocd-division/country:es/autonomous_community:cm/province:gu,Guadalajara
 ocd-division/country:es/autonomous_community:cm/province:to,Toledo
 ocd-division/country:es/autonomous_community:cn/province:gc,Las Palmas
+ocd-division/country:es/autonomous_community:cn/province:gc-1,Gran Canaria
+ocd-division/country:es/autonomous_community:cn/province:gc-2,Lanzarote
+ocd-division/country:es/autonomous_community:cn/province:gc-3,Fuerteventura
 ocd-division/country:es/autonomous_community:cn/province:tf,Santa Cruz de Tenerife
+ocd-division/country:es/autonomous_community:cn/province:tf-1,Tenerife
+ocd-division/country:es/autonomous_community:cn/province:tf-2,La Gomera
+ocd-division/country:es/autonomous_community:cn/province:tf-3,El Hierro
+ocd-division/country:es/autonomous_community:cn/province:tf-4,La Palma
 ocd-division/country:es/autonomous_community:ct/province:b,Barcelona
 ocd-division/country:es/autonomous_community:ct/province:gi,Girona
 ocd-division/country:es/autonomous_community:ct/province:ld,Lleida
@@ -38,6 +45,9 @@ ocd-division/country:es/autonomous_community:ga/province:lu,Lugo
 ocd-division/country:es/autonomous_community:ga/province:or,Ourense
 ocd-division/country:es/autonomous_community:ga/province:po,Pontevedra
 ocd-division/country:es/autonomous_community:ib/province:pm,Baleares
+ocd-division/country:es/autonomous_community:ib/province:pm-1,Mallorca
+ocd-division/country:es/autonomous_community:ib/province:pm-2,Menorca
+ocd-division/country:es/autonomous_community:ib/province:pm-3,Ibiza-Formentera
 ocd-division/country:es/autonomous_community:mc/province:mu,Murcia
 ocd-division/country:es/autonomous_community:md/province:m,Madrid
 ocd-division/country:es/autonomous_community:nc/province:na,Navarra

--- a/identifiers/country-es/provincia.csv
+++ b/identifiers/country-es/provincia.csv
@@ -1,3 +1,4 @@
+id,name
 ocd-division/country:es/autonomous_community:an/province:al,Almería
 ocd-division/country:es/autonomous_community:an/province:ca,Cádiz
 ocd-division/country:es/autonomous_community:an/province:co,Córdoba
@@ -26,14 +27,7 @@ ocd-division/country:es/autonomous_community:cm/province:cu,Cuenca
 ocd-division/country:es/autonomous_community:cm/province:gu,Guadalajara
 ocd-division/country:es/autonomous_community:cm/province:to,Toledo
 ocd-division/country:es/autonomous_community:cn/province:gc,Las Palmas
-ocd-division/country:es/autonomous_community:cn/province:gc-1,Gran Canaria
-ocd-division/country:es/autonomous_community:cn/province:gc-2,Lanzarote
-ocd-division/country:es/autonomous_community:cn/province:gc-3,Fuerteventura
 ocd-division/country:es/autonomous_community:cn/province:tf,Santa Cruz de Tenerife
-ocd-division/country:es/autonomous_community:cn/province:tf-1,Tenerife
-ocd-division/country:es/autonomous_community:cn/province:tf-2,La Gomera
-ocd-division/country:es/autonomous_community:cn/province:tf-3,El Hierro
-ocd-division/country:es/autonomous_community:cn/province:tf-4,La Palma
 ocd-division/country:es/autonomous_community:ct/province:b,Barcelona
 ocd-division/country:es/autonomous_community:ct/province:gi,Girona
 ocd-division/country:es/autonomous_community:ct/province:ld,Lleida
@@ -45,9 +39,6 @@ ocd-division/country:es/autonomous_community:ga/province:lu,Lugo
 ocd-division/country:es/autonomous_community:ga/province:or,Ourense
 ocd-division/country:es/autonomous_community:ga/province:po,Pontevedra
 ocd-division/country:es/autonomous_community:ib/province:pm,Baleares
-ocd-division/country:es/autonomous_community:ib/province:pm-1,Mallorca
-ocd-division/country:es/autonomous_community:ib/province:pm-2,Menorca
-ocd-division/country:es/autonomous_community:ib/province:pm-3,Ibiza-Formentera
 ocd-division/country:es/autonomous_community:mc/province:mu,Murcia
 ocd-division/country:es/autonomous_community:md/province:m,Madrid
 ocd-division/country:es/autonomous_community:nc/province:na,Navarra


### PR DESCRIPTION
For the upcoming election in Spain we need to extend the current list with a couple of subdivision which are necessary for a complete candidates and officeholder list of spain.

The former list is still correct, but for three provinces around the bealeares and canaries they use a couple of subdivision for the elections and their candidates. (parliament and senate)

Here is a list from the last election of 2019:
[2019 Candidaturas](http://www.juntaelectoralcentral.es/cs/jec/documentos/Generales_2019-R_Candidaturas%20proclamadas.pdf)