### PR TITLE
Update README docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The goal of this project is to assign somewhat predictable and globally unique identifiers to political divisions.
 
-The canonical documentation of OCD-IDs is expressed as [OCDEP 2: Open Civic Data Divisions](https://opencivicdata.readthedocs.io/en/latest/proposals/0002.html).
+The canonical documentation of OCD-IDs is expressed as [OCDEP 2: Open Civic Data Divisions](https://open-civic-data.readthedocs.io/en/latest/proposals/0002.html).
 
 Tests can be run with [Bazel](https://bazel.build/):
 


### PR DESCRIPTION
The OCD documentation changed base URL, this updates the readme to point to the correct place.