### PR TITLE
EU-Parliament Constituencies for Irleand

### DIFF
--- a/identifiers/country-ie.csv
+++ b/identifiers/country-ie.csv
@@ -39,6 +39,6 @@ ocd-division/country:ie/ed:tipperary,Tipperary
 ocd-division/country:ie/ed:waterford,Waterford
 ocd-division/country:ie/ed:wexford,Wexford
 ocd-division/country:ie/ed:wicklow,Wicklow
-ocd-division/country:ie/eu:dublin,Dublin
-ocd-division/country:ie/eu:midlands-north-west,Midlands-North-West
-ocd-division/country:ie/eu:south,South
+ocd-division/country:ie/eup:dublin,Dublin
+ocd-division/country:ie/eup:midlands-north-west,Midlands-North-West
+ocd-division/country:ie/eup:south,South

--- a/identifiers/country-ie.csv
+++ b/identifiers/country-ie.csv
@@ -39,3 +39,6 @@ ocd-division/country:ie/ed:tipperary,Tipperary
 ocd-division/country:ie/ed:waterford,Waterford
 ocd-division/country:ie/ed:wexford,Wexford
 ocd-division/country:ie/ed:wicklow,Wicklow
+ocd-division/country:ie/eu:dublin,Dublin
+ocd-division/country:ie/eu:midlands-north-west,Midlands-North-West
+ocd-division/country:ie/eu:south,South

--- a/identifiers/country-ie/README.md
+++ b/identifiers/country-ie/README.md
@@ -1,6 +1,11 @@
-# OCD Division Identifier
+# Open Civic Data Divisions: Ireland
 
 This folder list the following administrative divisions of Ireland:
 
-* Lower House Constituencies [ref](https://en.wikipedia.org/wiki/D%C3%A1il_constituencies). Used type: **ed**.
-* EU-Parliament Constituencies [ref](https://en.wikipedia.org/wiki/European_Parliament_constituencies_in_the_Republic_of_Ireland). Used type: **eu**.
+* Lower House Constituencies [ref](https://en.wikipedia.org/wiki/D%C3%A1il_constituencies).
+* EU-Parliament Constituencies [ref](https://en.wikipedia.org/wiki/European_Parliament_constituencies_in_the_Republic_of_Ireland).
+
+## Types
+
+* `ed`: electoral district
+* `eup`: eu parliament

--- a/identifiers/country-ie/README.md
+++ b/identifiers/country-ie/README.md
@@ -1,0 +1,6 @@
+# OCD Division Identifier
+
+This folder list the following administrative divisions of Ireland:
+
+* Lower House Constituencies [ref](https://en.wikipedia.org/wiki/D%C3%A1il_constituencies). Used type: **ed**.
+* EU-Parliament Constituencies [ref](https://en.wikipedia.org/wiki/European_Parliament_constituencies_in_the_Republic_of_Ireland). Used type: **eu**.

--- a/identifiers/country-ie/eu_parliament.csv
+++ b/identifiers/country-ie/eu_parliament.csv
@@ -1,4 +1,4 @@
 id,name
-ocd-division/country:ie/eu:dublin,Dublin
-ocd-division/country:ie/eu:midlands-north-west,Midlands-North-West
-ocd-division/country:ie/eu:south,South
+ocd-division/country:ie/eup:dublin,Dublin
+ocd-division/country:ie/eup:midlands-north-west,Midlands-North-West
+ocd-division/country:ie/eup:south,South

--- a/identifiers/country-ie/eu_parliament.csv
+++ b/identifiers/country-ie/eu_parliament.csv
@@ -1,0 +1,4 @@
+id,name
+ocd-division/country:ie/eu:dublin,Dublin
+ocd-division/country:ie/eu:midlands-north-west,Midlands-North-West
+ocd-division/country:ie/eu:south,South


### PR DESCRIPTION
added EU-Parliament Constituencies for Irleand and also for the EU election 2024 in Irleand. 
These are the first constituencies which are not the same like for the lower house of the country. 
So the whole thing is also open for discussion around the right type for the paths. I used "eu" right now, because the type described it the best for which usecase they are. But let me know if you have better suggestions.